### PR TITLE
BottomSheet DarkMode Handling UI gaps from figma

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
@@ -8,6 +8,8 @@ package com.microsoft.fluentuidemo.demos
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.support.design.widget.BottomSheetBehavior
+import android.support.v4.content.ContextCompat
 import android.support.v7.widget.LinearLayoutManager
 import android.view.Gravity
 import android.view.View
@@ -33,12 +35,12 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
         get() = false
 
     private lateinit var persistentBottomSheetDemo: PersistentBottomSheet
-    private lateinit var defaultPersistentBottomSheet :PersistentBottomSheet
-    private lateinit var currentSheet :PersistentBottomSheet
-    private var isBack:Boolean = false
-    private lateinit var view:TextView
-    private lateinit var mHorizontalSheet:List<SheetItem>
-    private lateinit var mHorizontalSheet2:List<SheetItem>
+    private lateinit var defaultPersistentBottomSheet: PersistentBottomSheet
+    private lateinit var currentSheet: PersistentBottomSheet
+    private var isBack: Boolean = false
+    private lateinit var view: TextView
+    private lateinit var mHorizontalSheet: List<SheetItem>
+    private lateinit var mHorizontalSheet2: List<SheetItem>
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -54,62 +56,79 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
         mHorizontalSheet = arrayListOf(
                 SheetItem(
                         R.id.bottom_sheet_item_flag,
+                        getString(R.string.bottom_sheet_item_flag_title),
                         R.drawable.ic_fluent_flag_24_regular,
-                        getString(R.string.bottom_sheet_item_flag_title)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)),
                 SheetItem(R.id.bottom_sheet_item_alarm,
-                        dummyBitmap(),
-                        getString(R.string.bottom_sheet_item_custom_image)),
+                        getString(R.string.bottom_sheet_item_custom_image),
+                        dummyBitmap()),
                 SheetItem(
                         R.id.persistent_sheet_item_add_view,
+                        getString(R.string.persistent_sheet_item_add_remove_view),
                         R.drawable.ic_add_circle_28_fill,
-                        getString(R.string.persistent_sheet_item_add_remove_view)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)),
                 SheetItem(
                         R.id.persistent_sheet_item_change_height_button,
+                        getString(R.string.persistent_sheet_item_change_collapsed_height),
                         R.drawable.ic_vertical_align_center_28_fill,
-                        getString(R.string.persistent_sheet_item_change_collapsed_height)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                ),
                 SheetItem(
                         R.id.bottom_sheet_item_reply,
+                        getString(R.string.bottom_sheet_item_reply_title),
                         R.drawable.ic_fluent_reply_24_regular,
-                        getString(R.string.bottom_sheet_item_reply_title)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                ),
                 SheetItem(
                         R.id.bottom_sheet_item_forward,
+                        getString(R.string.bottom_sheet_item_forward_title),
                         R.drawable.ic_fluent_forward_24_regular,
-                        getString(R.string.bottom_sheet_item_forward_title)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                ),
                 SheetItem(
                         R.id.bottom_sheet_item_delete,
+                        getString(R.string.bottom_sheet_item_delete_title),
                         R.drawable.ic_delete_24_regular,
-                        getString(R.string.bottom_sheet_item_delete_title)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                ),
                 SheetItem(
                         R.id.bottom_sheet_item_delete,
+                        getString(R.string.bottom_sheet_item_delete_title),
                         R.drawable.ic_delete_24_regular,
-                        getString(R.string.bottom_sheet_item_delete_title)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                ),
                 SheetItem(
                         R.id.bottom_sheet_item_delete,
+                        getString(R.string.bottom_sheet_item_delete_title),
                         R.drawable.ic_delete_24_regular,
-                        getString(R.string.bottom_sheet_item_delete_title))
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                )
         )
 
         mHorizontalSheet2 = arrayListOf(
                 SheetItem(
                         R.id.bottom_sheet_item_flag,
+                        getString(R.string.bottom_sheet_item_flag_title),
                         R.drawable.ic_fluent_flag_24_regular,
-                        getString(R.string.bottom_sheet_item_flag_title)),
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)),
+                SheetItem(R.id.bottom_sheet_item_alarm,
+                        getString(R.string.bottom_sheet_item_custom_image),
+                        dummyBitmap()),
+                SheetItem(
+                        R.id.persistent_sheet_item_add_view,
+                        getString(R.string.persistent_sheet_item_add_remove_view),
+                        R.drawable.ic_add_circle_28_fill,
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)),
+                SheetItem(
+                        R.id.persistent_sheet_item_change_height_button,
+                        getString(R.string.persistent_sheet_item_change_collapsed_height),
+                        R.drawable.ic_vertical_align_center_28_fill,
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)),
                 SheetItem(
                         R.id.bottom_sheet_item_reply,
+                        getString(R.string.bottom_sheet_item_reply_title),
                         R.drawable.ic_fluent_reply_24_regular,
-                        getString(R.string.bottom_sheet_item_reply_title)),
-                SheetItem(
-                        R.id.bottom_sheet_item_forward,
-                        R.drawable.ic_fluent_forward_24_regular,
-                        getString(R.string.bottom_sheet_item_forward_title)),
-                SheetItem(
-                        R.id.bottom_sheet_item_delete,
-                        R.drawable.ic_delete_24_regular,
-                        getString(R.string.bottom_sheet_item_delete_title)),
-                SheetItem(
-                        R.id.persistent_sheet_item_create_new_folder,
-                        R.drawable.ic_create_new_folder_24_filled,
-                        getString(R.string.persistent_sheet_item_create_new_folder_title))
+                        ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint))
         )
 
 
@@ -122,35 +141,45 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
         sheet_horizontal_item_list_2.setTextAppearance(R.style.TextAppearance_FluentUI_ListItemTitle)
 
         val marginBetweenView = resources.getDimension(R.dimen.fluentui_persistent_horizontal_item_right_margin).toInt()
-        val horizontalListAdapter  = SheetHorizontalItemAdapter(this,
+        val horizontalListAdapter = SheetHorizontalItemAdapter(this,
                 arrayListOf(
                         SheetItem(
                                 R.id.persistent_sheet_item_create_new_folder,
+                                getString(R.string.persistent_sheet_item_create_new_folder_title),
                                 R.drawable.ic_create_new_folder_24_filled,
-                                getString(R.string.persistent_sheet_item_create_new_folder_title)),
+                                ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                        ),
                         SheetItem(
                                 R.id.persistent_sheet_item_edit,
+                                getString(R.string.persistent_sheet_item_edit_title),
                                 R.drawable.ic_edit_24_filled,
-                                getString(R.string.persistent_sheet_item_edit_title)),
+                                ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                        ),
                         SheetItem(
                                 R.id.persistent_sheet_item_save,
+                                getString(R.string.persistent_sheet_item_save_title),
                                 R.drawable.ic_save_24_filled,
-                                getString(R.string.persistent_sheet_item_save_title)),
+                                ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                        ),
                         SheetItem(
                                 R.id.persistent_sheet_item_zoom_in,
+                                getString(R.string.persistent_sheet_item_zoom_in_title),
                                 R.drawable.ic_zoom_in_24_filled,
-                                getString(R.string.persistent_sheet_item_zoom_in_title)),
+                                ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                        ),
                         SheetItem(
                                 R.id.persistent_sheet_item_zoom_out,
+                                getString(R.string.persistent_sheet_item_zoom_out_title),
                                 R.drawable.ic_zoom_out_24_filled,
-                                getString(R.string.persistent_sheet_item_zoom_out_title))
-                ),0, marginBetweenView)
+                                ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint)
+                        )
+                ), 0, marginBetweenView)
         horizontalListAdapter.mOnSheetItemClickListener = this
         sheet_horizontal_item_list_3.layoutManager = LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
         sheet_horizontal_item_list_3.adapter = horizontalListAdapter
 
 
-        val verticalListAdapter =  BottomSheetAdapter(this,
+        val verticalListAdapter = BottomSheetAdapter(this,
                 arrayListOf(
                         BottomSheetItem(
                                 R.id.bottom_sheet_item_camera,
@@ -185,12 +214,11 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
         }
 
         collapse_persistent_bottom_sheet_button.setOnClickListener {
-            if(currentSheet.getPeekHeight() == 0) {
+            if (currentSheet.getPeekHeight() == 0) {
                 currentSheet.showPersistentSheet()
                 collapse_persistent_bottom_sheet_button.text = getString(R.string.collapse_persistent_sheet_button)
-            }
-            else {
-                currentSheet.collapsePersistentSheet()
+            } else {
+                currentSheet.hidePersistentSheet()
                 collapse_persistent_bottom_sheet_button.text = getString(R.string.show_persistent_sheet_button)
             }
         }
@@ -199,16 +227,28 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
             if (defaultPersistentBottomSheet.visibility == View.GONE) {
                 currentSheet = defaultPersistentBottomSheet
                 persistentBottomSheetDemo.visibility = View.GONE
+                set_one_line_content.visibility = View.VISIBLE
                 showDefaultBottomSheet()
             } else {
                 currentSheet = persistentBottomSheetDemo
                 defaultPersistentBottomSheet.visibility = View.GONE
+                set_one_line_content.visibility = View.GONE
             }
             currentSheet.visibility = View.VISIBLE
         }
 
+        set_one_line_content.setOnClickListener {
+            if (defaultPersistentBottomSheet.visibility == View.VISIBLE) {
+                PersistentBottomSheet.DefaultContentBuilder(this)
+                        .addHorizontalGridItemList(mHorizontalSheet2.subList(0, 5))
+                        .buildWith(defaultPersistentBottomSheet)
+                currentSheet.showPersistentSheet()
+            }
+        }
+
         //initially
         currentSheet = persistentBottomSheetDemo
+        set_one_line_content.visibility = View.GONE
     }
 
     private fun showDefaultBottomSheet() {
@@ -220,27 +260,26 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
                 .addHorizontalGridItemList(mHorizontalSheet)
                 .addDivider()
                 .addVerticalItemList(mHorizontalSheet, getString(R.string.fluentui_bottom_sheet_header))
-                .addVerticalItemList(mHorizontalSheet,getString(R.string.fluentui_bottom_sheet_header))
+                .addVerticalItemList(mHorizontalSheet, getString(R.string.fluentui_bottom_sheet_header))
                 .buildWith(defaultPersistentBottomSheet)
 
     }
 
-    override fun onSheetItemClick(item: SheetItem){
-        when(item.id) {
+    override fun onSheetItemClick(item: SheetItem) {
+        when (item.id) {
             R.id.persistent_sheet_item_add_view -> {
-                if(!this::view.isInitialized || view.parent == null) {
-                    view =  TextView(this)
+                if (!this::view.isInitialized || view.parent == null) {
+                    view = TextView(this)
                     view.text = getString(R.string.new_view)
                     view.height = 200
                     view.gravity = Gravity.CENTER
                     persistentBottomSheetDemo.addView(view, 1, demo_bottom_sheet)
-                }
-                else {
+                } else {
                     persistentBottomSheetDemo.removeView(view, demo_bottom_sheet)
                 }
             }
             R.id.persistent_sheet_item_change_height_button -> {
-                if(isBack)
+                if (isBack)
                     persistentBottomSheetDemo.changePeekHeight(-400)
                 else
                     persistentBottomSheetDemo.changePeekHeight(400)
@@ -263,7 +302,7 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
     }
 
     override fun onBottomSheetItemClick(item: BottomSheetItem) {
-        when(item.id) {
+        when (item.id) {
             R.id.bottom_sheet_item_camera -> showSnackbar(resources.getString(R.string.bottom_sheet_item_camera_toast))
             R.id.bottom_sheet_item_gallery -> showSnackbar(resources.getString(R.string.bottom_sheet_item_gallery_toast))
             R.id.bottom_sheet_item_videos -> showSnackbar(resources.getString(R.string.bottom_sheet_item_videos_toast))
@@ -281,4 +320,13 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
         option.outWidth = resources.getDimensionPixelSize(R.dimen.image_size)
         return Bitmap.createScaledBitmap(BitmapFactory.decodeResource(resources, R.drawable.avatar_allan_munger), option.outWidth, option.outHeight, false)
     }
+
+    override fun onBackPressed() {
+        if (currentSheet.getBottomSheetBehaviour().state == BottomSheetBehavior.STATE_EXPANDED) {
+            currentSheet.collapse()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
 }

--- a/FluentUI.Demo/src/main/res/layout/activity_persistent_bottom_sheet.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_persistent_bottom_sheet.xml
@@ -40,6 +40,13 @@
             android:layout_marginTop="@dimen/default_layout_margin"
             android:text="@string/toggle_sheet_content" />
 
+        <Button
+            android:id="@+id/set_one_line_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/default_layout_margin"
+            android:text="@string/one_line_content" />
+
     </LinearLayout>
 
     <com.microsoft.fluentui.persistentbottomsheet.PersistentBottomSheet

--- a/FluentUI.Demo/src/main/res/layout/demo_persistent_sheet_content.xml
+++ b/FluentUI.Demo/src/main/res/layout/demo_persistent_sheet_content.xml
@@ -14,8 +14,7 @@
     <com.microsoft.fluentui.persistentbottomsheet.SheetHorizontalItemList
         android:id="@+id/sheet_horizontal_item_list_1"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/default_layout_margin"/>
+        android:layout_height="wrap_content" />
 
     <View
         android:layout_width="match_parent"

--- a/FluentUI.Demo/src/main/res/values-night/colors.xml
+++ b/FluentUI.Demo/src/main/res/values-night/colors.xml
@@ -13,4 +13,7 @@
     <!--ActionBarLayout-->
     <color name="action_bar_radio_labels">@color/fluentui_white</color>
 
+    <!--Botttomsheet tint-->
+    <color name="bottomsheet_horizontal_icon_tint">@color/fluentui_gray_300</color>
+
 </resources>

--- a/FluentUI.Demo/src/main/res/values/colors.xml
+++ b/FluentUI.Demo/src/main/res/values/colors.xml
@@ -20,4 +20,7 @@
     <!--ActionBarLayout-->
     <color name="action_bar_radio_labels">@color/fluentui_black</color>
 
+    <!--Botttomsheet tint-->
+    <color name="bottomsheet_horizontal_icon_tint">@color/fluentui_gray_500</color>
+
 </resources>

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@
     <string name="show_persistent_sheet_button"> Show Persistent BottomSheet</string>
     <string name="new_view">This is New View</string>
     <string name="toggle_sheet_content">Toggle Bottomsheet Content</string>
+    <string name="one_line_content">One Line Bottomsheet Content</string>
     <string name="switch_to_custom_content">Switch to custom Content</string>
     <!--Persistent BottomSheet Items-->
     <string name="persistent_sheet_item_add_remove_view">Add/Remove View</string>

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerView.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerView.kt
@@ -12,7 +12,6 @@ import android.graphics.Path
 import android.graphics.RectF
 import android.support.v7.widget.LinearLayoutCompat
 import android.util.AttributeSet
-import com.microsoft.fluentui.drawer.R
 
 internal class DrawerView(context: Context, attrs: AttributeSet) : LinearLayoutCompat(context, attrs) {
     companion object {
@@ -24,12 +23,13 @@ internal class DrawerView(context: Context, attrs: AttributeSet) : LinearLayoutC
     }
 
     private val clipPath = Path()
+    private var cornerRadius: Float
     var behaviorType: BehaviorType
-    val cornerRadius :Float
 
     init {
         val a: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.SheetBehaviorLayout)
-        behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_behaviorType) ?: "BOTTOM")
+        behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_behaviorType)
+                ?: "BOTTOM")
         val drawerTypedArray = context.obtainStyledAttributes(attrs, R.styleable.DrawerView)
         cornerRadius = drawerTypedArray.getDimension(R.styleable.DrawerView_cornerRadius, resources.getDimension(R.dimen.fluentui_drawer_corner_radius))
         drawerTypedArray.recycle()
@@ -48,11 +48,16 @@ internal class DrawerView(context: Context, attrs: AttributeSet) : LinearLayoutC
         canvas.restoreToCount(save)
     }
 
+    fun setCornerRadius(radius: Float) {
+        cornerRadius = radius
+        invalidate()
+    }
+
     private fun updateClipPath(width: Float, height: Float) {
 
-        val radii = FloatArray(RADII_SIZE){0f}
+        val radii = FloatArray(RADII_SIZE) { 0f }
 
-        when(behaviorType) {
+        when (behaviorType) {
             BehaviorType.BOTTOM -> {
                 // top left corner
                 radii[0] = cornerRadius

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -123,7 +123,6 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
     private fun configureBottomSheetDrawerHandle(sheetContainerInfo: PersistentBottomSheetContentViewProvider.SheetContainerInfo) {
         if (sheetContainerInfo.isSingleLineItem) {
             setDrawerHandleVisibility(View.GONE)
-            persistentSheet.setCornerRadius(0f)
             persistentSheetContainer.setPadding(persistentSheetContainer.paddingLeft,
                     resources.getDimensionPixelSize(R.dimen.fluentui_persistent_bottomsheet_content_padding_vertical),
                     persistentSheetContainer.paddingRight,
@@ -131,7 +130,6 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             return
         }
         setDrawerHandleVisibility(View.VISIBLE)
-        persistentSheet.setCornerRadius(resources.getDimension(R.dimen.fluentui_persistentbottomsheet_corner_radius))
         persistentSheetContainer.setPadding(persistentSheetContainer.paddingLeft,
                 0,
                 persistentSheetContainer.paddingRight,

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -20,6 +20,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import com.microsoft.fluentui.drawer.DrawerView
 import com.microsoft.fluentui.drawer.OnDrawerContentCreatedListener
 import com.microsoft.fluentui.drawer.R
 import com.microsoft.fluentui.persistentbottomsheet.sheetItem.BottomSheetParam
@@ -41,7 +42,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
 
 
     private lateinit var persistentSheetBehavior: BottomSheetBehavior<View>
-    private lateinit var persistentSheet: ViewGroup
+    private lateinit var persistentSheet: DrawerView
     private lateinit var persistentSheetContainer: LinearLayout
     private var onDrawerContentCreatedListener: OnDrawerContentCreatedListener? = null
     private var contentViewProvider: PersistentBottomSheetContentViewProvider? = null
@@ -113,9 +114,42 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
     private fun updateSheetContent() {
         persistentSheetContainer.removeAllViews()
         contentViewProvider?.apply {
-            val contentView = this.getSheetContentView(persistentSheetContainer, itemLayoutParam)
-            onDrawerContentCreatedListener?.onDrawerContentCreated(contentView)
+            val sheetContainerInfo = this.getSheetContentView(persistentSheetContainer, itemLayoutParam)
+            onDrawerContentCreatedListener?.onDrawerContentCreated(sheetContainerInfo.Container)
+            configureBottomSheetDrawerHandle(sheetContainerInfo)
         }
+    }
+
+    private fun configureBottomSheetDrawerHandle(sheetContainerInfo: PersistentBottomSheetContentViewProvider.SheetContainerInfo) {
+        if (sheetContainerInfo.isSingleLineItem) {
+            setDrawerHandleVisibility(View.GONE)
+            persistentSheet.setCornerRadius(0f)
+            persistentSheetContainer.setPadding(persistentSheetContainer.paddingLeft,
+                    resources.getDimensionPixelSize(R.dimen.fluentui_persistent_bottomsheet_content_padding_vertical),
+                    persistentSheetContainer.paddingRight,
+                    persistentSheetContainer.paddingBottom)
+            return
+        }
+        setDrawerHandleVisibility(View.VISIBLE)
+        persistentSheet.setCornerRadius(resources.getDimension(R.dimen.fluentui_persistentbottomsheet_corner_radius))
+        persistentSheetContainer.setPadding(persistentSheetContainer.paddingLeft,
+                0,
+                persistentSheetContainer.paddingRight,
+                persistentSheetContainer.paddingBottom)
+        sheet_drawer_handle.setOnClickListener {
+            when {
+                persistentSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED -> expand()
+                persistentSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED -> collapse()
+                else -> {
+                    // it's in transition state do nothing
+                }
+            }
+        }
+    }
+
+    fun setDrawerHandleVisibility(visibility: Int) {
+        isDrawerHandleVisible = View.VISIBLE == visibility
+        sheet_drawer_handle.visibility = visibility
     }
 
 
@@ -190,7 +224,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             changePeekHeight(-childHeight)
     }
 
-    fun collapsePersistentSheet() {
+    fun hidePersistentSheet() {
         changePeekHeight(-persistentSheetBehavior.peekHeight)
     }
 
@@ -198,8 +232,12 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         changePeekHeight(-persistentSheetBehavior.peekHeight + itemLayoutParam.defaultPeekHeight)
     }
 
+    fun collapse() {
+        persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+    }
+
     fun expand() {
-        getSheetBehavior().state = BottomSheetBehavior.STATE_EXPANDED
+        persistentSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
     fun getPeekHeight(): Int {
@@ -240,6 +278,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
          *
          *
          */
+        @JvmOverloads
         fun addHorizontalItemList(itemSheet: List<SheetItem>, header: String? = null): DefaultContentBuilder {
             assertIfCustomIdSet()
             contentParam.add(BottomSheetParam.HorizontalItemList(itemSheet, header))
@@ -256,6 +295,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
          *        **  **  **
          *
          */
+        @JvmOverloads
         fun addHorizontalGridItemList(itemSheet: List<SheetItem>, header: String? = null): DefaultContentBuilder {
             assertIfCustomIdSet()
             contentParam.add(BottomSheetParam.HorizontalGridItemList(itemSheet, header))
@@ -265,6 +305,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         /**
          * add items vertically in a groups
          */
+        @JvmOverloads
         fun addVerticalItemList(itemSheet: List<SheetItem>, header: String? = null): DefaultContentBuilder {
             assertIfCustomIdSet()
             contentParam.add(BottomSheetParam.VerticalItemList(itemSheet, header))
@@ -274,6 +315,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         /**
          * adds a divider
          */
+        @JvmOverloads
         fun addDivider(pixelHeight: Int = context.resources.getDimensionPixelSize(R.dimen.fluentui_divider_height), @ColorRes color: Int = 0): DefaultContentBuilder {
             assertIfCustomIdSet()
             contentParam.add(BottomSheetParam.DividerItemType(pixelHeight, color))

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/SheetHorizontalItemList.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/SheetHorizontalItemList.kt
@@ -7,6 +7,7 @@ package com.microsoft.fluentui.persistentbottomsheet
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.support.annotation.ColorInt
 import android.support.annotation.DrawableRes
 import android.util.AttributeSet
 import android.view.View.NO_ID
@@ -109,11 +110,10 @@ open class SheetHorizontalItemList @JvmOverloads constructor(context: Context, a
     }
 }
 
-class SheetItem (val id: Int, @DrawableRes val drawable: Int, val title: String = "", val bitmap: Bitmap? = null) {
+class SheetItem(val id: Int, val title: String = "", @DrawableRes val drawable: Int, @ColorInt val tint: Int? = null, val bitmap: Bitmap? = null) {
 
     // just a  convenient constructor
-    @JvmOverloads
-    constructor(id: Int, bitmap: Bitmap, title: String = "") : this(id, NO_ID, title, bitmap)
+    constructor(id: Int, title: String = "", bitmap: Bitmap) : this(id, title, NO_ID, null, bitmap)
 
     interface OnClickListener {
         fun onSheetItemClick(item: SheetItem)

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/SheetHorizontalItemView.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/SheetHorizontalItemView.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.fluentui.persistentbottomsheet
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.support.v4.widget.TextViewCompat
 import android.util.AttributeSet
@@ -33,13 +34,14 @@ class SheetHorizontalItemView: TemplateView {
     @JvmOverloads
     constructor(context: Context,  attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr)
 
+    @SuppressLint("ResourceType")
     constructor(context: Context, sheetItem: SheetItem, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
         this.mSheetItem = sheetItem
         this.title = sheetItem.title
         if (sheetItem.bitmap != null) {
             this.customView = context.createImageView(sheetItem.bitmap)
         } else {
-            this.customView = context.createImageView(sheetItem.drawable)
+            this.customView = context.createImageView(sheetItem.drawable, sheetItem.tint)
         }
     }
 

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/HorizontalGridProvider.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/HorizontalGridProvider.kt
@@ -42,4 +42,12 @@ internal class HorizontalGridProvider(val context: Context) : IViewProvider {
         return view
 
     }
+
+    override fun isSingleLineContent(itemTypeList: BottomSheetParam.ItemTypeList,
+                                     itemLayoutParam: BottomSheetParam.ItemLayoutParam,
+                                     contentParam: BottomSheetParam.ContentParam): Boolean {
+        val list = itemTypeList as BottomSheetParam.HorizontalGridItemList
+        return list.horizontalItemSheet.size <= itemLayoutParam.itemInRow
+    }
+
 }

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/HorizontalViewProvider.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/HorizontalViewProvider.kt
@@ -43,4 +43,11 @@ internal class HorizontalViewProvider(val context: Context) : IViewProvider {
         horizontalListView.sheetItemClickListener = contentParam.listener
         return view
     }
+
+    override fun isSingleLineContent(itemTypeList: BottomSheetParam.ItemTypeList,
+                                     itemLayoutParam: BottomSheetParam.ItemLayoutParam,
+                                     contentParam: BottomSheetParam.ContentParam): Boolean {
+        val list = itemTypeList as BottomSheetParam.HorizontalItemList
+        return list.horizontalItemSheet.size <= itemLayoutParam.itemInRow
+    }
 }

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/PersistentBottomSheetContentViewProvider.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/PersistentBottomSheetContentViewProvider.kt
@@ -3,25 +3,31 @@ package com.microsoft.fluentui.persistentbottomsheet.sheetItem
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.LinearLayout
 
 internal class PersistentBottomSheetContentViewProvider(private val context: Context,
                                                         private val contentParam: BottomSheetParam.ContentParam) {
 
-    fun getSheetContentView(container: LinearLayout, itemLayoutParam: BottomSheetParam.ItemLayoutParam): View {
+    fun getSheetContentView(container: LinearLayout, itemLayoutParam: BottomSheetParam.ItemLayoutParam): SheetContainerInfo {
         if (contentParam.layoutResId != null) {
             val view = LayoutInflater.from(context).inflate(contentParam.layoutResId!!, container, false)
             container.addView(view)
-            return container
+            return SheetContainerInfo(container, false)
         }
         if (contentParam.listOfItemList.isEmpty()) {
-            return container
+            return SheetContainerInfo(container, false)
         }
-        contentParam.listOfItemList.forEach {
-            container.addView(getProvider(context, it).getContentView(it,itemLayoutParam,contentParam))
+        var isSingleLineItem = false
+        contentParam.listOfItemList.forEachIndexed { index, it ->
+            val provider = getProvider(context, it)
+            container.addView(provider.getContentView(it, itemLayoutParam, contentParam))
+            isSingleLineItem = index == 0 && provider.isSingleLineContent(it, itemLayoutParam, contentParam)
         }
-        return container
+        return SheetContainerInfo(container, isSingleLineItem)
     }
+
+    data class SheetContainerInfo(val Container: ViewGroup, val isSingleLineItem: Boolean)
 
     companion object {
 
@@ -44,4 +50,10 @@ internal interface IViewProvider {
     fun getContentView(itemTypeList: BottomSheetParam.ItemTypeList,
                        itemLayoutParam: BottomSheetParam.ItemLayoutParam,
                        contentParam: BottomSheetParam.ContentParam): View
+
+    fun isSingleLineContent(itemTypeList: BottomSheetParam.ItemTypeList,
+                            itemLayoutParam: BottomSheetParam.ItemLayoutParam,
+                            contentParam: BottomSheetParam.ContentParam): Boolean {
+        return false
+    }
 }

--- a/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/VerticalViewProvider.kt
+++ b/FluentUI.Drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/sheetItem/VerticalViewProvider.kt
@@ -36,7 +36,7 @@ internal class VerticalViewProvider(val context: Context) : IViewProvider {
             val listener = this
             verticalItemAdapter.onBottomSheetItemClickListener = object : OnClickListener {
                 override fun onBottomSheetItemClick(item: BottomSheetItem) {
-                    listener.onSheetItemClick(SheetItem(item.id, item.imageId, item.title, item.customBitmap))
+                    listener.onSheetItemClick(SheetItem(item.id, item.title, item.imageId, item.imageTint, item.customBitmap))
                 }
             }
         }
@@ -51,8 +51,19 @@ internal class VerticalViewProvider(val context: Context) : IViewProvider {
         return itemTypeList.verticalItemSheet.filter {
             it.id != 0
         }.map {
-            BottomSheetItem(it.id, it.drawable, it.title, customBitmap = it.bitmap, imageTintType = ImageTintType.NONE)
+            if (it.tint!=null) {
+                BottomSheetItem(it.id, it.drawable, it.title, customBitmap = it.bitmap, imageTint = it.tint, imageTintType = ImageTintType.CUSTOM)
+            }else{
+                BottomSheetItem(it.id, it.drawable, it.title, customBitmap = it.bitmap, imageTintType = ImageTintType.NONE)
+            }
         }
+    }
+
+    override fun isSingleLineContent(itemTypeList: BottomSheetParam.ItemTypeList,
+                                     itemLayoutParam: BottomSheetParam.ItemLayoutParam,
+                                     contentParam: BottomSheetParam.ContentParam): Boolean {
+        val verticalItemList = itemTypeList as BottomSheetParam.VerticalItemList
+        return verticalItemList.verticalItemSheet.size == 1
     }
 
 

--- a/FluentUI.Drawer/src/main/res/layout/vertical_bottomsheet_content.xml
+++ b/FluentUI.Drawer/src/main/res/layout/vertical_bottomsheet_content.xml
@@ -9,8 +9,7 @@
         style="@style/TextAppearance.FluentUI.PersistentBottomSheetHeading"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingStart="@dimen/fluentui_persistent_bottomsheet_content_offset"
-        android:paddingEnd="@dimen/fluentui_persistent_bottomsheet_content_offset" />
+        android:paddingEnd="@dimen/fluentui_persistent_bottomsheet_header_content_offset" />
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/vertical_list"

--- a/FluentUI.Drawer/src/main/res/layout/view_persistent_sheet.xml
+++ b/FluentUI.Drawer/src/main/res/layout/view_persistent_sheet.xml
@@ -5,6 +5,7 @@
 
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/persistent_bottom_sheet_outlined"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -27,11 +28,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginTop="@dimen/fluentui_drawer_handle_vertical_margin"
-            android:layout_marginBottom="@dimen/fluentui_drawer_handle_vertical_margin"
-            android:importantForAccessibility="no"
+            android:paddingTop="@dimen/fluentui_drawer_handle_vertical_margin"
+            android:paddingBottom="@dimen/fluentui_drawer_handle_vertical_margin"
+            android:paddingStart="@dimen/fluentui_drawer_handle_horizontal_margin"
+            android:contentDescription=" "
+            android:paddingEnd="@dimen/fluentui_drawer_handle_horizontal_margin"
             android:src="@drawable/ic_drawer_handle"
-            android:tint="?attr/fluentuiDrawerHandleColor" />
+            android:tint="?attr/fluentuiDrawerHandleColor"
+            tools:ignore="HardcodedText" />
 
         <android.support.v4.widget.NestedScrollView
             android:id="@+id/scroll_container"
@@ -43,6 +47,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:clipChildren="false"
+                android:paddingBottom="@dimen/fluentui_persistent_bottomsheet_content_padding_vertical"
                 android:orientation="vertical" />
         </android.support.v4.widget.NestedScrollView>
     </com.microsoft.fluentui.drawer.DrawerView>

--- a/FluentUI.Drawer/src/main/res/layout/view_sheet_horizontal_item_view.xml
+++ b/FluentUI.Drawer/src/main/res/layout/view_sheet_horizontal_item_view.xml
@@ -10,9 +10,10 @@
     android:layout_height="wrap_content"
     android:gravity="center"
     android:orientation="vertical"
-    android:paddingStart="@dimen/fluentui_persistent_bottomsheet_item_padding_horizontal"
-    android:paddingEnd="@dimen/fluentui_persistent_bottomsheet_item_padding_horizontal"
-    android:paddingTop="@dimen/fluentui_persistent_bottomsheet_horizontal_item_paddingTop">
+    android:paddingStart="@dimen/fluentui_persistent_bottomsheet_horizontalitem_padding_horizontal"
+    android:paddingTop="@dimen/fluentui_persistent_bottomsheet_horizontal_item_paddingTop"
+    android:paddingEnd="@dimen/fluentui_persistent_bottomsheet_horizontalitem_padding_horizontal"
+    android:paddingBottom="@dimen/fluentui_persistent_bottomsheet_horizontal_item_paddingBottom">
 
     <LinearLayout
         android:id="@+id/sheet_item_view_container"
@@ -22,11 +23,11 @@
 
     <TextView
         android:id="@+id/sheet_item_title"
+        style="@style/TextAppearance.FluentUI.PersistentBottomSheetHorizontalItem"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
-        style="@style/TextAppearance.FluentUI.PersistentBottomSheetHorizontalItem"
-        android:layout_marginTop="@dimen/fluentui_persistent_bottomsheet_horizontal_textview_margin_top"
+        android:layout_marginTop="@dimen/fluentui_persistent_bottomsheet_horizontal_icon_text_gap"
         android:paddingTop="@dimen/fluentui_persistent_bottomsheet_horizontal_textview_padding_vertical"
         android:paddingBottom="@dimen/fluentui_persistent_bottomsheet_horizontal_textview_padding_vertical"
         tools:text="Title" />

--- a/FluentUI.Drawer/src/main/res/values-night/themes.xml
+++ b/FluentUI.Drawer/src/main/res/values-night/themes.xml
@@ -5,5 +5,7 @@
         <!--Drawer-->
         <item name="fluentuiDrawerBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
         <item name="fluentuiDrawerHandleColor">@color/fluentui_gray_500</item>
+        <item name="fluentuiPersistentBottomSheetHeadingColor">@color/fluentui_gray_400</item>
+        <item name="fluentuiPersistentBottomSheetHorizontalItemColor">@color/fluentui_gray_400</item>
     </style>
 </resources>

--- a/FluentUI.Drawer/src/main/res/values/dimens.xml
+++ b/FluentUI.Drawer/src/main/res/values/dimens.xml
@@ -6,20 +6,24 @@
     <dimen name="fluentui_drawer_peek_width">0dp</dimen>
     <dimen name="fluentui_drawer_elevation">5dp</dimen>
     <dimen name="fluentui_drawer_handle_vertical_margin">8dp</dimen>
+    <dimen name="fluentui_drawer_handle_horizontal_margin">8dp</dimen>
     <!--Persistent BottomSheet-->
     <dimen name="fluentui_persistent_bottomsheet_item_view_margin">12dp</dimen>
     <!--BottomSheet-->
     <dimen name="fluentui_bottom_sheet_bottom_padding">8dp</dimen>
 
     <!--Persistent BottomSheet-->
-    <dimen name="fluentui_persistent_bottomsheet_horizontal_textview_margin_top">3dp</dimen>
-    <dimen name="fluentui_persistent_bottomsheet_horizontal_textview_padding_vertical">4dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_horizontal_textview_padding_vertical">1dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_horizontal_icon_text_gap">4dp</dimen>
     <dimen name="fluentui_persistent_bottomsheet_horizontal_item_paddingTop">10dp</dimen>
-    <dimen name="fluentui_persistent_bottomsheet_divider_margin_vertical">6dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_horizontal_item_paddingBottom">8dp</dimen>
     <dimen name="fluentui_persistent_bottomsheet_content_offset">8dp</dimen>
-    <dimen name="fluentui_persistent_bottomsheet_item_padding_horizontal">2dp</dimen>
-    <dimen name="fluentui_persistent_bottomsheet_header_marginTop">13dp</dimen>
-    <dimen name="fluentui_persistent_bottomsheet_header_marginBottom">6dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_header_content_offset">16dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_divider_margin_vertical">8dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_content_padding_vertical">8dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_horizontalitem_padding_horizontal">3dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_header_marginTop">15dp</dimen>
+    <dimen name="fluentui_persistent_bottomsheet_header_marginBottom">15dp</dimen>
     <dimen name="fluentui_persistent_bottomsheet_vertical_list_delta_offset">10dp</dimen>
     <dimen name="fluentui_bottomsheet_horizontalItem_min_width">64dp</dimen>
     <dimen name="fluentui_persistentbottomsheet_elevation">24dp</dimen>

--- a/FluentUI.Drawer/src/main/res/values/styles_font.xml
+++ b/FluentUI.Drawer/src/main/res/values/styles_font.xml
@@ -3,11 +3,12 @@
 
     <style name="TextAppearance.FluentUI.PersistentBottomSheetHeading">
         <item name="android:textSize">14sp</item>
-        <item name="android:fontFamily">"sans-serif"</item>
+        <item name="android:fontFamily">"sans-serif-medium"</item>
         <item name="android:letterSpacing">-0.01</item>
         <item name="android:textColor">?attr/fluentuiPersistentBottomSheetHeadingColor</item>
         <item name="android:layout_marginTop">@dimen/fluentui_persistent_bottomsheet_header_marginTop</item>
         <item name="android:layout_marginBottom">@dimen/fluentui_persistent_bottomsheet_header_marginBottom</item>
+        <item name="android:layout_marginStart">@dimen/fluentui_persistent_bottomsheet_header_content_offset</item>
     </style>
 
     <style name="TextAppearance.FluentUI.PersistentBottomSheet_Item">

--- a/FluentUI.Drawer/src/main/res/values/themes.xml
+++ b/FluentUI.Drawer/src/main/res/values/themes.xml
@@ -5,7 +5,7 @@
         <!--BottomSheet-->
         <item name="fluentuiPersistentBottomSheetHeadingColor">?attr/fluentuiForegroundSecondaryColor</item>
         <item name="fluentuiPersistentBottomSheetItemColor">?attr/fluentuiForegroundSecondaryColor</item>
-        <item name="fluentuiPersistentBottomSheetHorizontalItemColor">?attr/fluentuiForegroundColor</item>
+        <item name="fluentuiPersistentBottomSheetHorizontalItemColor">?attr/fluentuiForegroundSecondaryColor</item>
 
         <!--BottomSheet-->
         <item name="fluentuiBottomSheetBackgroundColor">?attr/fluentuiBackgroundColor</item>
@@ -15,7 +15,7 @@
 
         <!--Drawer-->
         <item name="fluentuiDrawerBackgroundColor">?attr/fluentuiBackgroundColor</item>
-        <item name="fluentuiDrawerHandleColor">?attr/fluentuiBackgroundPressedColor</item>
+        <item name="fluentuiDrawerHandleColor">?attr/fluentuiForegroundSecondaryIconColor</item>
 
     </style>
 


### PR DESCRIPTION
Make drawer handle clickable

### Platforms Impacted
- Android

### Description of changes
Changes include:
1 . Color changes as per new Figma
2. DarkMode color handling.
3. Single row bottomSheet handling
4. Make handle bar clickable and accessible.

### Verification
verified manually in demo app after making changes.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)