### PR TITLE
Template view crash fix

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/views/Cell.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/views/Cell.kt
@@ -50,7 +50,7 @@ class Cell : TemplateView {
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(context, attrs, defStyleAttr) {
         if (attrs != null) {
             val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.Cell)
-            title = styledAttrs.getString(R.styleable.Cell_fluentui_title)
+            title = styledAttrs.getString(R.styleable.Cell_title)
             description = styledAttrs.getString(R.styleable.Cell_description)
             val orientationOrdinal = styledAttrs.getInt(R.styleable.Cell_orientation, DEFAULT_ORIENTATION.ordinal)
             orientation = CellOrientation.values()[orientationOrdinal]

--- a/FluentUI.Demo/src/main/res/values/attrs_cell.xml
+++ b/FluentUI.Demo/src/main/res/values/attrs_cell.xml
@@ -6,7 +6,7 @@
 
 <resources>
     <declare-styleable name="Cell">
-        <attr name="fluentui_title"/>
+        <attr name="title"/>
         <attr name="description" format="string"/>
         <attr name="orientation" format="enum">
             <enum name="horizontal" value="0"/>


### PR DESCRIPTION
Fixed templateView demo app crash by reverting the attribute name of demo app.