### PR TITLE
Enable View Model to provide App level theme

### DIFF
--- a/FluentUI.Demo/src/main/java/com/example/theme/token/MyButtonTokens.kt
+++ b/FluentUI.Demo/src/main/java/com/example/theme/token/MyButtonTokens.kt
@@ -12,9 +12,9 @@ open class MyButtonTokens : ButtonTokens() {
     @Composable
     override fun fixedHeight(buttonInfo: ButtonInfo): Dp {
         return when (buttonInfo.size) {
-            ButtonSize.Small -> 32.dp
-            ButtonSize.Medium -> 40.dp
-            ButtonSize.Large -> 52.dp
+            ButtonSize.Small -> 50.dp
+            ButtonSize.Medium -> 60.dp
+            ButtonSize.Large -> 100.dp
         }
     }
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BasicInputsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BasicInputsActivity.kt
@@ -26,10 +26,11 @@ import com.example.theme.token.MyButtonTokens
 import com.example.theme.token.MyGlobalTokens
 import com.microsoft.fluentui.button.Button
 import com.microsoft.fluentui.button.FloatingActionButton
+import com.microsoft.fluentui.theme.AppThemeController
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.AliasTokens
-import com.microsoft.fluentui.theme.token.ControlType
+import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.GlobalTokens
 import com.microsoft.fluentui.theme.token.controlTokens.*
 import com.microsoft.fluentuidemo.DemoActivity
@@ -37,31 +38,28 @@ import com.microsoft.fluentuidemo.R
 
 class V2BasicInputsActivity : DemoActivity() {
     override val contentLayoutId: Int
-        get() = R.layout.v2_activity_basic_inputs
+        get() = R.layout.v2_activity_compose
     override val contentNeedsScrollableContainer: Boolean
         get() = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val viewModel = FluentTheme.getViewModel(this)
-
-        val buttons = findViewById<ComposeView>(R.id.buttons)
+        val compose_here = findViewById<ComposeView>(R.id.compose_here)
         val context = this
-        FluentTheme.register(ControlType.Button, ButtonTokens())
-        FluentTheme.register(ControlType.FloatingActionButton, FABTokens())
-        buttons.setContent {
-            val globalTokens: GlobalTokens by viewModel.initializeGlobalToken(globalTokens = GlobalTokens())
-            val aliasTokens: AliasTokens by viewModel.initializeAliasToken(aliasTokens = AliasTokens())
+
+        compose_here.setContent {
+            val globalTokens: GlobalTokens by AppThemeController.observeGlobalToken(initial = GlobalTokens())
+            val aliasTokens: AliasTokens by AppThemeController.observeAliasToken(initial = AliasTokens())
+            val controlTokens: ControlTokens by AppThemeController.observeControlToken(initial = ControlTokens())
+
             var fabState by rememberSaveable { mutableStateOf(FABState.Expanded) }
 
             Column(
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                     modifier = Modifier.padding(16.dp)
             ) {
-                FluentTheme.register(ControlType.Button, ButtonTokens())
-
-                FluentTheme(globalTokens = globalTokens, aliasTokens = aliasTokens) {
+                FluentTheme(globalTokens = globalTokens, aliasTokens = aliasTokens, controlTokens = controlTokens) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text("Button to update Theme via Global & Alias token")
 
@@ -72,10 +70,10 @@ class V2BasicInputsActivity : DemoActivity() {
                             Button(
                                     style = ButtonStyle.OutlinedButton,
                                     size = ButtonSize.Medium,
-                                    buttonTokens = ButtonTokens(),
                                     onClick = {
-                                        viewModel.onAliasChanged(AliasTokens())
-                                        viewModel.onGlobalChanged(GlobalTokens())
+                                        AppThemeController.onGlobalChanged(GlobalTokens())
+                                        AppThemeController.onAliasChanged(AliasTokens())
+                                        AppThemeController.onControlChanged(ControlTokens().updateTokens(ControlTokens.ControlType.Button, ButtonTokens()))
                                     },
                                     text = "Set Default Theme"
                             )
@@ -83,10 +81,10 @@ class V2BasicInputsActivity : DemoActivity() {
                             Button(
                                     style = ButtonStyle.OutlinedButton,
                                     size = ButtonSize.Medium,
-                                    buttonTokens = ButtonTokens(),
                                     onClick = {
-                                        viewModel.onAliasChanged(MyAliasTokens(MyGlobalTokens()))
-                                        viewModel.onGlobalChanged(MyGlobalTokens())
+                                        AppThemeController.onGlobalChanged(MyGlobalTokens())
+                                        AppThemeController.onAliasChanged(MyAliasTokens(MyGlobalTokens()))
+                                        AppThemeController.onControlChanged(ControlTokens().updateTokens(ControlTokens.ControlType.Button, MyButtonTokens()))
                                     },
                                     text = "Set New Theme"
                             )
@@ -109,6 +107,7 @@ class V2BasicInputsActivity : DemoActivity() {
                         FluentTheme(
                                 globalTokens = globalTokens,
                                 aliasTokens = aliasTokens,
+                                controlTokens = controlTokens,
                                 themeMode = ThemeMode.AutoColorful
                         ) {
                             Box(
@@ -125,7 +124,7 @@ class V2BasicInputsActivity : DemoActivity() {
                         }
                     }
                     item {
-                        FluentTheme(globalTokens = globalTokens, aliasTokens = aliasTokens) {
+                        FluentTheme(globalTokens = globalTokens, aliasTokens = aliasTokens, controlTokens = controlTokens) {
                             Text("Button with selected theme, auto mode and default control token")
                             CreateButtons()
 
@@ -135,7 +134,7 @@ class V2BasicInputsActivity : DemoActivity() {
                     }
                 }
             }
-            FluentTheme(globalTokens = globalTokens, aliasTokens = aliasTokens) {
+            FluentTheme(globalTokens = globalTokens, aliasTokens = aliasTokens, controlTokens = controlTokens) {
                 Box(
                         contentAlignment = Alignment.BottomEnd,
                         modifier = Modifier.fillMaxSize()

--- a/FluentUI.Demo/src/main/res/layout/v2_activity_compose.xml
+++ b/FluentUI.Demo/src/main/res/layout/v2_activity_compose.xml
@@ -4,6 +4,6 @@
   ~ Licensed under the MIT License.
   -->
 <androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/buttons"
+        android:id="@+id/compose_here"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/FluentTheme.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/FluentTheme.kt
@@ -2,7 +2,8 @@ package com.microsoft.fluentui.theme
 
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.lifecycle.*
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import com.microsoft.fluentui.theme.token.*
 
 enum class ThemeMode {
@@ -19,12 +20,14 @@ internal val LocalThemeMode = compositionLocalOf { ThemeMode.Auto }
 fun FluentTheme(
         globalTokens: GlobalTokens = GlobalTokens(),
         aliasTokens: AliasTokens = AliasTokens(),
+        controlTokens: ControlTokens = ControlTokens(),
         themeMode: ThemeMode = ThemeMode.Auto,
         content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(
             LocalGlobalTokens provides globalTokens,
             LocalAliasTokens provides aliasTokens,
+            LocalControlTokens provides controlTokens,
             LocalThemeMode provides themeMode
     ) {
         content()
@@ -32,7 +35,6 @@ fun FluentTheme(
 }
 
 object FluentTheme {
-
     val globalTokens: GlobalTokens
         @Composable
         @ReadOnlyComposable
@@ -43,45 +45,48 @@ object FluentTheme {
         @ReadOnlyComposable
         get() = LocalAliasTokens.current
 
-    val tokens: HashMap<ControlType, Any?> = HashMap()
-
-    fun register(type: ControlType, controlTokens: ControlTokens) {
-        tokens[type] = controlTokens
-    }
+    val controlTokens: ControlTokens
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalControlTokens.current
 
     val themeMode: ThemeMode
         @Composable
         @ReadOnlyComposable
         get() = LocalThemeMode.current
 
-    class ThemeViewModel : ViewModel() {
-        private val _aliasTokens: MutableLiveData<AliasTokens> = MutableLiveData(AliasTokens())
 
-        private val _globalTokens: MutableLiveData<GlobalTokens> = MutableLiveData(GlobalTokens())
+}
 
-        val aliasTokens: LiveData<AliasTokens> = _aliasTokens
-        val globalTokens: LiveData<GlobalTokens> = _globalTokens
+object AppThemeController : ViewModel() {
+    var globalTokens: MutableLiveData<GlobalTokens> = MutableLiveData(GlobalTokens())
+    var aliasTokens: MutableLiveData<AliasTokens> = MutableLiveData(AliasTokens())
+    var controlTokens: MutableLiveData<ControlTokens> = MutableLiveData(ControlTokens())
 
-        fun onAliasChanged(aliasTokens: AliasTokens) {
-            _aliasTokens.value = aliasTokens
-        }
-
-        fun onGlobalChanged(globalTokens: GlobalTokens) {
-            _globalTokens.value = globalTokens
-        }
-
-        @Composable
-        fun initializeGlobalToken(globalTokens: GlobalTokens): State<GlobalTokens> {
-            return this.globalTokens.observeAsState(initial = globalTokens)
-        }
-
-        @Composable
-        fun initializeAliasToken(aliasTokens: AliasTokens): State<AliasTokens> {
-            return this.aliasTokens.observeAsState(initial = aliasTokens)
-        }
+    fun onGlobalChanged(overrideGlobalTokens: GlobalTokens) {
+        globalTokens.value = overrideGlobalTokens
     }
 
-    fun getViewModel(owner: ViewModelStoreOwner): ThemeViewModel {
-        return ViewModelProvider(owner).get(ThemeViewModel::class.java)
+    fun onAliasChanged(overrideAliasTokens: AliasTokens) {
+        aliasTokens.value = overrideAliasTokens
+    }
+
+    fun onControlChanged(overrideControlTokens: ControlTokens) {
+        controlTokens.value = overrideControlTokens
+    }
+
+    @Composable
+    fun observeGlobalToken(initial: GlobalTokens): State<GlobalTokens> {
+        return this.globalTokens.observeAsState(initial)
+    }
+
+    @Composable
+    fun observeAliasToken(initial: AliasTokens): State<AliasTokens> {
+        return this.aliasTokens.observeAsState(initial)
+    }
+
+    @Composable
+    fun observeControlToken(initial: ControlTokens): State<ControlTokens> {
+        return this.controlTokens.observeAsState(initial)
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
@@ -5,11 +5,35 @@
 
 package com.microsoft.fluentui.theme.token
 
+import androidx.compose.runtime.compositionLocalOf
+import com.microsoft.fluentui.theme.token.controlTokens.ButtonTokens
+import com.microsoft.fluentui.theme.token.controlTokens.FABTokens
+
 interface ControlInfo
 
-interface ControlTokens
+interface ControlToken
 
-enum class ControlType {
-    Button,
-    FloatingActionButton
+class ControlTokens {
+
+    enum class ControlType {
+        Button,
+        FloatingActionButton,
+    }
+
+    val tokens: TokenSet<ControlType, ControlToken> by lazy {
+        TokenSet { token ->
+            when (token) {
+                ControlType.Button -> ButtonTokens()
+                ControlType.FloatingActionButton -> FABTokens()
+            }
+        }
+    }
+
+    fun updateTokens(type: ControlType, updatedToken: ControlToken): ControlTokens {
+        tokens[type] = updatedToken
+        return this
+    }
+
 }
+
+internal val LocalControlTokens = compositionLocalOf { ControlTokens() }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
@@ -30,12 +30,12 @@ enum class ButtonSize {
 }
 
 data class ButtonInfo(
-    val style: ButtonStyle = ButtonStyle.Button,
-    val size: ButtonSize = ButtonSize.Medium
+        val style: ButtonStyle = ButtonStyle.Button,
+        val size: ButtonSize = ButtonSize.Medium
 ) : ControlInfo
 
 @Parcelize
-open class ButtonTokens : ControlTokens, Parcelable {
+open class ButtonTokens : ControlToken, Parcelable {
 
     companion object {
         const val Type: String = "Button"
@@ -46,40 +46,40 @@ open class ButtonTokens : ControlTokens, Parcelable {
         return when (buttonInfo.style) {
             ButtonStyle.Button ->
                 StateColor(
-                    rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                        themeMode = themeMode
-                    ),
-                    pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                        themeMode = themeMode
-                    ),
-                    selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                        themeMode = themeMode
-                    ),
-                    focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                        themeMode = themeMode
-                    ),
-                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                        themeMode = themeMode
-                    )
+                        rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                                themeMode = themeMode
+                        ),
+                        pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                                themeMode = themeMode
+                        ),
+                        selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                                themeMode = themeMode
+                        ),
+                        focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                                themeMode = themeMode
+                        ),
+                        disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                                themeMode = themeMode
+                        )
                 )
 
             ButtonStyle.OutlinedButton, ButtonStyle.TextButton ->
                 StateColor(
-                    rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                        themeMode = themeMode
-                    ),
-                    pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
-                        themeMode = themeMode
-                    ),
-                    selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
-                        themeMode = themeMode
-                    ),
-                    focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                        themeMode = themeMode
-                    ),
-                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                        themeMode = themeMode
-                    )
+                        rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                                themeMode = themeMode
+                        ),
+                        pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                                themeMode = themeMode
+                        ),
+                        selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
+                                themeMode = themeMode
+                        ),
+                        focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                                themeMode = themeMode
+                        ),
+                        disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                                themeMode = themeMode
+                        )
                 )
         }
     }
@@ -88,39 +88,39 @@ open class ButtonTokens : ControlTokens, Parcelable {
     open fun textColor(buttonInfo: ButtonInfo): StateColor {
         return when (buttonInfo.style) {
             ButtonStyle.Button -> StateColor(
-                rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                    themeMode = themeMode
-                ),
-                pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                    themeMode = themeMode
-                ),
-                selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                    themeMode = themeMode
-                ),
-                focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                    themeMode = themeMode
-                ),
-                disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                    themeMode = themeMode
-                )
+                    rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                            themeMode = themeMode
+                    ),
+                    pressed = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                            themeMode = themeMode
+                    ),
+                    selected = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                            themeMode = themeMode
+                    ),
+                    focused = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                            themeMode = themeMode
+                    ),
+                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            themeMode = themeMode
+                    )
             )
             ButtonStyle.OutlinedButton, ButtonStyle.TextButton ->
                 StateColor(
-                    rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                        themeMode = themeMode
-                    ),
-                    pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
-                        themeMode = themeMode
-                    ),
-                    selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
-                        themeMode = themeMode
-                    ),
-                    focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
-                        themeMode = themeMode
-                    ),
-                    disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                        themeMode = themeMode
-                    )
+                        rest = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                                themeMode = themeMode
+                        ),
+                        pressed = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                                themeMode = themeMode
+                        ),
+                        selected = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
+                                themeMode = themeMode
+                        ),
+                        focused = aliasToken.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                                themeMode = themeMode
+                        ),
+                        disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                                themeMode = themeMode
+                        )
                 )
         }
     }
@@ -130,21 +130,21 @@ open class ButtonTokens : ControlTokens, Parcelable {
         return when (buttonInfo.style) {
             ButtonStyle.Button ->
                 StateColor(
-                    rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        themeMode = themeMode
-                    ),
-                    pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
-                        themeMode = themeMode
-                    ),
-                    selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
-                        themeMode = themeMode
-                    ),
-                    focused = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        themeMode = themeMode
-                    ),
-                    disabled = aliasToken.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                        themeMode = themeMode
-                    )
+                        rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                                themeMode = themeMode
+                        ),
+                        pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
+                                themeMode = themeMode
+                        ),
+                        selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
+                                themeMode = themeMode
+                        ),
+                        focused = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                                themeMode = themeMode
+                        ),
+                        disabled = aliasToken.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                                themeMode = themeMode
+                        )
                 )
             ButtonStyle.OutlinedButton -> StateColor()
             ButtonStyle.TextButton -> StateColor()
@@ -155,61 +155,61 @@ open class ButtonTokens : ControlTokens, Parcelable {
     open fun borderStroke(buttonInfo: ButtonInfo): StateBorderStroke {
         return when (buttonInfo.style) {
             ButtonStyle.Button, ButtonStyle.TextButton -> StateBorderStroke(
-                focused = listOf(
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
-                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
-                            themeMode = themeMode
-                        )
-                    ),
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
-                            themeMode = themeMode
-                        )
+                    focused = listOf(
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
+                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
+                                            themeMode = themeMode
+                                    )
+                            ),
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
+                                            themeMode = themeMode
+                                    )
+                            )
                     )
-                )
             )
 
             ButtonStyle.OutlinedButton -> StateBorderStroke(
-                pressed = listOf(
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                        aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1Pressed].value(
-                            themeMode = themeMode
-                        )
-                    )
-                ),
-                rest = listOf(
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                        aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1].value(
-                            themeMode = themeMode
-                        )
-                    )
-                ),
-                disabled = listOf(
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeDisabled].value(
-                            themeMode = themeMode
-                        )
-                    )
-                ),
-                focused = listOf(
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
-                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
-                            themeMode = themeMode
-                        )
+                    pressed = listOf(
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                                    aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1Pressed].value(
+                                            themeMode = themeMode
+                                    )
+                            )
                     ),
-                    BorderStroke(
-                        globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                        aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
-                            themeMode = themeMode
-                        )
+                    rest = listOf(
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                                    aliasToken.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1].value(
+                                            themeMode = themeMode
+                                    )
+                            )
+                    ),
+                    disabled = listOf(
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeDisabled].value(
+                                            themeMode = themeMode
+                                    )
+                            )
+                    ),
+                    focused = listOf(
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
+                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
+                                            themeMode = themeMode
+                                    )
+                            ),
+                            BorderStroke(
+                                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
+                                            themeMode = themeMode
+                                    )
+                            )
                     )
-                )
             )
         }
     }
@@ -249,16 +249,16 @@ open class ButtonTokens : ControlTokens, Parcelable {
         return when (buttonInfo.size) {
             ButtonSize.Small ->
                 PaddingValues(
-                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall],
-                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XXSmall]
+                        horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall],
+                        vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XXSmall]
                 )
             ButtonSize.Medium -> PaddingValues(
-                horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall]
+                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.XSmall]
             )
             ButtonSize.Large -> PaddingValues(
-                horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Large],
-                vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
+                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Large],
+                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
             )
         }
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
@@ -28,12 +28,12 @@ enum class FABSize {
 }
 
 data class FABInfo(
-    val state: FABState = FABState.Expanded,
-    val size: FABSize = FABSize.Large
+        val state: FABState = FABState.Expanded,
+        val size: FABSize = FABSize.Large
 ) : ControlInfo
 
 @Parcelize
-open class FABTokens : ControlTokens, Parcelable {
+open class FABTokens : ControlToken, Parcelable {
 
     companion object {
         const val Type: String = "FloatingActionButton"
@@ -42,62 +42,62 @@ open class FABTokens : ControlTokens, Parcelable {
     @Composable
     open fun iconColor(fabInfo: FABInfo): StateColor {
         return StateColor(
-            rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                themeMode = themeMode
-            ),
-            disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                themeMode = themeMode
-            )
+                rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                ),
+                disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        themeMode = themeMode
+                )
         )
     }
 
     @Composable
     open fun textColor(fabInfo: FABInfo): StateColor {
         return StateColor(
-            rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
-                themeMode = themeMode
-            ),
-            disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
-                themeMode = themeMode
-            )
+                rest = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                ),
+                disabled = aliasToken.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        themeMode = themeMode
+                )
         )
     }
 
     @Composable
     open fun backgroundColor(fabInfo: FABInfo): StateColor {
         return StateColor(
-            rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
-            ),
-            pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
-                themeMode = themeMode
-            ),
-            selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
-                themeMode = themeMode
-            ),
-            disabled = aliasToken.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                themeMode = themeMode
-            )
+                rest = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        themeMode = themeMode
+                ),
+                pressed = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
+                        themeMode = themeMode
+                ),
+                selected = aliasToken.brandBackgroundColor[AliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
+                        themeMode = themeMode
+                ),
+                disabled = aliasToken.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        themeMode = themeMode
+                )
         )
     }
 
     @Composable
     open fun borderStroke(fabInfo: FABInfo): StateBorderStroke {
         return StateBorderStroke(
-            focused = listOf(
-                BorderStroke(
-                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
-                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
-                        themeMode = themeMode
-                    )
-                ),
-                BorderStroke(
-                    globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
-                    aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
-                        themeMode = themeMode
-                    )
+                focused = listOf(
+                        BorderStroke(
+                                globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thick],
+                                aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus2].value(
+                                        themeMode = themeMode
+                                )
+                        ),
+                        BorderStroke(
+                                globalTokens.borderSize[GlobalTokens.BorderSizeTokens.Thin],
+                                aliasToken.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value(
+                                        themeMode = themeMode
+                                )
+                        )
                 )
-            )
         )
     }
 
@@ -122,13 +122,13 @@ open class FABTokens : ControlTokens, Parcelable {
         return when (fabInfo.size) {
             FABSize.Small ->
                 PaddingValues(
-                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
+                        horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                        vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Small]
                 )
             FABSize.Large ->
                 PaddingValues(
-                    horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                    vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
+                        horizontal = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                        vertical = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
                 )
         }
     }
@@ -138,17 +138,17 @@ open class FABTokens : ControlTokens, Parcelable {
         return when (fabInfo.size) {
             FABSize.Small ->
                 PaddingValues(
-                    top = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                    bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                    start = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
-                    end = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
+                        top = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                        bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                        start = globalTokens.spacing[GlobalTokens.SpacingTokens.Small],
+                        end = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium]
                 )
             FABSize.Large ->
                 PaddingValues(
-                    top = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                    bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                    start = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
-                    end = globalTokens.spacing[GlobalTokens.SpacingTokens.Large]
+                        top = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                        bottom = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                        start = globalTokens.spacing[GlobalTokens.SpacingTokens.Medium],
+                        end = globalTokens.spacing[GlobalTokens.SpacingTokens.Large]
                 )
         }
     }
@@ -180,11 +180,11 @@ open class FABTokens : ControlTokens, Parcelable {
     @Composable
     open fun elevation(fabInfo: FABInfo): StateElevation {
         return StateElevation(
-            rest = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow08],
-            pressed = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
-            selected = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
-            focused = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
-            disabled = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02]
+                rest = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow08],
+                pressed = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
+                selected = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
+                focused = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02],
+                disabled = globalTokens.elevation[GlobalTokens.ShadowTokens.Shadow02]
         )
     }
 }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/Button.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/Button.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -19,7 +18,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
-import com.microsoft.fluentui.theme.token.ControlType
+import com.microsoft.fluentui.theme.token.ControlTokens.ControlType
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonInfo
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonSize
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonStyle
@@ -30,39 +29,37 @@ val LocalButtonInfo = compositionLocalOf { ButtonInfo() }
 
 @Composable
 fun Button(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    style: ButtonStyle = ButtonStyle.Button,
-    size: ButtonSize = ButtonSize.Medium,
-    enabled: Boolean = true,
-    buttonTokens: ButtonTokens? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    icon: ImageVector? = null,
-    text: String? = null
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        style: ButtonStyle = ButtonStyle.Button,
+        size: ButtonSize = ButtonSize.Medium,
+        enabled: Boolean = true,
+        buttonTokens: ButtonTokens? = null,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        icon: ImageVector? = null,
+        text: String? = null
 ) {
-    val token = rememberSaveable {
-        (buttonTokens ?: FluentTheme.tokens[ControlType.Button] as ButtonTokens)
-    }
+    val token = buttonTokens ?: FluentTheme.controlTokens.tokens[ControlType.Button] as ButtonTokens
 
     CompositionLocalProvider(
-        LocalButtonTokens provides token,
-        LocalButtonInfo provides ButtonInfo(style, size)
+            LocalButtonTokens provides token,
+            LocalButtonInfo provides ButtonInfo(style, size)
     ) {
         val clickAndSemanticsModifier = Modifier.clickable(
-            interactionSource = interactionSource,
-            indication = LocalIndication.current,
-            enabled = enabled,
-            onClickLabel = null,
-            role = Role.Button,
-            onClick = onClick
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
+                enabled = enabled,
+                onClickLabel = null,
+                role = Role.Button,
+                onClick = onClick
         )
         val backgroundColor =
-            backgroundColor(getButtonToken(), getButtonInfo(), enabled, interactionSource)
+                backgroundColor(getButtonToken(), getButtonInfo(), enabled, interactionSource)
         val contentPadding = getButtonToken().padding(getButtonInfo())
         val iconSpacing = getButtonToken().spacing(getButtonInfo())
         val shape = RoundedCornerShape(getButtonToken().borderRadius(getButtonInfo()))
         val borders: List<BorderStroke> =
-            borderStroke(getButtonToken(), getButtonInfo(), enabled, interactionSource)
+                borderStroke(getButtonToken(), getButtonInfo(), enabled, interactionSource)
 
         var borderModifier: Modifier = Modifier
         var borderWidth = 0.dp
@@ -72,55 +69,55 @@ fun Button(
         }
 
         Box(
-            modifier
-                .height(getButtonToken().fixedHeight(getButtonInfo()))
-                .background(
-                    color = backgroundColor,
-                    shape = shape
-                )
-                .clip(shape)
-                .then(borderModifier)
-                .then(clickAndSemanticsModifier),
-            propagateMinConstraints = true
+                modifier
+                        .height(getButtonToken().fixedHeight(getButtonInfo()))
+                        .background(
+                                color = backgroundColor,
+                                shape = shape
+                        )
+                        .clip(shape)
+                        .then(borderModifier)
+                        .then(clickAndSemanticsModifier),
+                propagateMinConstraints = true
         ) {
             Row(
-                Modifier.padding(contentPadding),
-                horizontalArrangement = Arrangement.spacedBy(
-                    iconSpacing,
-                    Alignment.CenterHorizontally
-                ),
-                verticalAlignment = Alignment.CenterVertically
+                    Modifier.padding(contentPadding),
+                    horizontalArrangement = Arrangement.spacedBy(
+                            iconSpacing,
+                            Alignment.CenterHorizontally
+                    ),
+                    verticalAlignment = Alignment.CenterVertically
             ) {
 
                 if (icon != null)
                     Icon(
-                        imageVector = icon,
-                        contentDescription = text,
-                        modifier = Modifier.size(
-                            getButtonToken().iconSize(buttonInfo = getButtonInfo()).size
-                        ),
-                        tint = iconColor(
-                            getButtonToken(),
-                            getButtonInfo(),
-                            enabled,
-                            interactionSource
-                        )
+                            imageVector = icon,
+                            contentDescription = text,
+                            modifier = Modifier.size(
+                                    getButtonToken().iconSize(buttonInfo = getButtonInfo()).size
+                            ),
+                            tint = iconColor(
+                                    getButtonToken(),
+                                    getButtonInfo(),
+                                    enabled,
+                                    interactionSource
+                            )
                     )
 
                 if (text != null)
                     Text(
-                        text = text,
-                        fontSize = getButtonToken().fontInfo(getButtonInfo()).fontSize.size,
-                        lineHeight = getButtonToken().fontInfo(getButtonInfo()).fontSize.lineHeight,
-                        fontWeight = getButtonToken().fontInfo(getButtonInfo()).weight,
-                        color = textColor(
-                            getButtonToken(),
-                            getButtonInfo(),
-                            enabled,
-                            interactionSource
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                            text = text,
+                            fontSize = getButtonToken().fontInfo(getButtonInfo()).fontSize.size,
+                            lineHeight = getButtonToken().fontInfo(getButtonInfo()).fontSize.lineHeight,
+                            fontWeight = getButtonToken().fontInfo(getButtonInfo()).weight,
+                            color = textColor(
+                                    getButtonToken(),
+                                    getButtonInfo(),
+                                    enabled,
+                                    interactionSource
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                     )
             }
         }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/FloatingActionButton.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/FloatingActionButton.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -19,7 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
-import com.microsoft.fluentui.theme.token.ControlType
+import com.microsoft.fluentui.theme.token.ControlTokens.ControlType
 import com.microsoft.fluentui.theme.token.controlTokens.FABInfo
 import com.microsoft.fluentui.theme.token.controlTokens.FABSize
 import com.microsoft.fluentui.theme.token.controlTokens.FABState
@@ -43,9 +42,8 @@ fun FloatingActionButton(
     if (icon == null && (text == null && text == ""))
         return
 
-    val token = rememberSaveable {
-        (fabTokens ?: FluentTheme.tokens[ControlType.FloatingActionButton] as FABTokens)
-    }
+    val token = fabTokens
+            ?: FluentTheme.controlTokens.tokens[ControlType.FloatingActionButton] as FABTokens
 
     CompositionLocalProvider(
             LocalFABTokens provides token,

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/button/Utils.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/button/Utils.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import com.microsoft.fluentui.theme.token.ControlInfo
-import com.microsoft.fluentui.theme.token.ControlTokens
+import com.microsoft.fluentui.theme.token.ControlToken
 import com.microsoft.fluentui.theme.token.StateBorderStroke
 import com.microsoft.fluentui.theme.token.StateColor
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonInfo
@@ -20,9 +20,9 @@ import java.security.InvalidParameterException
 
 @Composable
 fun getColorByState(
-    stateData: StateColor,
-    enabled: Boolean,
-    interactionSource: InteractionSource
+        stateData: StateColor,
+        enabled: Boolean,
+        interactionSource: InteractionSource
 ): Color {
     if (enabled) {
         val isPressed by interactionSource.collectIsPressedAsState()
@@ -44,68 +44,68 @@ fun getColorByState(
 
 @Composable
 fun backgroundColor(
-    tokens: ControlTokens,
-    info: ControlInfo,
-    enabled: Boolean,
-    interactionSource: InteractionSource
+        tokens: ControlToken,
+        info: ControlInfo,
+        enabled: Boolean,
+        interactionSource: InteractionSource
 ): Color {
     val backgroundColors: StateColor =
-        when (tokens) {
-            is ButtonTokens -> tokens.backgroundColor(info as ButtonInfo)
-            is FABTokens -> tokens.backgroundColor(info as FABInfo)
-            else -> throw InvalidParameterException()
-        }
+            when (tokens) {
+                is ButtonTokens -> tokens.backgroundColor(info as ButtonInfo)
+                is FABTokens -> tokens.backgroundColor(info as FABInfo)
+                else -> throw InvalidParameterException()
+            }
 
     return getColorByState(backgroundColors, enabled, interactionSource)
 }
 
 @Composable
 fun iconColor(
-    tokens: ControlTokens,
-    info: ControlInfo,
-    enabled: Boolean,
-    interactionSource: InteractionSource
+        tokens: ControlToken,
+        info: ControlInfo,
+        enabled: Boolean,
+        interactionSource: InteractionSource
 ): Color {
     val iconColors: StateColor =
-        when (tokens) {
-            is ButtonTokens -> tokens.iconColor(info as ButtonInfo)
-            is FABTokens -> tokens.iconColor(info as FABInfo)
-            else -> throw InvalidParameterException()
-        }
+            when (tokens) {
+                is ButtonTokens -> tokens.iconColor(info as ButtonInfo)
+                is FABTokens -> tokens.iconColor(info as FABInfo)
+                else -> throw InvalidParameterException()
+            }
 
     return getColorByState(iconColors, enabled, interactionSource)
 }
 
 @Composable
 fun textColor(
-    tokens: ControlTokens,
-    info: ControlInfo,
-    enabled: Boolean,
-    interactionSource: InteractionSource
+        tokens: ControlToken,
+        info: ControlInfo,
+        enabled: Boolean,
+        interactionSource: InteractionSource
 ): Color {
     val textColors: StateColor =
-        when (tokens) {
-            is ButtonTokens -> tokens.textColor(info as ButtonInfo)
-            is FABTokens -> tokens.textColor(info as FABInfo)
-            else -> throw InvalidParameterException()
-        }
+            when (tokens) {
+                is ButtonTokens -> tokens.textColor(info as ButtonInfo)
+                is FABTokens -> tokens.textColor(info as FABInfo)
+                else -> throw InvalidParameterException()
+            }
 
     return getColorByState(textColors, enabled, interactionSource)
 }
 
 @Composable
 fun borderStroke(
-    tokens: ControlTokens,
-    info: ControlInfo,
-    enabled: Boolean,
-    interactionSource: InteractionSource
+        tokens: ControlToken,
+        info: ControlInfo,
+        enabled: Boolean,
+        interactionSource: InteractionSource
 ): List<BorderStroke> {
     val fetchBorderStroke: StateBorderStroke =
-        when (tokens) {
-            is ButtonTokens -> tokens.borderStroke(info as ButtonInfo)
-            is FABTokens -> tokens.borderStroke(info as FABInfo)
-            else -> throw InvalidParameterException()
-        }
+            when (tokens) {
+                is ButtonTokens -> tokens.borderStroke(info as ButtonInfo)
+                is FABTokens -> tokens.borderStroke(info as FABInfo)
+                else -> throw InvalidParameterException()
+            }
 
     if (enabled) {
         val isPressed by interactionSource.collectIsPressedAsState()


### PR DESCRIPTION
Theme Customization for Fluent UI V2.

Fluent UI V2 Android allows 3 levels of customization:
1. App Level
2. Activity Level
3. Control Instance Level

Using View Model as Singleton helps us to achieve app level singularity in theme. Activity/Scope Level customization is performed using the theme wrapper around content. Control/Instance level customization is achieved by passing a control token which has a higher priority than saved token. 

In this change we have saved Fluent Default Control tokens to avoid getting NPE.

Performed Code Formatting/Optimise Import checks via Android Studio