### PR TITLE
Use ContextThemeWrapper for others module

### DIFF
--- a/fluentui_others/src/main/java/com/microsoft/fluentui/actionbar/ActionBarLayout.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/actionbar/ActionBarLayout.kt
@@ -13,7 +13,7 @@ import kotlinx.android.synthetic.main.view_action_bar.view.*
 import java.lang.Exception
 import java.lang.IllegalStateException
 
-class ActionBarLayout @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) : TemplateView(FluentUIContextThemeWrapper(context), attrs) {
+class ActionBarLayout @JvmOverloads constructor(appContext: Context, attrs: AttributeSet? = null) : TemplateView(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs) {
     companion object {
         private val DEFAULT_TYPE = Type.BASIC
     }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/appbarlayout/AppBarLayout.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/appbarlayout/AppBarLayout.kt
@@ -121,7 +121,7 @@ class AppBarLayout : AppBarLayout {
         }
     }
 
-    constructor(context: Context, attrs: AttributeSet?) : super(FluentUIContextThemeWrapper(context), attrs) {
+    constructor(appContext: Context, attrs: AttributeSet?) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs) {
         setupToolbar(context)
         setBackgroundColor(ThemeUtil.getThemeAttrColor(context, R.attr.fluentuiAppBarLayoutBackgroundColor))
 

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/calendar/CalendarDayView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/calendar/CalendarDayView.kt
@@ -113,11 +113,11 @@ internal class CalendarDayView: AppCompatButton, Checkable {
      * @param [calendarConfig] Config passes CalendarView attributes
      * @constructor creates an instance of a CalendarDayView
      */
-    constructor(context: Context, calendarConfig: CalendarView.Config) : super(FluentUIContextThemeWrapper(context)) {
+    constructor(appContext: Context, calendarConfig: CalendarView.Config) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components)) {
         config = calendarConfig
         setWillNotDraw(false)
 
-        todayBackgroundDrawable = ContextCompat.getDrawable(this.context, R.drawable.calendar_background_today)
+        todayBackgroundDrawable = ContextCompat.getDrawable(context, R.drawable.calendar_background_today)
 
         paint.isAntiAlias = true
 
@@ -134,7 +134,7 @@ internal class CalendarDayView: AppCompatButton, Checkable {
         setTextSize(TypedValue.COMPLEX_UNIT_PX, config.calendarDayTextSize.toFloat())
         isAllCaps = false
 
-        _foregroundDrawable = ContextCompat.getDrawable(this.context, R.drawable.ms_ripple_transparent_background)
+        _foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.ms_ripple_transparent_background)
 
         setPadding(0, 0, 0, 0)
     }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
@@ -114,7 +114,7 @@ class CalendarView : LinearLayout, OnDateSelectedListener {
     }
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components), attrs, defStyleAttr) {
         dividerHeight = Math.round(resources.getDimension(R.dimen.fluentui_divider_height))
         calendarViewWidthForTablet = Math.round(resources.getDimension(R.dimen.fluentui_calendar_weeks_max_width))
 

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/datetimepicker/DateTimePickerDialog.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/datetimepicker/DateTimePickerDialog.kt
@@ -144,7 +144,7 @@ class DateTimePickerDialog : AppCompatDialog, Toolbar.OnMenuItemClickListener, O
         dateTime: ZonedDateTime = ZonedDateTime.now(),
         duration: Duration = Duration.ZERO
     ) : super(context, R.style.Dialog_FluentUI) {
-        fluentuiContext = FluentUIContextThemeWrapper(context)
+        fluentuiContext = FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components)
 
         this.dateRangeMode = dateRangeMode
         this.dateTime = dateTime

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
@@ -16,6 +16,7 @@ import android.widget.TextView
 import com.microsoft.fluentui.R
 import com.microsoft.fluentui.persona.IPersona
 import com.microsoft.fluentui.persona.Persona
+import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import com.microsoft.fluentui.util.ThemeUtil
 import com.microsoft.fluentui.view.TemplateView
 import com.tokenautocomplete.TokenCompleteTextView
@@ -222,7 +223,7 @@ class PeoplePickerView : TemplateView {
     }
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs, defStyleAttr) {
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.PeoplePickerView)
 
         label = styledAttrs.getString(R.styleable.PeoplePickerView_label) ?: ""

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/persona/AvatarGroupView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/persona/AvatarGroupView.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import com.microsoft.fluentui.R
+import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 
 
 enum class AvatarGroupStyle {
@@ -20,7 +21,7 @@ open class AvatarGroupView : FrameLayout {
     }
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs, defStyleAttr) {
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.AvatarGroupView)
         val avatarSizeOrdinal = styledAttrs.getInt(R.styleable.AvatarGroupView_avatarSize, AvatarView.DEFAULT_AVATAR_SIZE.ordinal)
         val avatarGroupStyleOrdinal = styledAttrs.getInt(R.styleable.AvatarGroupView_avatarGroupStyle, DEFAULT_AVATAR_GROUP_STYLE.ordinal)

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/persona/AvatarView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/persona/AvatarView.kt
@@ -16,6 +16,7 @@ import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatImageView
 import android.util.AttributeSet
 import com.microsoft.fluentui.R
+import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 
 enum class AvatarStyle {
     CIRCLE, SQUARE
@@ -38,7 +39,7 @@ open class AvatarView : AppCompatImageView {
     }
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs, defStyleAttr) {
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.AvatarView)
         val avatarSizeOrdinal = styledAttrs.getInt(R.styleable.AvatarView_avatarSize, DEFAULT_AVATAR_SIZE.ordinal)
         val avatarStyleOrdinal = styledAttrs.getInt(R.styleable.AvatarView_avatarStyle, DEFAULT_AVATAR_STYLE.ordinal)

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/persona/PersonaChipView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/persona/PersonaChipView.kt
@@ -20,6 +20,7 @@ import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.TextView
 import com.microsoft.fluentui.R
+import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import com.microsoft.fluentui.util.ThemeUtil
 import com.microsoft.fluentui.util.isVisible
 import com.microsoft.fluentui.view.TemplateView
@@ -91,7 +92,7 @@ class PersonaChipView : TemplateView {
     var listener: Listener? = null
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs, defStyleAttr) {
         if (attrs == null)
             return
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.PersonaChipView)

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/persona/PersonaListView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/persona/PersonaListView.kt
@@ -10,7 +10,9 @@ import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
+import com.microsoft.fluentui.R
 import com.microsoft.fluentui.listitem.ListItemDivider
+import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import java.util.*
 
 /**
@@ -39,7 +41,7 @@ class PersonaListView : RecyclerView {
     private val personaListAdapter = PersonaListAdapter(context)
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext, R.style.Theme_FluentUI_Components), attrs, defStyleAttr) {
         adapter = personaListAdapter
         layoutManager = LinearLayoutManager(context)
         addItemDecoration(ListItemDivider(context, DividerItemDecoration.VERTICAL))

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/persona/PersonaView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/persona/PersonaView.kt
@@ -103,7 +103,7 @@ class PersonaView : ListItemView {
     private val avatarView = AvatarView(context)
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(appContext, attrs, defStyleAttr) {
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.PersonaView)
         name = styledAttrs.getString(R.styleable.PersonaView_name) ?: ""
         email = styledAttrs.getString(R.styleable.PersonaView_email) ?: ""

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
@@ -21,6 +21,7 @@ import android.widget.RadioButton
 import android.widget.TextView
 import com.microsoft.fluentui.R
 import com.microsoft.fluentui.popupmenu.PopupMenu.Companion.DEFAULT_ITEM_CHECKABLE_BEHAVIOR
+import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import com.microsoft.fluentui.util.ThemeUtil
 import com.microsoft.fluentui.util.isVisible
 import com.microsoft.fluentui.view.TemplateView
@@ -59,7 +60,7 @@ internal class PopupMenuItemView : TemplateView {
     private var showCheckBox: Boolean = false
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components), attrs, defStyleAttr)
 
     fun setMenuItem(popupMenuItem: PopupMenuItem) {
         title = popupMenuItem.title

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
@@ -105,7 +105,7 @@ open class Searchbar : TemplateView, SearchView.OnQueryTextListener {
     var onCloseListener: SearchView.OnCloseListener? = null
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI), attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Components), attrs, defStyleAttr)
 
     /**
      * Sets the query text for the search view.

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/snackbar/Snackbar.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/snackbar/Snackbar.kt
@@ -45,7 +45,7 @@ class Snackbar : BaseTransientBottomBar<Snackbar> {
             val parent = findSuitableParent(view) ?:
                 throw IllegalArgumentException("No suitable parent found from the given view. Please provide a valid view.")
             // Need the theme wrapper to avoid crashing in Dark theme.
-            val content = LayoutInflater.from(FluentUIContextThemeWrapper(parent.context)).inflate(R.layout.view_snackbar, parent, false)
+            val content = LayoutInflater.from(FluentUIContextThemeWrapper(parent.context,R.style.Theme_FluentUI_Components)).inflate(R.layout.view_snackbar, parent, false)
             val snackbar = Snackbar(parent, content, ContentViewCallback(content))
             snackbar.duration = duration
             snackbar.setStyle(style)

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/toolbar/Toolbar.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/toolbar/Toolbar.kt
@@ -41,7 +41,7 @@ class Toolbar : Toolbar {
         }
 
     @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context), attrs, R.attr.toolbarStyle) {
+    constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_Components), attrs, R.attr.toolbarStyle) {
         // minHeight can't be set in theme or it will also set title height. Having minHeight helps center option menu icons.
         val styledAttributes = context.theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))
         val actionBarSize = styledAttributes.getDimensionPixelSize(0, -1)

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
@@ -70,7 +70,7 @@ class Tooltip {
 
         // Need the theme wrapper to avoid crashing in Dark theme.
         // TODO Change to inflate(R.layout.view_tooltip, parent, false) and refactor dismiss inside listener accordingly.
-        tooltipView = LayoutInflater.from(FluentUIContextThemeWrapper(context)).inflate(R.layout.view_tooltip, null)
+        tooltipView = LayoutInflater.from(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components)).inflate(R.layout.view_tooltip, null)
         textView = tooltipView.tooltip_text
         arrowUpView = tooltipView.tooltip_arrow_up
         arrowDownView = tooltipView.tooltip_arrow_down

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/widget/BottomNavigation.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/widget/BottomNavigation.kt
@@ -22,7 +22,7 @@ class BottomNavigationView : BottomNavigationView {
 
     @JvmOverloads
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
-        : super(FluentUIContextThemeWrapper(context), attrs, defStyleAttr)
+        : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components), attrs, defStyleAttr)
 
     override fun setLabelVisibilityMode(labelVisibilityMode: Int) {
         // The super call in the constructor runs setLabelVisibilityMode() before the constructor.

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/widget/Button.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/widget/Button.kt
@@ -18,5 +18,5 @@ import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 class Button : AppCompatButton {
     @JvmOverloads
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = R.attr.buttonStyle)
-        : super(FluentUIContextThemeWrapper(context), attrs, defStyleAttr)
+        : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components), attrs, defStyleAttr)
 }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/widget/ProgressBar.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/widget/ProgressBar.kt
@@ -8,6 +8,7 @@ package com.microsoft.fluentui.widget
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.ProgressBar
+import com.microsoft.fluentui.R
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 
 /**
@@ -17,5 +18,5 @@ import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 class ProgressBar : ProgressBar {
     @JvmOverloads
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0, defStyleRes: Int = 0)
-        : super(FluentUIContextThemeWrapper(context), attrs, defStyleAttr, defStyleRes)
+        : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Components), attrs, defStyleAttr, defStyleRes)
 }


### PR DESCRIPTION
### Platforms Impacted
- [ * ] Android

### Description of changes

This PR adds the context theme wrapper to others module as well. It will avoid the issues for existing users
who are using the complete library when they switch to modular fluent

### Verification

Tested using FluentUI demo app by changing the AppTheme - where the theme doesn't inherit Fluent theme


### Pull request checklist

This PR has considered:
- [* ] Light and Dark appearances
- [ *] VoiceOver and Keyboard Accessibility
- [* ] Internationalization and Right to Left layouts
- [ *] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)