### PR TITLE
Fix for bug 9450 of accessiblity

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_template_view.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_template_view.xml
@@ -52,6 +52,8 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
                 android:textAppearance="@style/TextAppearance.DemoDescription"
                 android:text="@string/template_list" />
 
@@ -85,6 +87,8 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
                 android:textAppearance="@style/TextAppearance.DemoDescription"
                 android:text="@string/regular_list" />
 


### PR DESCRIPTION
### Platforms Impacted
- [x] Android

### Description of changes
To allow TextView items to be focussable and touchable for keyboard and screenreader. Fix for bug#9450(https://dev.azure.com/microsoftdesign/fluentui-native/_workitems/edit/9450/)

### Verification
Tested in Emulator Pixel 3A API 28.

### Pull request checklist
This PR has considered:
- [X] VoiceOver and Keyboard Accessibility
