### PR TITLE
CCB

### DIFF
--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/contextualcommandbar/ContextualCommandBar.kt
@@ -53,11 +53,11 @@ class ContextualCommandBar @JvmOverloads constructor(
 
             try {
                 groupSpace = styledAttributes.getDimensionPixelSize(
-                        R.styleable.ContextualCommandBar_groupSpace,
+                        R.styleable.ContextualCommandBar_fluentui_groupSpace,
                         resources.getDimensionPixelSize(R.dimen.fluentui_contextual_command_bar_default_group_space)
                 )
                 itemSpace = styledAttributes.getDimensionPixelSize(
-                        R.styleable.ContextualCommandBar_itemSpace,
+                        R.styleable.ContextualCommandBar_fluentui_itemSpace,
                         resources.getDimensionPixelSize(R.dimen.fluentui_contextual_command_bar_default_item_space)
                 )
             } finally {

--- a/fluentui_ccb/src/main/res/values/attrs_contextual_command_bar.xml
+++ b/fluentui_ccb/src/main/res/values/attrs_contextual_command_bar.xml
@@ -6,7 +6,7 @@
 
 <resources>
     <declare-styleable name="ContextualCommandBar">
-        <attr name="itemSpace" format="dimension"/>
-        <attr name="groupSpace" format="dimension"/>
+        <attr name="fluentui_itemSpace"/>
+        <attr name="fluentui_groupSpace"/>
     </declare-styleable>
 </resources>

--- a/fluentui_core/src/main/res/values/attrs.xml
+++ b/fluentui_core/src/main/res/values/attrs.xml
@@ -68,6 +68,14 @@
 
     <!--fluentui_calendar End-->
 
+    <!--fluentui_ccb Start-->
+    <!--ContextualCommandBar-->
+    <attr name="fluentui_itemSpace" format="dimension"/>
+    <attr name="fluentui_groupSpace" format="dimension"/>
+    <!--ContextualCommandBar End-->
+
+    <!--fluentui_ccb End-->
+
     <!--fluentui_drawer Start-->
     <!--Drawer-->
     <attr name="fluentui_cornerRadius" format="dimension"/>


### PR DESCRIPTION
Moved the declare-styleable attributes to fluentui_core attrs.xml to reuse at the module level. Attributes are also prefixed with 'fluentui_' to avoid conflict with other UI library attributes