### PR TITLE
Peoplepicker

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_people_picker_view.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_people_picker_view.xml
@@ -17,15 +17,15 @@
         android:id="@+id/people_picker_select"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:label="@string/people_picker_select_example"
-        app:personaChipClickStyle="select" />
+        app:fluentui_label="@string/people_picker_select_example"
+        app:fluentui_personaChipClickStyle="select" />
 
     <com.microsoft.fluentui.peoplepicker.PeoplePickerView
         android:id="@+id/people_picker_select_deselect"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:label="@string/people_picker_select_deselect_example"
-        app:characterThreshold="3"
-        app:personaChipClickStyle="select_deselect" />
+        app:fluentui_label="@string/people_picker_select_deselect_example"
+        app:fluentui_characterThreshold="3"
+        app:fluentui_personaChipClickStyle="select_deselect" />
 
 </LinearLayout>

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -106,4 +106,14 @@
     <!--ActionBarLayout-->
     <attr name="fluentui_viewPager" format="reference"/>
     <!--fluent_others End-->
+
+    <!-- fluentui_peoplepicker Start-->
+
+    <!--PeoplePickerView-->
+    <attr name="fluentui_label" format="string" />
+    <attr name="fluentui_valueHint" format="string" />
+    <attr name="fluentui_showHint" format="boolean" />
+    <attr name="fluentui_characterThreshold" format="integer" />
+
+    <!-- fluentui_peoplepicker End-->
 </resources>

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
@@ -227,14 +227,14 @@ class PeoplePickerView : TemplateView {
     constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(appContext,R.style.Theme_FluentUI_PeoplePicker), attrs, defStyleAttr) {
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.PeoplePickerView)
 
-        label = styledAttrs.getString(R.styleable.PeoplePickerView_label) ?: ""
-        valueHint = styledAttrs.getString(R.styleable.PeoplePickerView_valueHint)
+        label = styledAttrs.getString(R.styleable.PeoplePickerView_fluentui_label) ?: ""
+        valueHint = styledAttrs.getString(R.styleable.PeoplePickerView_fluentui_valueHint)
             ?: context.getString(R.string.people_picker_accessibility_default_hint)
-        showHint = styledAttrs.getBoolean(R.styleable.PeoplePickerView_showHint, false)
-        characterThreshold = styledAttrs.getInteger(R.styleable.PeoplePickerView_characterThreshold, 1)
+        showHint = styledAttrs.getBoolean(R.styleable.PeoplePickerView_fluentui_showHint, false)
+        characterThreshold = styledAttrs.getInteger(R.styleable.PeoplePickerView_fluentui_characterThreshold, 1)
 
         val personaChipClickStyleOrdinal = styledAttrs.getInt(
-            R.styleable.PeoplePickerView_personaChipClickStyle,
+            R.styleable.PeoplePickerView_fluentui_personaChipClickStyle,
             PeoplePickerPersonaChipClickStyle.SELECT.ordinal
         )
         personaChipClickStyle = PeoplePickerPersonaChipClickStyle.values()[personaChipClickStyleOrdinal]

--- a/fluentui_peoplepicker/src/main/res/values/attrs.xml
+++ b/fluentui_peoplepicker/src/main/res/values/attrs.xml
@@ -20,4 +20,13 @@
     <attr name="fluentuiPeoplePickerSearchTextDisabledColor" format="reference|color"/>
     <attr name="fluentuiPeoplePickerSearchTextPressedColor" format="reference|color"/>
 
+    <!--common fluentui_peoplepicker Module attributes-->
+    <attr name="fluentui_personaChipClickStyle" format="enum">
+        <enum name="none" value="0"/>
+        <enum name="delete" value="1"/>
+        <enum name="select" value="2"/>
+        <enum name="select_deselect" value="3"/>
+    </attr>
+
+
 </resources>

--- a/fluentui_peoplepicker/src/main/res/values/attrs_people_picker.xml
+++ b/fluentui_peoplepicker/src/main/res/values/attrs_people_picker.xml
@@ -6,15 +6,10 @@
 
 <resources>
     <declare-styleable name="PeoplePickerView">
-        <attr name="label" format="string" />
-        <attr name="valueHint" format="string" />
-        <attr name="showHint" format="boolean" />
-        <attr name="characterThreshold" format="integer" />
-        <attr name="personaChipClickStyle" format="enum">
-            <enum name="none" value="0"/>
-            <enum name="delete" value="1"/>
-            <enum name="select" value="2"/>
-            <enum name="select_deselect" value="3"/>
-        </attr>
+        <attr name="fluentui_label"/>
+        <attr name="fluentui_valueHint"/>
+        <attr name="fluentui_showHint"/>
+        <attr name="fluentui_characterThreshold"/>
+        <attr name="fluentui_personaChipClickStyle"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
6 fluentui_peoplepicker : Moved the declare-styleable attributes to fluentui_core attrs.xml & enum attributes to fluentui_peoplepicker attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes