### PR TITLE
bug fix for dateTimePicker and make a new release 0.0.9

### DIFF
--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId 'com.microsoft.fluentuidemo'
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 8
-        versionName '0.0.8'
+        versionCode 9
+        versionName '0.0.9'
     }
     buildTypes {
         release {

--- a/FluentUI/build.gradle
+++ b/FluentUI/build.gradle
@@ -16,8 +16,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 8
-        versionName '0.0.8'
+        versionCode 9
+        versionName '0.0.9'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/FluentUI/src/main/java/com/microsoft/fluentui/calendar/CalendarAdapter.kt
+++ b/FluentUI/src/main/java/com/microsoft/fluentui/calendar/CalendarAdapter.kt
@@ -72,11 +72,10 @@ internal class CalendarAdapter : RecyclerView.Adapter<CalendarAdapter.CalendarDa
     private var dayCount: Int
     private var viewHeight: Int = 0
 
-    constructor(context: Context, config: CalendarView.Config, viewHeight: Int, onDateSelectedListener: OnDateSelectedListener) {
+    constructor(context: Context, config: CalendarView.Config, onDateSelectedListener: OnDateSelectedListener) {
         this.context = context
         this.config = config
         this.onDateSelectedListener = onDateSelectedListener
-        this.viewHeight = viewHeight
 
         selectionDrawableCircle = CalendarDaySelectionDrawable(this.context, Mode.SINGLE)
         selectionDrawableStart = CalendarDaySelectionDrawable(this.context, Mode.START)
@@ -171,6 +170,10 @@ internal class CalendarAdapter : RecyclerView.Adapter<CalendarAdapter.CalendarDa
             dayOfWeek = dayOfWeek.plus(1)
             ++i
         }
+    }
+
+    fun setViewHeight(viewHeight: Int) {
+        this.viewHeight = viewHeight
     }
 
     /**

--- a/FluentUI/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
+++ b/FluentUI/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
@@ -184,6 +184,7 @@ class CalendarView : LinearLayout, OnDateSelectedListener {
         var widthMeasureSpec = widthMeasureSpec
         val viewWidth = MeasureSpec.getSize(widthMeasureSpec)
         rowHeight = viewWidth / DAYS_IN_WEEK
+        weeksView.setRowHeight(rowHeight)
         widthMeasureSpec = MeasureSpec.makeMeasureSpec(rowHeight * DAYS_IN_WEEK, View.MeasureSpec.EXACTLY)
         resizeAnimator?.let {
             if (it.isRunning) {
@@ -215,19 +216,16 @@ class CalendarView : LinearLayout, OnDateSelectedListener {
         weekHeading = WeekHeadingView(context, config)
         addView(weekHeading)
 
-        post {
-            // RowHeight will be calculated after onmeasure only and hence calling this in post
-            weeksView = WeeksView(context, config, rowHeight, this)
-            weeksView.isSnappingEnabled = true
-            weeksView.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-            addView(weeksView)
-            weeksView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                    if (canExpand())
-                        displayMode = DisplayMode.FULL_MODE
-                }
-            })
-        }
+        weeksView = WeeksView(context, config, this)
+        weeksView.isSnappingEnabled = true
+        weeksView.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        addView(weeksView)
+        weeksView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                if (canExpand())
+                    displayMode = DisplayMode.FULL_MODE
+            }
+        })
 
         dividerDrawable = ContextCompat.getDrawable(context, R.drawable.ms_row_divider)
         showDividers = SHOW_DIVIDER_MIDDLE

--- a/FluentUI/src/main/java/com/microsoft/fluentui/calendar/WeeksView.kt
+++ b/FluentUI/src/main/java/com/microsoft/fluentui/calendar/WeeksView.kt
@@ -102,7 +102,7 @@ internal class WeeksView : MSRecyclerView {
     private lateinit var onDateSelectedListener: OnDateSelectedListener
     private lateinit var paint: TextPaint
 
-    constructor(context: Context, config: CalendarView.Config, rowHeight: Int, onDateSelectedListener: OnDateSelectedListener) : super(context) {
+    constructor(context: Context, config: CalendarView.Config, onDateSelectedListener: OnDateSelectedListener) : super(context) {
         this.config = config
         this.onDateSelectedListener = onDateSelectedListener
         setWillNotDraw(false)
@@ -113,7 +113,7 @@ internal class WeeksView : MSRecyclerView {
             addItemDecoration(divider)
         }
 
-        pickerAdapter = CalendarAdapter(context, config, rowHeight, this.onDateSelectedListener)
+        pickerAdapter = CalendarAdapter(context, config, this.onDateSelectedListener)
         adapter = pickerAdapter
 
         setHasFixedSize(true)
@@ -319,6 +319,10 @@ internal class WeeksView : MSRecyclerView {
         overlayTransitionAnimator.duration = OVERLAY_TRANSITION_DURATION
         overlayTransitionAnimator.addListener(hidingOverlayAnimationListener)
         overlayTransitionAnimator.start()
+    }
+
+    fun setRowHeight(rowHeight: Int) {
+        pickerAdapter.setViewHeight(rowHeight)
     }
 
     private class MonthDescriptor {


### PR DESCRIPTION
Bump up the version to 0.0.9

Fix a crash in DateTimePicker due to rowheight
Now we are not depending on post as WeeksView was net getting initialized when calendarView was used as a dialog