### PR TITLE
Bug fixes for tablayout

### DIFF
--- a/FluentUI/src/main/java/com/microsoft/fluentui/tablayout/TabLayout.kt
+++ b/FluentUI/src/main/java/com/microsoft/fluentui/tablayout/TabLayout.kt
@@ -96,7 +96,8 @@ class TabLayout : TemplateView {
      * */
     fun updateTemplate() {
         val tabLayout = tabLayout ?: return
-        var paddingHorizontal = resources.getDimension(R.dimen.fluentui_tab_padding_horizontal).toInt()
+        val paddingHorizontalLeft = resources.getDimension(R.dimen.fluentui_tab_padding_horizontal).toInt()
+        var paddingHorizontalRight = resources.getDimension(R.dimen.fluentui_tab_padding_horizontal).toInt()
         val paddingVertical = resources.getDimension(R.dimen.fluentui_tab_padding_vertical).toInt()
         when (tabType) {
             TabType.STANDARD -> {
@@ -105,7 +106,7 @@ class TabLayout : TemplateView {
                 setTabLayoutBackground()
             }
             TabType.SWITCH -> {
-                tabLayout.tabMode = TabLayout.MODE_FIXED
+                tabLayout.tabMode = TabLayout.MODE_SCROLLABLE
                 tabLayout.layoutParams.width = LayoutParams.WRAP_CONTENT
                 setTabLayoutBackground()
             }
@@ -114,10 +115,10 @@ class TabLayout : TemplateView {
                 tabLayout.layoutParams.width = LayoutParams.MATCH_PARENT
                 tabLayout.setBackgroundResource(0)
                 updateMargin()
-                paddingHorizontal = 0
+                paddingHorizontalRight = 0
             }
         }
-        tabLayoutContainer?.setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, paddingVertical)
+        tabLayoutContainer?.setPadding(paddingHorizontalLeft, paddingVertical, paddingHorizontalRight, paddingVertical)
         setSelectorColors()
         setTextAppearance()
     }

--- a/FluentUI/src/main/res/layout/view_tab_layout.xml
+++ b/FluentUI/src/main/res/layout/view_tab_layout.xml
@@ -12,7 +12,6 @@
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tab_layout"
-        app:tabContentStart="@dimen/fluentui_tab_content_start"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:tabMode="fixed"


### PR DESCRIPTION
### Platforms Impacted
- [ ] Android

### Description of changes
In the Switch mode if the texts are of different length, the one with bigger length was getting moved to next line and hence we have to use scroll mode

In the pills mode there is 0 right horizontal padding

Remove hardcoded content start margin