### PR TITLE
People picker view fixes

### DIFF
--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
@@ -443,6 +443,14 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
     }
 
     /**
+     * Refreshes picked persona views, since there is no option to refresh the existing views and [invalidate] is not working,
+     * so rebuilding all the spans again
+     */
+    fun refreshPickedPersonaViews() {
+        rebuildPersonaSpans()
+    }
+
+    /**
      * Insert a new span for an object.
      * Adapted from [insertSpan] and [addObject] in [TokenCompleteTextView].
      * Because [addObject] is in a post runnable sometimes the timing is off,

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
@@ -302,9 +302,6 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
         if (objects.size == personaChipLimit)
             return
 
-        lastSpan?.let {
-            shouldAnnouncePersonaAdditionMap[it.token] = true
-        }
         super.replaceText(text)
         context.activity?.let {
             if (DuoSupportUtils.isDualScreenMode(it) && lastSpan != null) {
@@ -422,6 +419,7 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
             hiddenPersonaSpans.forEach { span ->
                 // addObject does not work in this code block when in accessibility mode so we use insertPersonaSpan instead.
                 // The persona still gets added to objects through the TokenSpanWatcher.
+                shouldAnnouncePersonaAdditionMap[span.token] = false
                 insertPersonaSpan(span.token)
             }
 
@@ -433,7 +431,6 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
      * Add a picked persona
      */
     fun addPickedPersona(persona: IPersona) {
-        shouldAnnouncePersonaAdditionMap[persona] = true
         super.addObject(persona)
     }
 
@@ -635,7 +632,7 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
 
     private class TokenListener(val view: PeoplePickerTextView) : TokenCompleteTextView.TokenListener<IPersona> {
         override fun onTokenAdded(token: IPersona) {
-            if (view.shouldAnnouncePersonaAdditionMap[token] == true)
+            if (view.shouldAnnouncePersonaAdditionMap[token] != false)
                 view.tokenListener?.onTokenAdded(token)
             if (view.isFocused)
                 view.announcePersonaAdded(token)
@@ -817,7 +814,7 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
 
         // We only want to announce when a persona was added by a user.
         // If text has been replaced in the text editor and a token was added, the user added a token.
-        if (shouldAnnouncePersonaAdditionMap[persona] == true) {
+        if (shouldAnnouncePersonaAdditionMap[persona] != false) {
             announceForAccessibility("$replacedText ${getAnnouncementText(
                 persona,
                 R.string.people_picker_accessibility_persona_added

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import android.view.accessibility.AccessibilityEvent
 import android.widget.Filter
 import android.widget.TextView
+import com.microsoft.fluentui.peoplepicker.*
 import com.microsoft.fluentui.persona.IPersona
 import com.microsoft.fluentui.persona.Persona
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
@@ -254,7 +255,7 @@ class PeoplePickerView : TemplateView {
         // Fixed properties for TokenCompleteTextView.
         peoplePickerTextView?.apply {
             dropDownWidth = ViewGroup.LayoutParams.MATCH_PARENT
-            allowCollapse(true)
+            allowCollapse(allowCollapse)
             isLongClickable = true
             setTokenListener(TokenListener(this@PeoplePickerView))
             performBestGuess(true)
@@ -274,11 +275,24 @@ class PeoplePickerView : TemplateView {
         }
     }
 
+    fun addPickedPersona(persona: IPersona) {
+        peoplePickerTextView?.addPickedPersona(persona)
+    }
+
+    fun removePickedPersona(persona: IPersona) {
+        peoplePickerTextView?.removePickedPersona(persona)
+    }
+
     private fun updateViews() {
-        labelTextView?.text = label
+        if(label.isBlank()) {
+            labelTextView?.visibility = GONE
+        } else {
+            labelTextView?.visibility = VISIBLE
+            labelTextView?.text = label
+        }
         peoplePickerTextView?.apply {
             valueHint = this@PeoplePickerView.valueHint
-            allowCollapse(allowCollapse)
+            allowCollapse = this@PeoplePickerView.allowCollapse
             allowDuplicatePersonaChips = this@PeoplePickerView.allowDuplicatePersonaChips
             characterThreshold = this@PeoplePickerView.characterThreshold
             personaChipLimit = this@PeoplePickerView.personaChipLimit

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
@@ -255,7 +255,7 @@ class PeoplePickerView : TemplateView {
         // Fixed properties for TokenCompleteTextView.
         peoplePickerTextView?.apply {
             dropDownWidth = ViewGroup.LayoutParams.MATCH_PARENT
-            allowCollapse(allowCollapse)
+            allowCollapse = this@PeoplePickerView.allowCollapse
             isLongClickable = true
             setTokenListener(TokenListener(this@PeoplePickerView))
             performBestGuess(true)
@@ -275,10 +275,16 @@ class PeoplePickerView : TemplateView {
         }
     }
 
+    /**
+     * Add a picked persona
+     */
     fun addPickedPersona(persona: IPersona) {
         peoplePickerTextView?.addPickedPersona(persona)
     }
 
+    /**
+     * Removes a persona from picked items
+     */
     fun removePickedPersona(persona: IPersona) {
         peoplePickerTextView?.removePickedPersona(persona)
     }

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
@@ -289,6 +289,21 @@ class PeoplePickerView : TemplateView {
         peoplePickerTextView?.removePickedPersona(persona)
     }
 
+    /**
+     * Refreshes a persona view in both picked items and available options.
+     * Can be used if doing any async operation to load Persona data e.g. downloading avatar image.
+     */
+    fun refreshPersona(persona: IPersona) {
+        if(pickedPersonas.contains(persona)) {
+            peoplePickerTextView?.refreshPickedPersonaViews()
+        }
+
+        val personaIndexInSuggestions = availablePersonas?.indexOf(persona) ?: -1
+        if(personaIndexInSuggestions >= 0) {
+            peoplePickerTextViewAdapter?.notifyDataSetChanged()
+        }
+    }
+
     private fun updateViews() {
         if(label.isBlank()) {
             labelTextView?.visibility = GONE


### PR DESCRIPTION
Fixes remove span announcement
Fixes view rendering when allowCollapse is false
Added APIs to add and remove span
Fixes extra padding if label is blank

### Platforms Impacted
- [X] Android

### Description of changes

PeoplePickerView.kt
- Added APIs to add and remove span
- Hide the labelTextView if label is not provided

PeoplePickerTextView..kt
- Since removeObject post task to handler, added map for remove span notifications
- Added allowCollapse check inside performCollapseAndAdjustLayout method

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [X] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)