### PR TITLE
Topappbars

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_demo_detail.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_demo_detail.xml
@@ -18,7 +18,7 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:scrollBehavior="pin" />
+        app:fluentui_scrollBehavior="pin" />
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/demo_detail_scrollable_container"

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -34,6 +34,7 @@
     <!--Transparent Foregrounds-->
     <attr name="fluentuiForegroundOnPrimary80Color" format="reference|color"/>
     <attr name="fluentuiForegroundOnPrimary70Color" format="reference|color"/>
+<<<<<<< HEAD
 
     <!--Attributes from Modules-->
 
@@ -146,4 +147,13 @@
     <attr name="fluentui_tabUnselectedTextColor" format="color" />
 
     <!--fluentui_tablayout End-->
+||||||| parent of 2dc6d10 (Moved the declare-styleable attributes to fluentui_core attrs.xml & enum attributes to fluentui_topappbars attrs.xml to reuse at module level. Attributes also prefixed with 'fluentui_' to avoid conflict with other UI library attributes)
+=======
+
+    <!--fluentui_topappbars Start-->
+
+    <!--AppBarLayout-->
+    <attr name="fluentui_scrollTargetViewId" format="integer" />
+    <!--fluentui_topappbars End-->
+>>>>>>> 2dc6d10 (Moved the declare-styleable attributes to fluentui_core attrs.xml & enum attributes to fluentui_topappbars attrs.xml to reuse at module level. Attributes also prefixed with 'fluentui_' to avoid conflict with other UI library attributes)
 </resources>

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/appbarlayout/AppBarLayout.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/appbarlayout/AppBarLayout.kt
@@ -126,8 +126,8 @@ class AppBarLayout : AppBarLayout {
         setBackgroundColor(ThemeUtil.getThemeAttrColor(context, R.attr.fluentuiAppBarLayoutBackgroundColor))
 
         val styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.AppBarLayout)
-        scrollTargetViewId = styledAttributes.getResourceId(R.styleable.AppBarLayout_scrollTargetViewId, View.NO_ID)
-        val scrollBehaviorOrdinal = styledAttributes.getInt(R.styleable.AppBarLayout_scrollBehavior, DEFAULT_SCROLL_BEHAVIOR.ordinal)
+        scrollTargetViewId = styledAttributes.getResourceId(R.styleable.AppBarLayout_fluentui_scrollTargetViewId, View.NO_ID)
+        val scrollBehaviorOrdinal = styledAttributes.getInt(R.styleable.AppBarLayout_fluentui_scrollBehavior, DEFAULT_SCROLL_BEHAVIOR.ordinal)
         scrollBehavior = ScrollBehavior.values()[scrollBehaviorOrdinal]
         styledAttributes.recycle()
     }

--- a/fluentui_topappbars/src/main/res/values/attrs.xml
+++ b/fluentui_topappbars/src/main/res/values/attrs.xml
@@ -28,4 +28,14 @@
     <attr name="fluentuiToolbarSubtitleTextColor" format="reference|color"/>
     <attr name="fluentuiToolbarIconColor" format="reference|color"/>
 
+    <!--common fluentui_topappbars Module attributes-->
+
+    <!--AppBarLayout-->
+    <attr name="fluentui_scrollBehavior" format="enum">
+        <enum name="none" value="0" />
+        <enum name="collapseToolbar" value="1" />
+        <enum name="pin" value="2" />
+    </attr>
+
+
 </resources>

--- a/fluentui_topappbars/src/main/res/values/attrs_app_bar_layout.xml
+++ b/fluentui_topappbars/src/main/res/values/attrs_app_bar_layout.xml
@@ -6,11 +6,7 @@
 
 <resources>
     <declare-styleable name="AppBarLayout">
-        <attr name="scrollTargetViewId" format="integer" />
-        <attr name="scrollBehavior" format="enum">
-            <enum name="none" value="0" />
-            <enum name="collapseToolbar" value="1" />
-            <enum name="pin" value="2" />
-        </attr>
+        <attr name="fluentui_scrollTargetViewId"/>
+        <attr name="fluentui_scrollBehavior"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
9 fluentui_topappbars : Moved the declare-styleable attributes to fluentui_core attrs.xml & enum attributes to fluentui_topappbars attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes