### PR TITLE
Fix to retain token info during config change or any recomposition

### DIFF
--- a/fluentui_core/build.gradle
+++ b/fluentui_core/build.gradle
@@ -5,6 +5,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-parcelize'
 
 apply from: '../config.gradle'
 apply from: '../publish.gradle'

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
@@ -30,8 +30,8 @@ enum class ButtonSize {
 }
 
 data class ButtonInfo(
-        val style: ButtonStyle = ButtonStyle.Button,
-        val size: ButtonSize = ButtonSize.Medium
+    val style: ButtonStyle = ButtonStyle.Button,
+    val size: ButtonSize = ButtonSize.Medium
 ) : ControlInfo
 
 @Parcelize
@@ -46,40 +46,40 @@ open class ButtonTokens : ControlTokens, Parcelable {
         return when (buttonInfo.style) {
             ButtonStyle.Button ->
                 StateColor(
-                        rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                                themeMode = themeMode
-                        ),
-                        pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                                themeMode = themeMode
-                        ),
-                        selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                                themeMode = themeMode
-                        ),
-                        focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                                themeMode = themeMode
-                        ),
-                        disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
-                                themeMode = themeMode
-                        )
+                    rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
+                        themeMode = themeMode
+                    )
                 )
 
             ButtonStyle.OutlinedButton, ButtonStyle.TextButton ->
                 StateColor(
-                        rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                                themeMode = themeMode
-                        ),
-                        pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
-                                themeMode = themeMode
-                        ),
-                        selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
-                                themeMode = themeMode
-                        ),
-                        focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                                themeMode = themeMode
-                        ),
-                        disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                                themeMode = themeMode
-                        )
+                    rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        themeMode = themeMode
+                    ),
+                    pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                        themeMode = themeMode
+                    ),
+                    selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
+                        themeMode = themeMode
+                    ),
+                    focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        themeMode = themeMode
+                    ),
+                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        themeMode = themeMode
+                    )
                 )
         }
     }
@@ -88,39 +88,39 @@ open class ButtonTokens : ControlTokens, Parcelable {
     open fun textColor(buttonInfo: ButtonInfo): StateColor {
         return when (buttonInfo.style) {
             ButtonStyle.Button -> StateColor(
-                    rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                            themeMode = themeMode
-                    ),
-                    pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                            themeMode = themeMode
-                    ),
-                    selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                            themeMode = themeMode
-                    ),
-                    focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                            themeMode = themeMode
-                    ),
-                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
-                            themeMode = themeMode
-                    )
+                rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                    themeMode = themeMode
+                ),
+                pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                    themeMode = themeMode
+                ),
+                selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                    themeMode = themeMode
+                ),
+                focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                    themeMode = themeMode
+                ),
+                disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
+                    themeMode = themeMode
+                )
             )
             ButtonStyle.OutlinedButton, ButtonStyle.TextButton ->
                 StateColor(
-                        rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                                themeMode = themeMode
-                        ),
-                        pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
-                                themeMode = themeMode
-                        ),
-                        selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
-                                themeMode = themeMode
-                        ),
-                        focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                                themeMode = themeMode
-                        ),
-                        disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                                themeMode = themeMode
-                        )
+                    rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        themeMode = themeMode
+                    ),
+                    pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                        themeMode = themeMode
+                    ),
+                    selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
+                        themeMode = themeMode
+                    ),
+                    focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        themeMode = themeMode
+                    ),
+                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        themeMode = themeMode
+                    )
                 )
         }
     }
@@ -130,21 +130,21 @@ open class ButtonTokens : ControlTokens, Parcelable {
         return when (buttonInfo.style) {
             ButtonStyle.Button ->
                 StateColor(
-                        rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                                themeMode = themeMode
-                        ),
-                        pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
-                                themeMode = themeMode
-                        ),
-                        selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
-                                themeMode = themeMode
-                        ),
-                        focused = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                                themeMode = themeMode
-                        ),
-                        disabled = aliasToken.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                                themeMode = themeMode
-                        )
+                    rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        themeMode = themeMode
+                    ),
+                    pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
+                        themeMode = themeMode
+                    ),
+                    selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
+                        themeMode = themeMode
+                    ),
+                    focused = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        themeMode = themeMode
+                    ),
+                    disabled = aliasToken.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        themeMode = themeMode
+                    )
                 )
             ButtonStyle.OutlinedButton -> StateColor()
             ButtonStyle.TextButton -> StateColor()
@@ -155,54 +155,61 @@ open class ButtonTokens : ControlTokens, Parcelable {
     open fun borderStroke(buttonInfo: ButtonInfo): StateBorderStroke {
         return when (buttonInfo.style) {
             ButtonStyle.Button, ButtonStyle.TextButton -> StateBorderStroke(
-                    focused = listOf(
-                            BorderStroke(
-                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
-                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
-                                            themeMode = themeMode
-                                    )
-                            ),
-                            BorderStroke(
-                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
-                                            themeMode = themeMode
-                                    )
-                            )
+                focused = listOf(
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
+                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
+                            themeMode = themeMode
+                        )
+                    ),
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
+                            themeMode = themeMode
+                        )
                     )
+                )
             )
 
             ButtonStyle.OutlinedButton -> StateBorderStroke(
-                    pressed = listOf(BorderStroke(
-                            globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                            aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1Pressed].value(
-                                    themeMode = themeMode
-                            )
-                    )),
-                    rest = listOf(BorderStroke(
-                            globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                            aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1].value(
-                                    themeMode = themeMode
-                            )
-                    )),
-                    disabled = listOf(BorderStroke(
-                            globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                            aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeDisabled].value(
-                                    themeMode = themeMode
-                            )
-                    )),
-                    focused = listOf(
-                            BorderStroke(
-                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
-                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
-                                            themeMode = themeMode
-                                    )),
-                            BorderStroke(
-                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
-                                            themeMode = themeMode
-                                    )
-                            )
+                pressed = listOf(
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                        aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1Pressed].value(
+                            themeMode = themeMode
+                        )
                     )
+                ),
+                rest = listOf(
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                        aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1].value(
+                            themeMode = themeMode
+                        )
+                    )
+                ),
+                disabled = listOf(
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeDisabled].value(
+                            themeMode = themeMode
+                        )
+                    )
+                ),
+                focused = listOf(
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
+                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
+                            themeMode = themeMode
+                        )
+                    ),
+                    BorderStroke(
+                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
+                            themeMode = themeMode
+                        )
+                    )
+                )
             )
         }
     }
@@ -242,16 +249,16 @@ open class ButtonTokens : ControlTokens, Parcelable {
         return when (buttonInfo.size) {
             ButtonSize.Small ->
                 PaddingValues(
-                        horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall],
-                        vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XXSmall]
+                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall],
+                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XXSmall]
                 )
             ButtonSize.Medium -> PaddingValues(
-                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall]
+                horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall]
             )
             ButtonSize.Large -> PaddingValues(
-                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Large],
-                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
+                horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Large],
+                vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
             )
         }
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.fluentui.theme.token.controlTokens
 
+import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
@@ -14,6 +15,7 @@ import com.microsoft.fluentui.theme.FluentTheme.aliasToken
 import com.microsoft.fluentui.theme.FluentTheme.globalTokens
 import com.microsoft.fluentui.theme.FluentTheme.themeMode
 import com.microsoft.fluentui.theme.token.*
+import kotlinx.parcelize.Parcelize
 
 enum class ButtonStyle {
     Button,
@@ -32,7 +34,8 @@ data class ButtonInfo(
         val size: ButtonSize = ButtonSize.Medium
 ) : ControlInfo
 
-open class ButtonTokens : ControlTokens {
+@Parcelize
+open class ButtonTokens : ControlTokens, Parcelable {
 
     companion object {
         const val Type: String = "Button"

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
@@ -28,8 +28,8 @@ enum class FABSize {
 }
 
 data class FABInfo(
-        val state: FABState = FABState.Expanded,
-        val size: FABSize = FABSize.Large
+    val state: FABState = FABState.Expanded,
+    val size: FABSize = FABSize.Large
 ) : ControlInfo
 
 @Parcelize
@@ -42,62 +42,62 @@ open class FABTokens : ControlTokens, Parcelable {
     @Composable
     open fun iconColor(fabInfo: FABInfo): StateColor {
         return StateColor(
-                rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                        themeMode = themeMode
-                ),
-                disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
-                        themeMode = themeMode
-                )
+            rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                themeMode = themeMode
+            ),
+            disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
+                themeMode = themeMode
+            )
         )
     }
 
     @Composable
     open fun textColor(fabInfo: FABInfo): StateColor {
         return StateColor(
-                rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                        themeMode = themeMode
-                ),
-                disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
-                        themeMode = themeMode
-                )
+            rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                themeMode = themeMode
+            ),
+            disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable2].value(
+                themeMode = themeMode
+            )
         )
     }
 
     @Composable
     open fun backgroundColor(fabInfo: FABInfo): StateColor {
         return StateColor(
-                rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        themeMode = themeMode
-                ),
-                pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
-                        themeMode = themeMode
-                ),
-                selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
-                        themeMode = themeMode
-                ),
-                disabled = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackgroundDisabled].value(
-                        themeMode = themeMode
-                )
+            rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                themeMode = themeMode
+            ),
+            pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
+                themeMode = themeMode
+            ),
+            selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
+                themeMode = themeMode
+            ),
+            disabled = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackgroundDisabled].value(
+                themeMode = themeMode
+            )
         )
     }
 
     @Composable
     open fun borderStroke(fabInfo: FABInfo): StateBorderStroke {
         return StateBorderStroke(
-                focused = listOf(
-                        BorderStroke(
-                                globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
-                                aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
-                                        themeMode = themeMode
-                                )
-                        ),
-                        BorderStroke(
-                                globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                                aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
-                                        themeMode = themeMode
-                                )
-                        )
+            focused = listOf(
+                BorderStroke(
+                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
+                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
+                        themeMode = themeMode
+                    )
+                ),
+                BorderStroke(
+                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
+                        themeMode = themeMode
+                    )
                 )
+            )
         )
     }
 
@@ -122,13 +122,13 @@ open class FABTokens : ControlTokens, Parcelable {
         return when (fabInfo.size) {
             FABSize.Small ->
                 PaddingValues(
-                        horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                        vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
+                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
                 )
             FABSize.Large ->
                 PaddingValues(
-                        horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                        vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
+                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
                 )
         }
     }
@@ -138,17 +138,17 @@ open class FABTokens : ControlTokens, Parcelable {
         return when (fabInfo.size) {
             FABSize.Small ->
                 PaddingValues(
-                        top = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                        bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                        start = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                        end = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
+                    top = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                    bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                    start = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                    end = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
                 )
             FABSize.Large ->
                 PaddingValues(
-                        top = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                        bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                        start = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                        end = globalTokens.spacing[GlobalTokens.SpacingTokens.Large]
+                    top = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                    bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                    start = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                    end = globalTokens.spacing[GlobalTokens.SpacingTokens.Large]
                 )
         }
     }
@@ -180,11 +180,11 @@ open class FABTokens : ControlTokens, Parcelable {
     @Composable
     open fun elevation(fabInfo: FABInfo): StateElevation {
         return StateElevation(
-                rest = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow08],
-                pressed = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
-                selected = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
-                focused = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
-                disabled = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02]
+            rest = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow08],
+            pressed = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
+            selected = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
+            focused = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
+            disabled = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02]
         )
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.fluentui.theme.token.controlTokens
 
+import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
@@ -14,6 +15,7 @@ import com.microsoft.fluentui.theme.FluentTheme.aliasToken
 import com.microsoft.fluentui.theme.FluentTheme.globalTokens
 import com.microsoft.fluentui.theme.FluentTheme.themeMode
 import com.microsoft.fluentui.theme.token.*
+import kotlinx.parcelize.Parcelize
 
 enum class FABState {
     Expanded,
@@ -30,7 +32,8 @@ data class FABInfo(
         val size: FABSize = FABSize.Large
 ) : ControlInfo
 
-open class FABTokens : ControlTokens {
+@Parcelize
+open class FABTokens : ControlTokens, Parcelable {
 
     companion object {
         const val Type: String = "FloatingActionButton"

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/Button.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/Button.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,7 +40,7 @@ fun Button(
         icon: ImageVector? = null,
         text: String? = null
 ) {
-    val token = remember {
+    val token = rememberSaveable {
         (buttonTokens ?: FluentTheme.tokens[ControlType.Button] as ButtonTokens)
     }
 
@@ -69,15 +70,15 @@ fun Button(
         }
 
         Box(
-                modifier
-                        .height(getButtonToken().fixedHeight(getButtonInfo()))
-                        .background(
-                                color = backgroundColor,
-                                shape = shape
-                        )
-                        .clip(shape)
-                        .then(borderModifier)
-                        .then(clickAndSemanticsModifier),
+            modifier
+                .height(getButtonToken().fixedHeight(getButtonInfo()))
+                .background(
+                    color = backgroundColor,
+                    shape = shape
+                )
+                .clip(shape)
+                .then(borderModifier)
+                .then(clickAndSemanticsModifier),
                 propagateMinConstraints = true
         ) {
             Row(

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/Button.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/Button.kt
@@ -30,37 +30,39 @@ val LocalButtonInfo = compositionLocalOf { ButtonInfo() }
 
 @Composable
 fun Button(
-        onClick: () -> Unit,
-        modifier: Modifier = Modifier,
-        style: ButtonStyle = ButtonStyle.Button,
-        size: ButtonSize = ButtonSize.Medium,
-        enabled: Boolean = true,
-        buttonTokens: ButtonTokens? = null,
-        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-        icon: ImageVector? = null,
-        text: String? = null
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: ButtonStyle = ButtonStyle.Button,
+    size: ButtonSize = ButtonSize.Medium,
+    enabled: Boolean = true,
+    buttonTokens: ButtonTokens? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    icon: ImageVector? = null,
+    text: String? = null
 ) {
     val token = rememberSaveable {
         (buttonTokens ?: FluentTheme.tokens[ControlType.Button] as ButtonTokens)
     }
 
     CompositionLocalProvider(
-            LocalButtonTokens provides token,
-            LocalButtonInfo provides ButtonInfo(style, size)
+        LocalButtonTokens provides token,
+        LocalButtonInfo provides ButtonInfo(style, size)
     ) {
         val clickAndSemanticsModifier = Modifier.clickable(
-                interactionSource = interactionSource,
-                indication = LocalIndication.current,
-                enabled = enabled,
-                onClickLabel = null,
-                role = Role.Button,
-                onClick = onClick
+            interactionSource = interactionSource,
+            indication = LocalIndication.current,
+            enabled = enabled,
+            onClickLabel = null,
+            role = Role.Button,
+            onClick = onClick
         )
-        val backgroundColor = backgroundColor(getButtonToken(), getButtonInfo(), enabled, interactionSource)
+        val backgroundColor =
+            backgroundColor(getButtonToken(), getButtonInfo(), enabled, interactionSource)
         val contentPadding = getButtonToken().padding(getButtonInfo())
         val iconSpacing = getButtonToken().spacing(getButtonInfo())
         val shape = RoundedCornerShape(getButtonToken().borderRadius(getButtonInfo()))
-        val borders: List<BorderStroke> = borderStroke(getButtonToken(), getButtonInfo(), enabled, interactionSource)
+        val borders: List<BorderStroke> =
+            borderStroke(getButtonToken(), getButtonInfo(), enabled, interactionSource)
 
         var borderModifier: Modifier = Modifier
         var borderWidth = 0.dp
@@ -79,33 +81,46 @@ fun Button(
                 .clip(shape)
                 .then(borderModifier)
                 .then(clickAndSemanticsModifier),
-                propagateMinConstraints = true
+            propagateMinConstraints = true
         ) {
             Row(
-                    Modifier.padding(contentPadding),
-                    horizontalArrangement = Arrangement.spacedBy(
-                            iconSpacing,
-                            Alignment.CenterHorizontally
-                    ),
-                    verticalAlignment = Alignment.CenterVertically
+                Modifier.padding(contentPadding),
+                horizontalArrangement = Arrangement.spacedBy(
+                    iconSpacing,
+                    Alignment.CenterHorizontally
+                ),
+                verticalAlignment = Alignment.CenterVertically
             ) {
 
                 if (icon != null)
-                    Icon(imageVector = icon,
-                            contentDescription = text,
-                            modifier = Modifier.size(
-                                    getButtonToken().iconSize(buttonInfo = getButtonInfo()).size),
-                            tint = iconColor(getButtonToken(), getButtonInfo(), enabled, interactionSource)
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = text,
+                        modifier = Modifier.size(
+                            getButtonToken().iconSize(buttonInfo = getButtonInfo()).size
+                        ),
+                        tint = iconColor(
+                            getButtonToken(),
+                            getButtonInfo(),
+                            enabled,
+                            interactionSource
+                        )
                     )
 
                 if (text != null)
-                    Text(text = text,
-                            fontSize = getButtonToken().fontInfo(getButtonInfo()).fontSize.size,
-                            lineHeight = getButtonToken().fontInfo(getButtonInfo()).fontSize.lineHeight,
-                            fontWeight = getButtonToken().fontInfo(getButtonInfo()).weight,
-                            color = textColor(getButtonToken(), getButtonInfo(), enabled, interactionSource),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                    Text(
+                        text = text,
+                        fontSize = getButtonToken().fontInfo(getButtonInfo()).fontSize.size,
+                        lineHeight = getButtonToken().fontInfo(getButtonInfo()).fontSize.lineHeight,
+                        fontWeight = getButtonToken().fontInfo(getButtonInfo()).weight,
+                        color = textColor(
+                            getButtonToken(),
+                            getButtonInfo(),
+                            enabled,
+                            interactionSource
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
             }
         }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/FloatingActionButton.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/FloatingActionButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,7 +40,7 @@ fun FloatingActionButton(onClick: () -> Unit,
                          icon: ImageVector? = null,
                          text: String? = null
 ) {
-    val token = remember {
+    val token = rememberSaveable {
         (fabTokens ?: FluentTheme.tokens[ControlType.FloatingActionButton] as FABTokens)
     }
 

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/FloatingActionButton.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/FloatingActionButton.kt
@@ -29,40 +29,43 @@ val LocalFABTokens = compositionLocalOf { FABTokens() }
 val LocalFABInfo = compositionLocalOf { FABInfo() }
 
 @Composable
-fun FloatingActionButton(onClick: () -> Unit,
-                         modifier: Modifier = Modifier,
-                         state: FABState = FABState.Expanded,
-                         size: FABSize = FABSize.Large,
-                         expanded: Boolean = true,
-                         enabled: Boolean = true,
-                         fabTokens: FABTokens? = null,
-                         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-                         icon: ImageVector? = null,
-                         text: String? = null
+fun FloatingActionButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: FABState = FABState.Expanded,
+    size: FABSize = FABSize.Large,
+    expanded: Boolean = true,
+    enabled: Boolean = true,
+    fabTokens: FABTokens? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    icon: ImageVector? = null,
+    text: String? = null
 ) {
     val token = rememberSaveable {
         (fabTokens ?: FluentTheme.tokens[ControlType.FloatingActionButton] as FABTokens)
     }
 
     CompositionLocalProvider(
-            LocalFABTokens provides token,
-            LocalFABInfo provides FABInfo(state, size)
+        LocalFABTokens provides token,
+        LocalFABInfo provides FABInfo(state, size)
     ) {
         val clickAndSemanticsModifier = Modifier.clickable(
-                interactionSource = interactionSource,
-                indication = LocalIndication.current,
-                enabled = enabled,
-                onClickLabel = null,
-                role = Role.Button,
-                onClick = onClick
+            interactionSource = interactionSource,
+            indication = LocalIndication.current,
+            enabled = enabled,
+            onClickLabel = null,
+            role = Role.Button,
+            onClick = onClick
         )
         val fabExpandedState: Boolean = (text != null && expanded)
-        val backgroundColor = backgroundColor(getFABToken(), getFABInfo(), enabled, interactionSource)
+        val backgroundColor =
+            backgroundColor(getFABToken(), getFABInfo(), enabled, interactionSource)
         val contentPadding = if (fabExpandedState) getFABToken().textPadding(getFABInfo())
         else getFABToken().iconPadding(getFABInfo())
         val iconSpacing = if (fabExpandedState) getFABToken().spacing(getFABInfo()) else 0.dp
         val shape = CircleShape
-        val borders: List<BorderStroke> = borderStroke(getFABToken(), getFABInfo(), enabled, interactionSource)
+        val borders: List<BorderStroke> =
+            borderStroke(getFABToken(), getFABInfo(), enabled, interactionSource)
 
         var borderModifier: Modifier = Modifier
         var borderWidth = 0.dp
@@ -72,49 +75,53 @@ fun FloatingActionButton(onClick: () -> Unit,
         }
 
         Box(
-                modifier
-                        .height(getFABToken().fixedHeight(getFABInfo()))
-                        .defaultMinSize(minWidth = getFABToken().minWidth(getFABInfo()))
-                        .shadow(
-                                elevation = elevation(
-                                        enabled = enabled,
-                                        interactionSource = interactionSource),
-                                shape = CircleShape
-                        )
-                        .background(
-                                color = backgroundColor,
-                                shape = shape
-                        )
-                        .clip(shape)
-                        .then(borderModifier)
-                        .then(clickAndSemanticsModifier),
-                propagateMinConstraints = true
+            modifier
+                .height(getFABToken().fixedHeight(getFABInfo()))
+                .defaultMinSize(minWidth = getFABToken().minWidth(getFABInfo()))
+                .shadow(
+                    elevation = elevation(
+                        enabled = enabled,
+                        interactionSource = interactionSource
+                    ),
+                    shape = CircleShape
+                )
+                .background(
+                    color = backgroundColor,
+                    shape = shape
+                )
+                .clip(shape)
+                .then(borderModifier)
+                .then(clickAndSemanticsModifier),
+            propagateMinConstraints = true
         ) {
             Row(
-                    Modifier.padding(contentPadding),
-                    horizontalArrangement = Arrangement.spacedBy(
-                            iconSpacing,
-                            Alignment.CenterHorizontally
-                    ),
-                    verticalAlignment = Alignment.CenterVertically
+                Modifier.padding(contentPadding),
+                horizontalArrangement = Arrangement.spacedBy(
+                    iconSpacing,
+                    Alignment.CenterHorizontally
+                ),
+                verticalAlignment = Alignment.CenterVertically
             ) {
 
                 if (icon != null)
-                    Icon(imageVector = icon,
-                            contentDescription = text,
-                            modifier = Modifier.size(
-                                    getFABToken().iconSize(getFABInfo()).size),
-                            tint = iconColor(getFABToken(), getFABInfo(), enabled, interactionSource)
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = text,
+                        modifier = Modifier.size(
+                            getFABToken().iconSize(getFABInfo()).size
+                        ),
+                        tint = iconColor(getFABToken(), getFABInfo(), enabled, interactionSource)
                     )
 
                 AnimatedVisibility(fabExpandedState) {
-                    Text(text = text!!,
-                            fontSize = getFABToken().fontInfo(getFABInfo()).fontSize.size,
-                            lineHeight = getFABToken().fontInfo(getFABInfo()).fontSize.lineHeight,
-                            fontWeight = getFABToken().fontInfo(getFABInfo()).weight,
-                            color = textColor(getFABToken(), getFABInfo(), enabled, interactionSource),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                    Text(
+                        text = text!!,
+                        fontSize = getFABToken().fontInfo(getFABInfo()).fontSize.size,
+                        lineHeight = getFABToken().fontInfo(getFABInfo()).fontSize.lineHeight,
+                        fontWeight = getFABToken().fontInfo(getFABInfo()).weight,
+                        color = textColor(getFABToken(), getFABInfo(), enabled, interactionSource),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
             }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/Utils.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/Utils.kt
@@ -19,7 +19,11 @@ import com.microsoft.fluentui.theme.token.controlTokens.FABTokens
 import java.security.InvalidParameterException
 
 @Composable
-fun getColorByState(stateData: StateColor, enabled: Boolean, interactionSource: InteractionSource): Color {
+fun getColorByState(
+    stateData: StateColor,
+    enabled: Boolean,
+    interactionSource: InteractionSource
+): Color {
     if (enabled) {
         val isPressed by interactionSource.collectIsPressedAsState()
         if (isPressed)
@@ -39,49 +43,69 @@ fun getColorByState(stateData: StateColor, enabled: Boolean, interactionSource: 
 }
 
 @Composable
-fun backgroundColor(tokens: ControlTokens, info: ControlInfo, enabled: Boolean, interactionSource: InteractionSource): Color {
+fun backgroundColor(
+    tokens: ControlTokens,
+    info: ControlInfo,
+    enabled: Boolean,
+    interactionSource: InteractionSource
+): Color {
     val backgroundColors: StateColor =
-            when (tokens) {
-                is ButtonTokens -> tokens.backgroundColor(info as ButtonInfo)
-                is FABTokens -> tokens.backgroundColor(info as FABInfo)
-                else -> throw InvalidParameterException()
-            }
+        when (tokens) {
+            is ButtonTokens -> tokens.backgroundColor(info as ButtonInfo)
+            is FABTokens -> tokens.backgroundColor(info as FABInfo)
+            else -> throw InvalidParameterException()
+        }
 
     return getColorByState(backgroundColors, enabled, interactionSource)
 }
 
 @Composable
-fun iconColor(tokens: ControlTokens, info: ControlInfo, enabled: Boolean, interactionSource: InteractionSource): Color {
+fun iconColor(
+    tokens: ControlTokens,
+    info: ControlInfo,
+    enabled: Boolean,
+    interactionSource: InteractionSource
+): Color {
     val iconColors: StateColor =
-            when (tokens) {
-                is ButtonTokens -> tokens.iconColor(info as ButtonInfo)
-                is FABTokens -> tokens.iconColor(info as FABInfo)
-                else -> throw InvalidParameterException()
-            }
+        when (tokens) {
+            is ButtonTokens -> tokens.iconColor(info as ButtonInfo)
+            is FABTokens -> tokens.iconColor(info as FABInfo)
+            else -> throw InvalidParameterException()
+        }
 
     return getColorByState(iconColors, enabled, interactionSource)
 }
 
 @Composable
-fun textColor(tokens: ControlTokens, info: ControlInfo, enabled: Boolean, interactionSource: InteractionSource): Color {
+fun textColor(
+    tokens: ControlTokens,
+    info: ControlInfo,
+    enabled: Boolean,
+    interactionSource: InteractionSource
+): Color {
     val textColors: StateColor =
-            when (tokens) {
-                is ButtonTokens -> tokens.textColor(info as ButtonInfo)
-                is FABTokens -> tokens.textColor(info as FABInfo)
-                else -> throw InvalidParameterException()
-            }
+        when (tokens) {
+            is ButtonTokens -> tokens.textColor(info as ButtonInfo)
+            is FABTokens -> tokens.textColor(info as FABInfo)
+            else -> throw InvalidParameterException()
+        }
 
     return getColorByState(textColors, enabled, interactionSource)
 }
 
 @Composable
-fun borderStroke(tokens: ControlTokens, info: ControlInfo, enabled: Boolean, interactionSource: InteractionSource): List<BorderStroke> {
+fun borderStroke(
+    tokens: ControlTokens,
+    info: ControlInfo,
+    enabled: Boolean,
+    interactionSource: InteractionSource
+): List<BorderStroke> {
     val fetchBorderStroke: StateBorderStroke =
-            when (tokens) {
-                is ButtonTokens -> tokens.borderStroke(info as ButtonInfo)
-                is FABTokens -> tokens.borderStroke(info as FABInfo)
-                else -> throw InvalidParameterException()
-            }
+        when (tokens) {
+            is ButtonTokens -> tokens.borderStroke(info as ButtonInfo)
+            is FABTokens -> tokens.borderStroke(info as FABInfo)
+            else -> throw InvalidParameterException()
+        }
 
     if (enabled) {
         val isPressed by interactionSource.collectIsPressedAsState()


### PR DESCRIPTION
using remeberSaveable for control token to survive configuration change. This fix help to retain the token info provided at the time of creation for any case of recomposition
