### PR TITLE
Listitem

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/views/Cell.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/views/Cell.kt
@@ -50,7 +50,7 @@ class Cell : TemplateView {
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
         if (attrs != null) {
             val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.Cell)
-            title = styledAttrs.getString(R.styleable.Cell_title)
+            title = styledAttrs.getString(R.styleable.Cell_fluentui_title)
             description = styledAttrs.getString(R.styleable.Cell_description)
             val orientationOrdinal = styledAttrs.getInt(R.styleable.Cell_orientation, DEFAULT_ORIENTATION.ordinal)
             orientation = CellOrientation.values()[orientationOrdinal]

--- a/FluentUI.Demo/src/main/res/layout/activity_persona_view.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_persona_view.xml
@@ -25,7 +25,7 @@
         android:layout_height="wrap_content"
         app:avatarSize="xxlarge"
         app:email="@string/persona_email_kat_larsson"
-        app:footer="@string/persona_footer"
+        app:fluentui_footer="@string/persona_footer"
         app:name="@string/persona_name_kat_larsson"
         app:subtitle="@string/persona_email_kat_larsson" />
 

--- a/FluentUI.Demo/src/main/res/values/attrs_cell.xml
+++ b/FluentUI.Demo/src/main/res/values/attrs_cell.xml
@@ -6,7 +6,7 @@
 
 <resources>
     <declare-styleable name="Cell">
-        <attr name="title" format="string"/>
+        <attr name="fluentui_title"/>
         <attr name="description" format="string"/>
         <attr name="orientation" format="enum">
             <enum name="horizontal" value="0"/>

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -89,4 +89,15 @@
     <attr name="fluentui_headerTextAppearance" format="reference" />
 
     <!--fluentui_drawer End-->
+
+    <!--fluentui_listitem Start-->
+
+    <!--ListItemView-->
+    <attr name="fluentui_title" format="string" />
+    <attr name="fluentui_subtitle" format="string" />
+    <attr name="fluentui_footer" format="string" />
+    <attr name="fluentui_titleMaxLines" format="integer" />
+    <attr name="fluentui_subtitleMaxLines" format="integer" />
+    <attr name="fluentui_footerMaxLines" format="integer" />
+    <!--fluentui_listitem End-->
 </resources>

--- a/fluentui_drawer/src/main/res/layout/view_bottom_sheet_item.xml
+++ b/fluentui_drawer/src/main/res/layout/view_bottom_sheet_item.xml
@@ -7,7 +7,7 @@
 <com.microsoft.fluentui.listitem.ListItemView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    app:customViewSize="small"
-    app:layoutDensity="dense"
+    app:fluentui_customViewSize="small"
+    app:fluentui_layoutDensity="dense"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/listitem/ListItemView.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/listitem/ListItemView.kt
@@ -15,7 +15,6 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
-import com.microsoft.fluentui.listitem.R
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import com.microsoft.fluentui.util.setContentAndUpdateVisibility
 import com.microsoft.fluentui.view.TemplateView
@@ -289,25 +288,25 @@ open class ListItemView : TemplateView {
         // TODO: Add need examples in the demo that tests these attributes. Can inflate a layout in the adapter.
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.ListItemView)
 
-        title = styledAttrs.getString(R.styleable.ListItemView_title) ?: ""
-        subtitle = styledAttrs.getString(R.styleable.ListItemView_subtitle) ?: ""
-        footer = styledAttrs.getString(R.styleable.ListItemView_footer) ?: ""
+        title = styledAttrs.getString(R.styleable.ListItemView_fluentui_title) ?: ""
+        subtitle = styledAttrs.getString(R.styleable.ListItemView_fluentui_subtitle) ?: ""
+        footer = styledAttrs.getString(R.styleable.ListItemView_fluentui_footer) ?: ""
 
-        titleMaxLines = styledAttrs.getInt(R.styleable.ListItemView_titleMaxLines, DEFAULT_MAX_LINES)
-        subtitleMaxLines = styledAttrs.getInt(R.styleable.ListItemView_subtitleMaxLines, DEFAULT_MAX_LINES)
-        footerMaxLines = styledAttrs.getInt(R.styleable.ListItemView_footerMaxLines, DEFAULT_MAX_LINES)
+        titleMaxLines = styledAttrs.getInt(R.styleable.ListItemView_fluentui_titleMaxLines, DEFAULT_MAX_LINES)
+        subtitleMaxLines = styledAttrs.getInt(R.styleable.ListItemView_fluentui_subtitleMaxLines, DEFAULT_MAX_LINES)
+        footerMaxLines = styledAttrs.getInt(R.styleable.ListItemView_fluentui_footerMaxLines, DEFAULT_MAX_LINES)
 
-        val titleTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListItemView_titleTruncateAt, DEFAULT_TRUNCATION.ordinal)
+        val titleTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListItemView_fluentui_titleTruncateAt, DEFAULT_TRUNCATION.ordinal)
         titleTruncateAt = TextUtils.TruncateAt.values()[titleTruncateAtOrdinal]
-        val subtitleTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListItemView_subtitleTruncateAt, DEFAULT_TRUNCATION.ordinal)
+        val subtitleTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListItemView_fluentui_subtitleTruncateAt, DEFAULT_TRUNCATION.ordinal)
         subtitleTruncateAt = TextUtils.TruncateAt.values()[subtitleTruncateAtOrdinal]
-        val footerTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListItemView_footerTruncateAt, DEFAULT_TRUNCATION.ordinal)
+        val footerTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListItemView_fluentui_footerTruncateAt, DEFAULT_TRUNCATION.ordinal)
         footerTruncateAt = TextUtils.TruncateAt.values()[footerTruncateAtOrdinal]
 
-        val layoutDensityOrdinal = styledAttrs.getInt(R.styleable.ListItemView_layoutDensity, DEFAULT_LAYOUT_DENSITY.ordinal)
+        val layoutDensityOrdinal = styledAttrs.getInt(R.styleable.ListItemView_fluentui_layoutDensity, DEFAULT_LAYOUT_DENSITY.ordinal)
         layoutDensity = LayoutDensity.values()[layoutDensityOrdinal]
 
-        val customViewSizeOrdinal = styledAttrs.getInt(R.styleable.ListItemView_customViewSize, DEFAULT_CUSTOM_VIEW_SIZE.ordinal)
+        val customViewSizeOrdinal = styledAttrs.getInt(R.styleable.ListItemView_fluentui_customViewSize, DEFAULT_CUSTOM_VIEW_SIZE.ordinal)
         customViewSize = CustomViewSize.values()[customViewSizeOrdinal]
 
         styledAttrs.recycle()

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/listitem/ListSubHeaderView.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/listitem/ListSubHeaderView.kt
@@ -14,7 +14,6 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
-import com.microsoft.fluentui.listitem.R
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 import com.microsoft.fluentui.util.ThemeUtil
 import com.microsoft.fluentui.util.setContentAndUpdateVisibility
@@ -103,12 +102,12 @@ class ListSubHeaderView : TemplateView {
         // TODO: Add need examples in the demo that tests these attributes. Can inflate a layout in the adapter.
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.ListSubHeaderView)
 
-        title = styledAttrs.getString(R.styleable.ListSubHeaderView_title) ?: ""
+        title = styledAttrs.getString(R.styleable.ListSubHeaderView_fluentui_title) ?: ""
 
-        val titleColorOrdinal = styledAttrs.getInt(R.styleable.ListSubHeaderView_titleColor, DEFAULT_TITLE_COLOR.ordinal)
+        val titleColorOrdinal = styledAttrs.getInt(R.styleable.ListSubHeaderView_fluentui_titleColor, DEFAULT_TITLE_COLOR.ordinal)
         titleColor = TitleColor.values()[titleColorOrdinal]
 
-        val titleTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListSubHeaderView_titleTruncateAt, DEFAULT_TRUNCATION.ordinal)
+        val titleTruncateAtOrdinal = styledAttrs.getInt(R.styleable.ListSubHeaderView_fluentui_titleTruncateAt, DEFAULT_TRUNCATION.ordinal)
         titleTruncateAt = TextUtils.TruncateAt.values()[titleTruncateAtOrdinal]
 
         styledAttrs.recycle()

--- a/fluentui_listitem/src/main/res/values/attrs.xml
+++ b/fluentui_listitem/src/main/res/values/attrs.xml
@@ -16,4 +16,11 @@
     <attr name="fluentuiListSubHeaderTitlePrimaryColor" format="reference|color"/>
     <attr name="fluentuiListSubHeaderTitleSecondaryColor" format="reference|color"/>
     <attr name="fluentuiListSubHeaderTitleTertiaryColor" format="reference|color"/>
+    <!--Module attributes-->
+
+    <attr name="fluentui_titleColor" format="enum">
+        <enum name="primary" value="0" />
+        <enum name="secondary" value="1" />
+        <enum name="tertiary" value="2" />
+    </attr>
 </resources>

--- a/fluentui_listitem/src/main/res/values/attrs_list_item.xml
+++ b/fluentui_listitem/src/main/res/values/attrs_list_item.xml
@@ -6,35 +6,35 @@
 
 <resources>
     <declare-styleable name="ListItemView">
-        <attr name="title" format="string" />
-        <attr name="subtitle" format="string" />
-        <attr name="footer" format="string" />
-        <attr name="titleMaxLines" format="integer" />
-        <attr name="subtitleMaxLines" format="integer" />
-        <attr name="footerMaxLines" format="integer" />
-        <attr name="titleTruncateAt" format="enum">
+        <attr name="fluentui_title"/>
+        <attr name="fluentui_subtitle"/>
+        <attr name="fluentui_footer"/>
+        <attr name="fluentui_titleMaxLines"/>
+        <attr name="fluentui_subtitleMaxLines"/>
+        <attr name="fluentui_footerMaxLines"/>
+        <attr name="fluentui_titleTruncateAt" format="enum">
             <enum name="start" value="0" />
             <enum name="middle" value="1" />
             <enum name="end" value="2" />
             <enum name="marquee" value="3" />
         </attr>
-        <attr name="subtitleTruncateAt" format="enum">
+        <attr name="fluentui_subtitleTruncateAt" format="enum">
             <enum name="start" value="0" />
             <enum name="middle" value="1" />
             <enum name="end" value="2" />
             <enum name="marquee" value="3" />
         </attr>
-        <attr name="footerTruncateAt" format="enum">
+        <attr name="fluentui_footerTruncateAt" format="enum">
             <enum name="start" value="0" />
             <enum name="middle" value="1" />
             <enum name="end" value="2" />
             <enum name="marquee" value="3" />
         </attr>
-        <attr name="layoutDensity" format="enum">
+        <attr name="fluentui_layoutDensity" format="enum">
             <enum name="regular" value="0" />
             <enum name="dense" value="1" />
         </attr>
-        <attr name="customViewSize" format="enum">
+        <attr name="fluentui_customViewSize" format="enum">
             <enum name="small" value="0" />
             <enum name="medium" value="1" />
             <enum name="large" value="2" />

--- a/fluentui_listitem/src/main/res/values/attrs_list_sub_header.xml
+++ b/fluentui_listitem/src/main/res/values/attrs_list_sub_header.xml
@@ -6,12 +6,8 @@
 
 <resources>
     <declare-styleable name="ListSubHeaderView">
-        <attr name="title" />
-        <attr name="titleColor" format="enum">
-            <enum name="primary" value="0" />
-            <enum name="secondary" value="1" />
-            <enum name="tertiary" value="2" />
-        </attr>
-        <attr name="titleTruncateAt" />
+        <attr name="fluentui_title" />
+        <attr name="fluentui_titleColor"/>
+        <attr name="fluentui_titleTruncateAt" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
4 fluentui_listitem : Moved the declare-styleable attributes to fluentui_core attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes