### PR TITLE
Drawer

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_persistent_bottom_sheet.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_persistent_bottom_sheet.xml
@@ -74,8 +74,8 @@
         android:layout_height="match_parent"
         android:id="@+id/demo_persistent_sheet"
         android:layout_alignParentBottom="true"
-        app:peekHeight="@dimen/fluentui_persistent_bottom_sheet_peek_height"
-        app:isDrawerHandleVisible="true"/>
+        app:fluentui_peekHeight="@dimen/fluentui_persistent_bottom_sheet_peek_height"
+        app:fluentui_isDrawerHandleVisible="true"/>
 
     <com.microsoft.fluentui.persistentbottomsheet.PersistentBottomSheet
         android:layout_width="match_parent"
@@ -83,8 +83,8 @@
         android:id="@+id/default_persistent_sheet"
         android:layout_alignParentBottom="true"
         android:visibility="gone"
-        app:peekHeight="@dimen/fluentui_persistent_bottom_sheet_peek_height"
-        app:ItemsInRow="5"
-        app:isDrawerHandleVisible="true"/>
+        app:fluentui_peekHeight="@dimen/fluentui_persistent_bottom_sheet_peek_height"
+        app:fluentui_itemsInRow="5"
+        app:fluentui_isDrawerHandleVisible="true"/>
 
 </RelativeLayout>

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -67,4 +67,26 @@
     <attr name="fluentui_selectorWheelItemCount" format="integer" />
 
     <!--fluentui_calendar End-->
+
+    <!--fluentui_drawer Start-->
+    <!--Drawer-->
+    <attr name="fluentui_cornerRadius" format="dimension"/>
+
+    <!--PersistentBottomSheet-->
+    <!-- The min height of the BottomSheet -->
+    <attr name="fluentui_peekHeight" format="dimension" />
+    <!--  Determines whether to keep the default drawer handle or not -->
+    <attr name="fluentui_isDrawerHandleVisible" format="boolean" />
+    <!--  horizontal Item in a row-->
+    <attr name="fluentui_itemsInRow" format="integer" />
+    <!-- horizontal item text style-->
+    <attr name="fluentui_horizontalItemTextAppearance" format="reference" />
+    <!-- vertical item text style-->
+    <attr name="fluentui_verticalItemTextAppearance" format="reference" />
+    <!-- vertical item subtitle style-->
+    <attr name="fluentui_verticalItemSubTextAppearance" format="reference" />
+    <!--header text style-->
+    <attr name="fluentui_headerTextAppearance" format="reference" />
+
+    <!--fluentui_drawer End-->
 </resources>

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerView.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerView.kt
@@ -31,7 +31,7 @@ internal class DrawerView(context: Context, attrs: AttributeSet) : LinearLayoutC
         behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_behaviorType)
                 ?: "BOTTOM")
         val drawerTypedArray = context.obtainStyledAttributes(attrs, R.styleable.DrawerView)
-        cornerRadius = drawerTypedArray.getDimension(R.styleable.DrawerView_cornerRadius, resources.getDimension(R.dimen.fluentui_drawer_corner_radius))
+        cornerRadius = drawerTypedArray.getDimension(R.styleable.DrawerView_fluentui_cornerRadius, resources.getDimension(R.dimen.fluentui_drawer_corner_radius))
         drawerTypedArray.recycle()
         a.recycle()
     }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerView.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerView.kt
@@ -28,7 +28,7 @@ internal class DrawerView(context: Context, attrs: AttributeSet) : LinearLayoutC
 
     init {
         val a: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.SheetBehaviorLayout)
-        behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_behaviorType)
+        behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_fluentui_behaviorType)
                 ?: "BOTTOM")
         val drawerTypedArray = context.obtainStyledAttributes(attrs, R.styleable.DrawerView)
         cornerRadius = drawerTypedArray.getDimension(R.styleable.DrawerView_fluentui_cornerRadius, resources.getDimension(R.dimen.fluentui_drawer_corner_radius))

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/SideSheetBehavior.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/SideSheetBehavior.kt
@@ -83,13 +83,13 @@ class SideSheetBehavior<V: View> : CoordinatorLayout.Behavior<V> {
     constructor(context: Context, attrs: AttributeSet? = null): super(context, attrs) {
         val a:TypedArray = context.obtainStyledAttributes(attrs, R.styleable.SheetBehaviorLayout)
         setFitToContents(a.getBoolean(
-                R.styleable.SheetBehaviorLayout_behaviorFitToContents, true))
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorFitToContents, true))
         hideable = a.getBoolean(
-                R.styleable.SheetBehaviorLayout_behaviorHideable, false)
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorHideable, false)
         skipCollapsed = a.getBoolean(
-                R.styleable.SheetBehaviorLayout_behaviorSkipCollapsed, false)
-        peekWidth = a.getDimensionPixelSize(R.styleable.SheetBehaviorLayout_behaviorPeekWidth, 0)
-        behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_behaviorType) ?: "RIGHT")
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorSkipCollapsed, false)
+        peekWidth = a.getDimensionPixelSize(R.styleable.SheetBehaviorLayout_fluentui_behaviorPeekWidth, 0)
+        behaviorType = BehaviorType.valueOf(a.getString(R.styleable.SheetBehaviorLayout_fluentui_behaviorType) ?: "RIGHT")
         a.recycle()
 
         val configuration: ViewConfiguration = ViewConfiguration.get(context)

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/TopSheetBehavior.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/TopSheetBehavior.kt
@@ -82,13 +82,13 @@ class TopSheetBehavior<V : View> : CoordinatorLayout.Behavior<V> {
                 R.styleable.SheetBehaviorLayout)
 
         setPeekHeight(a.getDimensionPixelSize(
-                R.styleable.SheetBehaviorLayout_behaviorPeekHeight, -1))
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorPeekHeight, -1))
         setFitToContents(a.getBoolean(
-                R.styleable.SheetBehaviorLayout_behaviorFitToContents, true))
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorFitToContents, true))
         hideable = a.getBoolean(
-                R.styleable.SheetBehaviorLayout_behaviorHideable, false)
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorHideable, false)
         skipCollapsed = a.getBoolean(
-                R.styleable.SheetBehaviorLayout_behaviorSkipCollapsed, false)
+                R.styleable.SheetBehaviorLayout_fluentui_behaviorSkipCollapsed, false)
         a.recycle()
 
         val configuration: ViewConfiguration = ViewConfiguration.get(context)

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -58,15 +58,15 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
 
     init {
         val attributes = context.obtainStyledAttributes(attrs, R.styleable.PersistentBottomSheet)
-        isDrawerHandleVisible = attributes.getBoolean(R.styleable.PersistentBottomSheet_isDrawerHandleVisible, true)
-        val defaultPeekHeight = attributes.getDimensionPixelSize(R.styleable.PersistentBottomSheet_peekHeight, 0)
-        val itemsInRow = attributes.getInteger(R.styleable.PersistentBottomSheet_ItemsInRow, R.integer.fluentui_persistent_bottomsheet_max_item_row)
-        val horizontalItemTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_horizontalItemTextAppearance,
+        isDrawerHandleVisible = attributes.getBoolean(R.styleable.PersistentBottomSheet_fluentui_isDrawerHandleVisible, true)
+        val defaultPeekHeight = attributes.getDimensionPixelSize(R.styleable.PersistentBottomSheet_fluentui_peekHeight, 0)
+        val itemsInRow = attributes.getInteger(R.styleable.PersistentBottomSheet_fluentui_itemsInRow, R.integer.fluentui_persistent_bottomsheet_max_item_row)
+        val horizontalItemTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_fluentui_horizontalItemTextAppearance,
                 R.style.TextAppearance_FluentUI_PersistentBottomSheetHorizontalItem)
-        val verticalItemTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_verticalItemTextAppearance,
+        val verticalItemTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_fluentui_verticalItemTextAppearance,
                 R.style.TextAppearance_FluentUI_PersistentBottomSheet_Item)
-        val verticalSubTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_verticalItemSubTextAppearance, 0)
-        val headerTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_headerTextAppearance,
+        val verticalSubTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_fluentui_verticalItemSubTextAppearance, 0)
+        val headerTextStyle = attributes.getResourceId(R.styleable.PersistentBottomSheet_fluentui_headerTextAppearance,
                 R.style.TextAppearance_FluentUI_PersistentBottomSheetHeading)
 
         itemLayoutParam = BottomSheetParam.ItemLayoutParam(defaultPeekHeight, itemsInRow,

--- a/fluentui_drawer/src/main/res/layout/dialog_drawer.xml
+++ b/fluentui_drawer/src/main/res/layout/dialog_drawer.xml
@@ -22,7 +22,7 @@
         app:layout_behavior="@string/bottom_sheet_behavior"
         app:behavior_hideable="true"
         app:behavior_peekHeight="@dimen/fluentui_drawer_peek_height"
-        app:behaviorType="BOTTOM">
+        app:fluentui_behaviorType="BOTTOM">
 
         <ImageView
             android:layout_width="wrap_content"

--- a/fluentui_drawer/src/main/res/layout/dialog_side_drawer.xml
+++ b/fluentui_drawer/src/main/res/layout/dialog_side_drawer.xml
@@ -20,9 +20,9 @@
         android:elevation="@dimen/fluentui_drawer_elevation"
         android:background="?attr/fluentuiDrawerBackgroundColor"
         android:clipToPadding="true"
-        app:behaviorHideable="true"
-        app:behaviorPeekWidth="@dimen/fluentui_drawer_peek_width"
-        app:behaviorType="RIGHT"
+        app:fluentui_behaviorHideable="true"
+        app:fluentui_behaviorPeekWidth="@dimen/fluentui_drawer_peek_width"
+        app:fluentui_behaviorType="RIGHT"
         app:layout_behavior="@string/side_sheet_behavior">
 
         <LinearLayout

--- a/fluentui_drawer/src/main/res/layout/dialog_top_drawer.xml
+++ b/fluentui_drawer/src/main/res/layout/dialog_top_drawer.xml
@@ -19,9 +19,9 @@
         android:elevation="@dimen/fluentui_drawer_elevation"
         android:orientation="vertical"
         app:layout_behavior="@string/top_sheet_behavior"
-        app:behaviorHideable="false"
-        app:behaviorPeekHeight="@dimen/fluentui_drawer_peek_height"
-        app:behaviorType="TOP">
+        app:fluentui_behaviorHideable="false"
+        app:fluentui_behaviorPeekHeight="@dimen/fluentui_drawer_peek_height"
+        app:fluentui_behaviorType="TOP">
 
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/fluentui_drawer/src/main/res/layout/view_persistent_sheet.xml
+++ b/fluentui_drawer/src/main/res/layout/view_persistent_sheet.xml
@@ -20,7 +20,7 @@
         android:clipToPadding="true"
         android:elevation="@dimen/fluentui_persistentbottomsheet_elevation"
         android:orientation="vertical"
-        app:behaviorType="BOTTOM"
+        app:fluentui_behaviorType="BOTTOM"
         app:cornerRadius="@dimen/fluentui_persistentbottomsheet_corner_radius"
         app:layout_behavior="@string/bottom_sheet_behavior">
 

--- a/fluentui_drawer/src/main/res/values/attrs.xml
+++ b/fluentui_drawer/src/main/res/values/attrs.xml
@@ -24,11 +24,11 @@
 
     <!-- SheetBehavior-->
     <declare-styleable name="SheetBehaviorLayout">
-        <attr format="string" name="behaviorType"/>
-        <attr format="dimension" name="behaviorPeekHeight"/>
-        <attr format="dimension" name="behaviorPeekWidth" />
-        <attr format="boolean" name="behaviorHideable"/>
-        <attr format="boolean" name="behaviorSkipCollapsed"/>
-        <attr format="boolean" name="behaviorFitToContents"/>
+        <attr format="string" name="fluentui_behaviorType"/>
+        <attr format="dimension" name="fluentui_behaviorPeekHeight"/>
+        <attr format="dimension" name="fluentui_behaviorPeekWidth" />
+        <attr format="boolean" name="fluentui_behaviorHideable"/>
+        <attr format="boolean" name="fluentui_behaviorSkipCollapsed"/>
+        <attr format="boolean" name="fluentui_behaviorFitToContents"/>
     </declare-styleable>
 </resources>

--- a/fluentui_drawer/src/main/res/values/attrs_drawerview.xml
+++ b/fluentui_drawer/src/main/res/values/attrs_drawerview.xml
@@ -5,6 +5,6 @@
   -->
 <resources>
     <declare-styleable name="DrawerView">
-        <attr name="cornerRadius" format="dimension"/>
+        <attr name="fluentui_cornerRadius"/>
     </declare-styleable>
 </resources>

--- a/fluentui_drawer/src/main/res/values/attrs_persistent_bottomsheet.xml
+++ b/fluentui_drawer/src/main/res/values/attrs_persistent_bottomsheet.xml
@@ -6,18 +6,18 @@
 <resources>
     <declare-styleable name="PersistentBottomSheet">
         <!-- The min height of the BottomSheet -->
-        <attr name="peekHeight" format="dimension" />
+        <attr name="fluentui_peekHeight"/>
         <!--  Determines whether to keep the default drawer handle or not -->
-        <attr name="isDrawerHandleVisible" format="boolean" />
+        <attr name="fluentui_isDrawerHandleVisible"/>
         <!--  horizontal Item in a row-->
-        <attr name="ItemsInRow" format="integer" />
+        <attr name="fluentui_itemsInRow"/>
         <!-- horizontal item text style-->
-        <attr name="horizontalItemTextAppearance" format="reference" />
+        <attr name="fluentui_horizontalItemTextAppearance"/>
         <!-- vertical item text style-->
-        <attr name="verticalItemTextAppearance" format="reference" />
+        <attr name="fluentui_verticalItemTextAppearance"/>
         <!-- vertical item subtitle style-->
-        <attr name="verticalItemSubTextAppearance" format="reference" />
+        <attr name="fluentui_verticalItemSubTextAppearance"/>
         <!--header text style-->
-        <attr name="headerTextAppearance" format="reference" />
+        <attr name="fluentui_headerTextAppearance"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
3 fluentui_drawer : Moved the declare-styleable attributes to fluentui_core attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes