### PR TITLE
Handle ShiftTab Scenarios in PeoplePickerView and SearchBar

### DIFF
--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
@@ -265,8 +265,10 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         val handled = super.onKeyUp(keyCode, event)
         if(!handled && keyCode == KeyEvent.KEYCODE_TAB){
-            val view = parent.focusSearch(this, FOCUS_FORWARD)
-            return view?.requestFocus()?: false
+            if(!event.isShiftPressed) {
+                val view = parent.focusSearch(this, FOCUS_FORWARD)
+                return view?.requestFocus() ?: false
+            }
         }
         return handled
     }

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.SearchView
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
@@ -130,6 +131,17 @@ open class Searchbar : TemplateView, SearchView.OnQueryTextListener {
     override fun onQueryTextChange(query: String): Boolean {
         updateCloseIconVisibility()
         return onQueryTextListener?.onQueryTextChange(query) ?: false
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        val handled = super.dispatchKeyEvent(event)
+        if(searchView != null && searchView!!.hasFocus() && !handled && event?.action == KeyEvent.ACTION_UP  &&  event?.keyCode == KeyEvent.KEYCODE_TAB){
+            if(event.isShiftPressed) {
+                val view = searchView?.parent?.focusSearch(this, FOCUS_BACKWARD)
+                return view?.requestFocus() ?: false
+            }
+        }
+        return handled
     }
 
     // Template


### PR DESCRIPTION
PeoplePickerTextView used to handle shifttab by default and hence when we were manually handling tab key. It was restricting it's usage, due to which we have to put a check that it should move focus forward only when shift is not pressed or when just Tab is pressed

Searchbar was not respecting shiftTab to move the focus backward so we are handling it manually now

