### PR TITLE
Tooltip Orientation and Second Screen Fixes

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/util/DisplayUtils.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/util/DisplayUtils.kt
@@ -41,7 +41,7 @@ val Context.navigationBarHeight: Int
 val Context.softNavBarOffsetX: Int
     get() {
         val rotation = (getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
-        return if (rotation == Surface.ROTATION_270 && hasSoftNavigationBar && !isTablet)
+        return if (rotation == Surface.ROTATION_270 && !isTablet)
             navigationBarHeight
         else
             0
@@ -66,13 +66,6 @@ val Context.desiredDialogSize: IntArray
         dialogSize[1] = WindowManager.LayoutParams.WRAP_CONTENT
 
         return dialogSize
-    }
-
-// This check returns false in emulators
-val Context.hasSoftNavigationBar: Boolean
-    get() {
-        val id = resources.getIdentifier(CONFIG_SHOW_NAVIGATION_BAR, BOOL_STRING, ANDROID_STRING)
-        return id > 0 && resources.getBoolean(id)
     }
 
 val Context.displaySize: Point

--- a/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
+++ b/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
@@ -147,15 +147,13 @@ class Tooltip {
         if (requireReinit ) initTooltipArrow(anchorRect, anchor.layoutIsRtl, config.offsetX)
         if (requireReadjustment) readjustTooltip(anchorRect, anchor.layoutIsRtl, config)
 
-        if (config.touchDismissLocation == TouchDismissLocation.INSIDE) {
-            tooltipView.x = if (anchor.layoutIsRtl) resetPositionXForRtl() else positionX.toFloat()
-            tooltipView.y = positionY.toFloat()
-            anchor.post { popupWindow.showAtLocation(anchor, Gravity.NO_GRAVITY, 0, 0) }
-        } else {
-            popupWindow.width = contentWidth
-            popupWindow.height = contentHeight
-            anchor.post { popupWindow.showAtLocation(anchor, Gravity.NO_GRAVITY, positionX, positionY)}
-        }
+        popupWindow.width = contentWidth
+        popupWindow.height = contentHeight
+        anchor.post { popupWindow.showAtLocation(anchor, Gravity.NO_GRAVITY, positionX, positionY)}
+
+        if (config.touchDismissLocation == TouchDismissLocation.INSIDE)
+            popupWindow.setOutsideTouchable(false);
+
         // popupWindow may get dismissed by outside touch for TouchDismissLocation.ANYWHERE
         popupWindow.setOnDismissListener {
             dismissSideEffects()
@@ -232,9 +230,6 @@ class Tooltip {
             positionY = anchor.top - contentHeight - offsetY
             if(secondScreen) positionY -= displayHeight + DuoSupportUtils.DUO_HINGE_WIDTH
         }
-
-        if (dismissLocation == TouchDismissLocation.INSIDE)
-            positionY -= if(secondScreen) 0 else context.statusBarHeight
     }
 
     private fun initContentView(content: View) {

--- a/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
+++ b/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
@@ -156,7 +156,7 @@ class Tooltip {
             popupWindow.height = contentHeight
             anchor.post { popupWindow.showAtLocation(anchor, Gravity.NO_GRAVITY, positionX, positionY)}
         }
-//      popupWindow gets may get dismissed by outside touch for TouchDismissLocation.ANYWHERE
+        // popupWindow may get dismissed by outside touch for TouchDismissLocation.ANYWHERE
         popupWindow.setOnDismissListener {
             dismissSideEffects()
         }

--- a/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
+++ b/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
@@ -132,7 +132,7 @@ class Tooltip {
 
         // Get location of anchor view on screen
         val screenPos = IntArray(2)
-        anchor.getLocationOnScreen(screenPos)
+        anchor.getLocationInWindow(screenPos)
         // Get rect for anchor view
         val anchorRect = Rect(screenPos[0], screenPos[1], screenPos[0] + anchor.width, screenPos[1] + anchor.height)
 
@@ -156,6 +156,10 @@ class Tooltip {
             popupWindow.height = contentHeight
             anchor.post { popupWindow.showAtLocation(anchor, Gravity.NO_GRAVITY, positionX, positionY)}
         }
+//      popupWindow gets may get dismissed by outside touch for TouchDismissLocation.ANYWHERE
+        popupWindow.setOnDismissListener {
+            dismissSideEffects()
+        }
 
         return this
     }
@@ -173,10 +177,13 @@ class Tooltip {
         tooltipBackGround.background = ContextCompat.getDrawable(context, drawable)
     }
 
-    fun dismiss() {
+    private fun dismissSideEffects() {
         tooltipView.announceForAccessibility(context.getString(R.string.tooltip_accessibility_dismiss_announcement))
-        popupWindow.dismiss()
         onDismissListener?.onDismiss()
+    }
+
+    fun dismiss() {
+        popupWindow.dismiss()
     }
 
     private fun measureContentSize() {
@@ -194,14 +201,14 @@ class Tooltip {
         positionX = anchorCenter - contentWidth / 2 + offsetX
 
         // Duo Second Screen Support
-        val secondScreen = anchorCenter > displayWidth
+        val secondScreen = anchorCenter > displayWidth  && context.activity?.let { DuoSupportUtils.isDeviceSurfaceDuo(it) } ?: false
         if (secondScreen) positionX -= displayWidth + DuoSupportUtils.DUO_HINGE_WIDTH
 
         // Navigation Bar in Nougat+ can appear on the left on phones at 270 rotation and adds
         // its height to the left of the display creating an offset that needs to be corrected to get
-        // accurate horizontal position. Note that the soft navigation bar check returns false in emulators.
+        // accurate horizontal position.
         val softNavBarOffsetX = context.softNavBarOffsetX
-        if (positionX + contentWidth + margin + softNavBarOffsetX > displayWidth)
+        if (positionX + contentWidth + margin - softNavBarOffsetX > displayWidth)
             positionX = displayWidth - contentWidth - margin + softNavBarOffsetX
         else if (positionX < softNavBarOffsetX + margin)
             positionX = margin + softNavBarOffsetX
@@ -214,7 +221,7 @@ class Tooltip {
         positionY = anchor.bottom
 
         // Duo Second Screen Support
-        val secondScreen = anchor.bottom > displayHeight
+        val secondScreen = anchor.bottom > displayHeight  && context.activity?.let { DuoSupportUtils.isDeviceSurfaceDuo(it) } ?: false
         if(secondScreen) positionY -= displayHeight + DuoSupportUtils.DUO_HINGE_WIDTH
 
         isAboveAnchor = context.activity?.let {
@@ -264,7 +271,7 @@ class Tooltip {
         val layoutParams = toolTipArrow.layoutParams as LinearLayout.LayoutParams
         val cornerRadius = context.resources.getDimensionPixelSize(R.dimen.fluentui_tooltip_radius)
         if(!isSideAnchor){ // Normal Top/Bottom arrow
-            val anchorCenterX = if (anchorRect.centerX() > displayWidth) anchorRect.centerX() - displayWidth - DuoSupportUtils.DUO_HINGE_WIDTH
+            val anchorCenterX = if (anchorRect.centerX() > displayWidth  && context.activity?.let { DuoSupportUtils.isDeviceSurfaceDuo(it) } ?: false ) anchorRect.centerX() - displayWidth - DuoSupportUtils.DUO_HINGE_WIDTH
                                      else anchorRect.centerX()
 
             val offset = if (isRTL)
@@ -277,7 +284,7 @@ class Tooltip {
         else{// Edge Case Left/Right arrow
             layoutParams.gravity = Gravity.TOP
             var topMargin = anchorRect.centerY() - positionY - tooltipArrowWidth
-            val secondScreen = anchorRect.top > displayHeight
+            val secondScreen = anchorRect.top > displayHeight  && context.activity?.let { DuoSupportUtils.isDeviceSurfaceDuo(it) } ?: false
             topMargin -= if (secondScreen) displayHeight else 0
             if(positionY + contentHeight >= displayHeight) topMargin -= cornerRadius
             layoutParams.topMargin = topMargin
@@ -295,12 +302,12 @@ class Tooltip {
         val startPosition = positionX + layoutParams.marginStart
         val topBarHeight = context.statusBarHeight + ( context.activity?.supportActionBar?.height ?: 0 )
         val doesNotFitAboveOrBelow = (positionY < topBarHeight) || (positionY + contentHeight > displayHeight)
-        val rightSpace = displayWidth - anchorRect.right - context.softNavBarOffsetX
-        val rightEdge = ( startPosition + upArrowWidth + cornerRadius + margin > displayWidth ) || (doesNotFitAboveOrBelow && anchorRect.left > rightSpace)
+        val rightSpace = displayWidth - anchorRect.right + context.softNavBarOffsetX
+        val rightEdge = ( startPosition + upArrowWidth + cornerRadius + margin - context.softNavBarOffsetX > displayWidth ) || (doesNotFitAboveOrBelow && anchorRect.left > rightSpace)
         val leftEdge = ( startPosition - cornerRadius - margin - context.softNavBarOffsetX < 0 ) || (doesNotFitAboveOrBelow && anchorRect.left < rightSpace)
 
         // Duo Support
-        val secondScreen = anchorRect.left > displayWidth
+        val secondScreen = anchorRect.left > displayWidth  && context.activity?.let { DuoSupportUtils.isDeviceSurfaceDuo(it) } ?: false
         if (leftEdge ) { // checks if the arrow is cut by the left edge of the screen and sets positionX to the left of the anchor with proper width.
             positionX = anchorRect.right
             if (secondScreen) positionX -= displayWidth + DuoSupportUtils.DUO_HINGE_WIDTH
@@ -373,7 +380,7 @@ class Tooltip {
                 // Otherwise sets positionY such that the content ends at the bottom of anchor
                 else anchorRect.bottom - contentHeight
 
-        val secondScreen = anchorRect.top > displayHeight
+        val secondScreen = anchorRect.top > displayHeight  && context.activity?.let { DuoSupportUtils.isDeviceSurfaceDuo(it) } ?: false
         positionY -= if (secondScreen) displayHeight else 0
 
         // Readjusts positionY if it crosses AppBar on the top

--- a/fluentui_transients/src/main/res/layout/view_tooltip_text.xml
+++ b/fluentui_transients/src/main/res/layout/view_tooltip_text.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) Microsoft Corporation. All rights reserved.
+  ~ Licensed under the MIT License.
+  -->
+
 <TextView android:id="@+id/tooltip_text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"


### PR DESCRIPTION
### Platforms Impacted
- [X] Android

### Description of changes

1. Changed anchor.getLocationOnScreen(screenPos) to anchor.getLocationInWindow(screenPos). Both of these return the same values in most conditions. This changes helps in solving shifts(due to status bar) when device is rotated 90 ACW. 
2. Removed hasSoftNavigationBar check on device 270 ACW rotation. We get a 0 navigationBar height if it is not present. Removed the comment that this check does not work on emulator.
3. Assuming views going off-screen as a second screen scenario is incorrect as views may be defined that cross device boundaries. Added an explicit check for second screen in these scenarios.
4. OnDismissListener was not being called on Dismiss by touching outside popup window, corrected.


### Verification

Changes verified manually on Pixel4 API 30 in 2 configurations: Navigation Bar On, Navigation Bar Off(Gesture Navigation mode)

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [X] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)