### PR TITLE
Others

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/demo_action_bar_activity.xml
+++ b/FluentUI.Demo/src/main/res/layout/demo_action_bar_activity.xml
@@ -17,6 +17,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:type="basic" />
+        app:fluentui_type="basic" />
 
 </FrameLayout>

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -100,4 +100,10 @@
     <attr name="fluentui_subtitleMaxLines" format="integer" />
     <attr name="fluentui_footerMaxLines" format="integer" />
     <!--fluentui_listitem End-->
+
+    <!--fluent_others Start-->
+
+    <!--ActionBarLayout-->
+    <attr name="fluentui_viewPager" format="reference"/>
+    <!--fluent_others End-->
 </resources>

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/actionbar/ActionBarLayout.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/actionbar/ActionBarLayout.kt
@@ -45,8 +45,8 @@ class ActionBarLayout @JvmOverloads constructor(appContext: Context, attrs: Attr
 
     init {
         val styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.ActionBarLayout)
-        viewPagerAttr = styledAttributes.getResourceId(R.styleable.ActionBarLayout_viewPager, View.NO_ID)
-        typeAttr = Type.values()[styledAttributes.getInt(R.styleable.ActionBarLayout_type, DEFAULT_TYPE.ordinal)]
+        viewPagerAttr = styledAttributes.getResourceId(R.styleable.ActionBarLayout_fluentui_viewPager, View.NO_ID)
+        typeAttr = Type.values()[styledAttributes.getInt(R.styleable.ActionBarLayout_fluentui_type, DEFAULT_TYPE.ordinal)]
         styledAttributes.recycle()
         finalPageString = context.getString(R.string.action_bar_default_final_action)
     }

--- a/fluentui_others/src/main/res/values/attrs.xml
+++ b/fluentui_others/src/main/res/values/attrs.xml
@@ -40,4 +40,12 @@
     <attr name="fluentuiCompoundButtonTintDefaultColor" format="reference|color"/>
     <attr name="fluentuiCompoundButtonTintCheckedColor" format="reference|color"/>
 
+    <!--common fluentui_others Module attributes-->
+    <!--ActionBarLayout-->
+    <attr name="fluentui_type" format="enum">
+        <enum name="basic" value="0"/>
+        <enum name="icon" value="1"/>
+        <enum name="carousel" value="2"/>
+    </attr>
+
 </resources>

--- a/fluentui_others/src/main/res/values/attrs_action_bar_layout.xml
+++ b/fluentui_others/src/main/res/values/attrs_action_bar_layout.xml
@@ -6,11 +6,7 @@
 
 <resources>
     <declare-styleable name="ActionBarLayout">
-        <attr name="type" format="enum">
-            <enum name="basic" value="0"/>
-            <enum name="icon" value="1"/>
-            <enum name="carousel" value="2"/>
-        </attr>
-        <attr name="viewPager" format="reference"/>
+        <attr name="fluentui_type"/>
+        <attr name="fluentui_viewPager"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
5 fluentui_others : Moved the declare-styleable attributes to fluentui_core attrs.xml & enum attributes to fluentui_others attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes