### PR TITLE
PersistentBottomSheet, when is magnified using Magnification accessibility tool, on touching of it beyond original boundary dismissing it

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
@@ -134,6 +134,14 @@ open class DrawerDialog @JvmOverloads constructor(context: Context, val behavior
         Handler().postDelayed(::expand, expandDelayMilliseconds)
     }
 
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        if(event?.action == KeyEvent.ACTION_UP  &&  event?.keyCode == KeyEvent.KEYCODE_ESCAPE){
+            dismissDialog()
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         var topMargin = 0

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -52,7 +52,6 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
     private var expandedStateDrawerHandleContentDescription : String? = null
 
     private var colorBackground = ContextCompat.getColor(context, android.R.color.transparent)
-    private var shouldInterceptTouch = false
     private var isDrawerHandleVisible = true
     private var sheetContainer: PersistentBottomSheetContentViewProvider.SheetContainerInfo? = null
     private var focusDrawerHandleInAccessibility = true

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -90,8 +90,12 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         override fun onSlide(bottomSheet: View, slideOffset: Float) {
             val colorOffset = (slideOffset * FADE_OUT_THRESHOLD).coerceIn(0f,255f)
             persistentSheetBinding.persistentBottomSheetOutlined.setBackgroundColor(ColorUtils.setAlphaComponent(colorBackground, colorOffset.toInt()))
+            persistentSheetBinding.persistentBottomSheetOutlined.setOnClickListener {
+                if (persistentSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+                    persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+                }
+            }
         }
-
     }
 
     override val templateId: Int
@@ -166,33 +170,12 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         persistentSheetBehavior.peekHeight = newY
     }
 
-    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
-        val viewRect = Rect()
-        persistentSheetBinding.persistentBottomSheet.getGlobalVisibleRect(viewRect)
-
-        if (persistentSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
-            if (!viewRect.contains(ev!!.rawX.toInt(), ev.rawY.toInt())) {
-                persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                shouldInterceptTouch = true
-                return true
-            }
-        }
-        shouldInterceptTouch = false
-        return super.onInterceptTouchEvent(ev)
-    }
-
     override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
         if (event?.keyCode == KeyEvent.KEYCODE_ESCAPE) {
             event.dispatch(this, null, null)
             return true
         }
         return super.dispatchKeyEvent(event)
-    }
-
-    override fun onTouchEvent(event: MotionEvent?): Boolean {
-        if (shouldInterceptTouch)
-            return true
-        return super.onTouchEvent(event)
     }
 
     internal fun getSheetBehavior(): BottomSheetBehavior<View> {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -6,19 +6,15 @@
 package com.microsoft.fluentui.persistentbottomsheet
 
 import android.content.Context
-import android.graphics.Rect
+import android.os.Build
 import android.transition.ChangeBounds
 import android.transition.TransitionManager
 import android.util.AttributeSet
 import android.view.KeyEvent
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityEvent
-import androidx.annotation.ColorRes
-import androidx.annotation.LayoutRes
-import androidx.annotation.RestrictTo
-import androidx.annotation.StyleRes
+import androidx.annotation.*
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -89,11 +85,6 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         override fun onSlide(bottomSheet: View, slideOffset: Float) {
             val colorOffset = (slideOffset * FADE_OUT_THRESHOLD).coerceIn(0f,255f)
             persistentSheetBinding.persistentBottomSheetOutlined.setBackgroundColor(ColorUtils.setAlphaComponent(colorBackground, colorOffset.toInt()))
-            persistentSheetBinding.persistentBottomSheetOutlined.setOnClickListener {
-                if (persistentSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
-                    persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                }
-            }
         }
     }
 
@@ -239,25 +230,39 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
 
     fun expand(focusDrawerHandle: Boolean = true) {
         persistentSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+        setClickListenerForDismissal()
         focusDrawerHandleInAccessibility = focusDrawerHandle
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
     }
 
-    fun hide(){
+    fun hide() {
         persistentSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
     }
 
     fun show(expanded: Boolean = false, focusDrawerHandle: Boolean = true) {
         if (expanded) {
             persistentSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+            setClickListenerForDismissal()
         } else {
             persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
         }
         focusDrawerHandleInAccessibility = focusDrawerHandle
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
+        }
+    }
+
+    private fun setClickListenerForDismissal() {
+        persistentSheetBinding.persistentBottomSheetOutlined.setOnClickListener {
+            if (persistentSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+                persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            }
+            persistentSheetBinding.persistentBottomSheetOutlined.isClickable = false
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                persistentSheetBinding.persistentBottomSheetOutlined.focusable = NOT_FOCUSABLE
+            }
         }
     }
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -225,6 +225,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
 
     fun collapse(focusDrawerHandle: Boolean = true) {
         persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+        makeOutlineNonClickable()
         focusDrawerHandleInAccessibility = focusDrawerHandle
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
@@ -250,6 +251,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             setClickListenerForDismissal()
         } else {
             persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            makeOutlineNonClickable()
         }
         focusDrawerHandleInAccessibility = focusDrawerHandle
         if(focusDrawerHandle) {
@@ -262,10 +264,14 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             if (persistentSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
                 persistentSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
             }
-            persistentSheetBinding.persistentBottomSheetOutlined.isClickable = false
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                persistentSheetBinding.persistentBottomSheetOutlined.focusable = NOT_FOCUSABLE
-            }
+            makeOutlineNonClickable()
+        }
+    }
+
+    private fun makeOutlineNonClickable() {
+        persistentSheetBinding.persistentBottomSheetOutlined.isClickable = false
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            persistentSheetBinding.persistentBottomSheetOutlined.focusable = NOT_FOCUSABLE
         }
     }
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -14,7 +14,10 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityEvent
-import androidx.annotation.*
+import androidx.annotation.ColorRes
+import androidx.annotation.LayoutRes
+import androidx.annotation.RestrictTo
+import androidx.annotation.StyleRes
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import com.google.android.material.bottomsheet.BottomSheetBehavior

--- a/fluentui_drawer/src/main/res/layout/dialog_side_drawer.xml
+++ b/fluentui_drawer/src/main/res/layout/dialog_side_drawer.xml
@@ -9,6 +9,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_container"
     android:layout_width="match_parent"
+    android:focusable="false"
     android:layout_height="match_parent">
 
     <com.microsoft.fluentui.drawer.DrawerView


### PR DESCRIPTION
PersistentBottomSheet, when is magnified using Magnification accessibility tool, on touching of it beyond original boundary dismissing it.

### Platforms Impacted
- [x] Android

### Description of changes

Instead of relying on the getGlobalVisibleRect which returns original/unmagnified coordinates, attached a click listener on the outline which takes care of dismissing the bottom sheet.

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

After fix, able to click on the menu items in persistent bottom sheet, able to dismiss it by clicking out the menu view.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances - N/A
- [x] VoiceOver and Keyboard Accessibility - No change
- [ ] Internationalization and Right to Left layouts - NA
- [x] Size classes and window sizes (notched devices, multitasking, different window sizes, etc) - NA