### PR TITLE
Accessibility Fixes for TabLayout, Drawer , BottomSheets

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/TabLayoutActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/TabLayoutActivity.kt
@@ -41,6 +41,7 @@ class TabLayoutActivity : DemoActivity() {
     }
 
     private fun clickListener(v: View) {
+        demo_tab_layout.visibility = View.VISIBLE
         tabLayout.removeAllTabs()
         tabLayout.setupWithViewPager(null)
 

--- a/FluentUI.Demo/src/main/res/layout/activity_tab_layout.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_tab_layout.xml
@@ -15,6 +15,7 @@
         style="@style/FluentUIDemo.TabLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:tabType="Standard"/>
 
     <androidx.viewpager.widget.ViewPager

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
@@ -47,6 +47,11 @@ open class DrawerDialog @JvmOverloads constructor(context: Context, val behavior
         override fun onStateChanged(bottomSheet: View, newState: Int) {
             if(newState == BottomSheetBehavior.STATE_COLLAPSED) // when state is STATE_COLLAPSED
                 dismissDialog()
+            if (newState == BottomSheetBehavior.STATE_EXPANDED) {
+                if (drawerContent.childCount > 0) {
+                    drawerContent.getChildAt(0)?.requestFocus()
+                }
+            }
         }
 
         override fun onSlide(bottomSheet: View, slideOffset: Float) {

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tablayout/TabLayout.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tablayout/TabLayout.kt
@@ -15,8 +15,6 @@ import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.*
 import com.google.android.material.tabs.TabLayout
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import com.microsoft.fluentui.util.ThemeUtil
@@ -41,7 +39,7 @@ class TabLayout : TemplateView {
     var tabType: TabType? = null
         set(value) {
             field = value
-            updateTemplate()
+            updateTemplate(true)
         }
 
     private var tabLayoutContainer: ViewGroup? = null
@@ -104,7 +102,7 @@ class TabLayout : TemplateView {
      * Updates the given template based on the [tabType]. For [TabType.PILLS], this method must be called
      * to set the appropriate margins if the [tabType] is set before the Tabs have been added.
      * */
-    fun updateTemplate() {
+    fun updateTemplate(explicit:Boolean = false) {
         val tabLayout = tabLayout ?: return
         val paddingHorizontalLeft = resources.getDimension(R.dimen.fluentui_tab_padding_horizontal).toInt()
         var paddingHorizontalRight = resources.getDimension(R.dimen.fluentui_tab_padding_horizontal).toInt()
@@ -129,7 +127,7 @@ class TabLayout : TemplateView {
             }
         }
         tabLayoutContainer?.setPadding(paddingHorizontalLeft, paddingVertical, paddingHorizontalRight, paddingVertical)
-        setSelectorProperties()
+        setSelectorProperties(explicit)
         setTextAppearance()
     }
 
@@ -144,9 +142,7 @@ class TabLayout : TemplateView {
             tab.layoutParams = (tab.layoutParams as LinearLayout.LayoutParams).apply {
                 rightMargin = resources.getDimension(R.dimen.fluentui_tab_margin).toInt()
             }
-            setTabAccessibility(tabLayout, i, tab as TabLayout.TabView)
         }
-        tabLayout.requestLayout()
     }
 
     /**
@@ -182,13 +178,17 @@ class TabLayout : TemplateView {
         tabLayout.setTabTextColors(tabUnselectedTextColor, tabSelectedTextColor)
     }
 
-    private fun setSelectorProperties() {
+    private fun setSelectorProperties(explicit: Boolean= false) {
         val tabLayout = tabLayout ?: return
         val viewGroup = tabLayout.getChildAt(0) as ViewGroup
         for (i in 0 until tabLayout.tabCount) {
             val tab: TabLayout.TabView = viewGroup.getChildAt(i) as TabLayout.TabView
             tab.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
             tab.background = getStateListDrawable()
+            setTabAccessibility(tabLayout, i, tab)
+        }
+        if (explicit) {
+            tabLayout.requestFocus()
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] Android

### Changes
Add Default Keyboard Focus for Drawers, BottoomSheet when opened.
Remove Empty TabLayout.
Auto Focus tab layout when selected

### Verification
Manually.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)