### PR TITLE
Tablayout

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_tab_layout.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_tab_layout.xml
@@ -15,7 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:tabType="Standard"/>
+        app:fluentui_tabType="Standard"/>
 
     <androidx.viewpager.widget.ViewPager
         android:id="@+id/view_pager"

--- a/FluentUI.Demo/src/main/res/values/styles.xml
+++ b/FluentUI.Demo/src/main/res/values/styles.xml
@@ -188,12 +188,12 @@
     <!-- TabLayout Demo, for this style to be used you should declare attrs used or directly use
          color values -->
     <style name="FluentUIDemo.TabLayout" parent="">
-        <item name="containerBackgroundColor">?attr/fluentuiBackgroundPrimaryColor</item>
-        <item name="tabsBackgroundColor">@color/fluentui_communication_shade_10</item>
-        <item name="tabSelectedBackgroundColor">?attr/fluentuiBackgroundColor</item>
-        <item name="tabUnselectedBackgroundColor">@color/fluentui_communication_shade_10</item>
-        <item name="tabSelectedTextColor">?attr/fluentuiBackgroundPrimaryColor</item>
-        <item name="tabUnselectedTextColor">?attr/fluentuiBackgroundColor</item>
+        <item name="fluentui_containerBackgroundColor">?attr/fluentuiBackgroundPrimaryColor</item>
+        <item name="fluentui_tabsBackgroundColor">@color/fluentui_communication_shade_10</item>
+        <item name="fluentui_tabSelectedBackgroundColor">?attr/fluentuiBackgroundColor</item>
+        <item name="fluentui_tabUnselectedBackgroundColor">@color/fluentui_communication_shade_10</item>
+        <item name="fluentui_tabSelectedTextColor">?attr/fluentuiBackgroundPrimaryColor</item>
+        <item name="fluentui_tabUnselectedTextColor">?attr/fluentuiBackgroundColor</item>
     </style>
     <!-- ListItem Demo -->
     <style name="FluentUIDemo.ListItemSubHeaderTitle" parent="">

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -134,4 +134,16 @@
     <attr name="fluentui_showCloseIconWhenSelected" format="boolean" />
 
     <!--fluentui_persona End-->
+
+    <!--fluentui_tablayout Start-->
+
+    <!--TabLayout-->
+    <attr name="fluentui_containerBackgroundColor" format="color" />
+    <attr name="fluentui_tabsBackgroundColor" format="color" />
+    <attr name="fluentui_tabSelectedBackgroundColor" format="color" />
+    <attr name="fluentui_tabUnselectedBackgroundColor" format="color" />
+    <attr name="fluentui_tabSelectedTextColor" format="color" />
+    <attr name="fluentui_tabUnselectedTextColor" format="color" />
+
+    <!--fluentui_tablayout End-->
 </resources>

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tablayout/TabLayout.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tablayout/TabLayout.kt
@@ -53,7 +53,7 @@ class TabLayout : TemplateView {
     @JvmOverloads
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_TabLayout), attrs, defStyleAttr) {
         val styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.TabLayout)
-        val tabTypeOrdinal = styledAttributes.getInt(R.styleable.TabLayout_tabType, TabType.STANDARD.ordinal)
+        val tabTypeOrdinal = styledAttributes.getInt(R.styleable.TabLayout_fluentui_tabType, TabType.STANDARD.ordinal)
         /**
          * Use this.context while accessing themed attributes within a constructor
          * As here, the object is still not initialized, just [context] will refer
@@ -62,22 +62,22 @@ class TabLayout : TemplateView {
          * in that theme
          **/
         containerBackgroundColor = styledAttributes.getColor(
-            R.styleable.TabLayout_containerBackgroundColor,
+            R.styleable.TabLayout_fluentui_containerBackgroundColor,
             ThemeUtil.getColor(this.context, R.attr.fluentuiTabLayoutContainerBackgroundColor))
         tabsBackgroundColor = styledAttributes.getColor(
-            R.styleable.TabLayout_tabsBackgroundColor,
+            R.styleable.TabLayout_fluentui_tabsBackgroundColor,
             ThemeUtil.getColor(this.context, R.attr.fluentuiTabLayoutBackgroundColor))
         selectedTabBackgroundColor = styledAttributes.getColor(
-            R.styleable.TabLayout_tabSelectedBackgroundColor,
+            R.styleable.TabLayout_fluentui_tabSelectedBackgroundColor,
             ThemeUtil.getColor(this.context, R.attr.fluentuiTabSelectedBackgroundColor))
         unselectedTabBackgroundColor = styledAttributes.getColor(
-            R.styleable.TabLayout_tabUnselectedBackgroundColor,
+            R.styleable.TabLayout_fluentui_tabUnselectedBackgroundColor,
             ThemeUtil.getColor(this.context, R.attr.fluentuiTabUnselectedBackgroundColor))
         tabSelectedTextColor = styledAttributes.getColor(
-            R.styleable.TabLayout_tabSelectedTextColor,
+            R.styleable.TabLayout_fluentui_tabSelectedTextColor,
             ThemeUtil.getColor(this.context, R.attr.fluentuiTabSelectedTextColor))
         tabUnselectedTextColor = styledAttributes.getColor(
-            R.styleable.TabLayout_tabUnselectedTextColor,
+            R.styleable.TabLayout_fluentui_tabUnselectedTextColor,
             ThemeUtil.getColor(this.context, R.attr.fluentuiTabUnselectedTextColor))
         tabType = TabType.values()[tabTypeOrdinal]
         styledAttributes.recycle()

--- a/fluentui_tablayout/src/main/res/values/attrs.xml
+++ b/fluentui_tablayout/src/main/res/values/attrs.xml
@@ -12,4 +12,11 @@
     <attr name="fluentuiTabUnselectedBackgroundColor" format="reference|color"/>
     <attr name="fluentuiTabSelectedBackgroundColor" format="reference|color"/>
     <attr name="fluentuiTabTextAppearance" format="reference" />
+
+    <!--common fluentui_tablayout Module attributes-->
+    <attr name="fluentui_tabType" format="enum">
+        <enum name="Standard" value="0" />
+        <enum name="Switch" value="1" />
+        <enum name="Pills" value="2" />
+    </attr>
 </resources>

--- a/fluentui_tablayout/src/main/res/values/attrs_tab_layout.xml
+++ b/fluentui_tablayout/src/main/res/values/attrs_tab_layout.xml
@@ -6,16 +6,12 @@
 
 <resources>
     <declare-styleable name="TabLayout">
-        <attr name="tabType" format="enum">
-            <enum name="Standard" value="0" />
-            <enum name="Switch" value="1" />
-            <enum name="Pills" value="2" />
-        </attr>
-        <attr name="containerBackgroundColor" format="color" />
-        <attr name="tabsBackgroundColor" format="color" />
-        <attr name="tabSelectedBackgroundColor" format="color" />
-        <attr name="tabUnselectedBackgroundColor" format="color" />
-        <attr name="tabSelectedTextColor" format="color" />
-        <attr name="tabUnselectedTextColor" format="color" />
+        <attr name="fluentui_tabType"/>
+        <attr name="fluentui_containerBackgroundColor"/>
+        <attr name="fluentui_tabsBackgroundColor"/>
+        <attr name="fluentui_tabSelectedBackgroundColor"/>
+        <attr name="fluentui_tabUnselectedBackgroundColor"/>
+        <attr name="fluentui_tabSelectedTextColor"/>
+        <attr name="fluentui_tabUnselectedTextColor"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
8 fluentui_tablayout : Moved the declare-styleable attributes to fluentui_core attrs.xml & enum attributes to fluentui_tablayout attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes