### PR TITLE
bug-5886326: Adding null check at setImageDrawable

### DIFF
--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/persona/AvatarView.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/persona/AvatarView.kt
@@ -277,6 +277,8 @@ open class AvatarView : AppCompatImageView {
     }
 
     override fun setImageDrawable(drawable: Drawable?) {
+        if(drawable == null)
+            return
         if (drawable is BitmapDrawable)
             setImageBitmap(drawable.bitmap)
         else


### PR DESCRIPTION
SetImageDrawable method updates the view with null and therefore the default initials view is shown.