### PR TITLE
Fix: CCB Item Tint to be set only in case of Drawables

### DIFF
--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/contextualcommandbar/CommandItemAdapter.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/contextualcommandbar/CommandItemAdapter.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
 import com.microsoft.fluentui.ccb.R
 import com.microsoft.fluentui.util.isVisible
 
@@ -73,6 +74,7 @@ internal class CommandItemAdapter(
             with(viewHolder.icon) {
                 isVisible = true
                 setImageResource(icon)
+                imageTintList = AppCompatResources.getColorStateList(context, R.color.contextual_command_bar_icon_tint)
                 contentDescription = description
                 isEnabled = isItemEnabled
                 isSelected = isItemSelected

--- a/fluentui_ccb/src/main/res/layout/view_command_item.xml
+++ b/fluentui_ccb/src/main/res/layout/view_command_item.xml
@@ -17,8 +17,7 @@
         android:id="@+id/contextual_command_item_icon"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_gravity="center"
-        app:tint="@color/contextual_command_bar_icon_tint" />
+        android:layout_gravity="center"/>
 
     <TextView
         android:id="@+id/contextual_command_item_label"


### PR DESCRIPTION
Leave out tint in case of Bitmaps in order to consume images with non transparent background. Tint covers the entire area of the image thus making a picture completely coloured. 