### PR TITLE
Update strings.xml in fluentui_others to avoid aapt2 compile error

### DIFF
--- a/fluentui_others/src/main/res/values/strings.xml
+++ b/fluentui_others/src/main/res/values/strings.xml
@@ -19,9 +19,9 @@
     <string name="action_bar_right_icon_description">Next</string>
     <!--accessibiltiy-->
     <!--Announcement when page is scrolled-->
-    <string name="action_bar_accessibility_page_announcement">Slider page %d of %d</string>
+    <string name="action_bar_accessibility_page_announcement">Slider page %1$d of %2$d</string>
     <!--Announcement when actionbarlayout opens or when Skip is pressed-->
-    <string name="action_bar_accessibility_viewpager_description">Multi-page view. Slider page %d of %d</string>
+    <string name="action_bar_accessibility_viewpager_description">Multi-page view. Slider page %1$d of %2$d</string>
 
     <string name="fluentui_bottom_sheet_header">BottomSheet Heading</string>
 </resources>


### PR DESCRIPTION
### Platforms Impacted
- [x] Android

### Description of changes

Hi,

Using this library in projects with aapt2 could cause the following build failure:
```
error: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?
```
because it enforces a more strict way of writing string placeholders.

Pls help merge! Thanks!
Xiaoyu

### Verification

tested in our project

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| `error: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?` | pass :) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)