### PR TITLE
Drawer accessibility bug

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
@@ -134,6 +134,14 @@ open class DrawerDialog @JvmOverloads constructor(context: Context, val behavior
         Handler().postDelayed(::expand, expandDelayMilliseconds)
     }
 
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        if(event?.action == KeyEvent.ACTION_UP  &&  event?.keyCode == KeyEvent.KEYCODE_ESCAPE){
+            dismissDialog()
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         var topMargin = 0

--- a/fluentui_drawer/src/main/res/layout/dialog_side_drawer.xml
+++ b/fluentui_drawer/src/main/res/layout/dialog_side_drawer.xml
@@ -9,6 +9,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_container"
     android:layout_width="match_parent"
+    android:focusable="false"
     android:layout_height="match_parent">
 
     <com.microsoft.fluentui.drawer.DrawerView


### PR DESCRIPTION
Handle Accessibility bugs in Drawer
1) Drawer's container should not take keyboard keyboard. focus
2) Pressing escape key should close the drawer