### PR TITLE
Dimens-Removing listitems dimens dependency for persona

### DIFF
--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -56,7 +56,7 @@ android {
             dimension 'distribution'
             applicationIdSuffix '.df'
             signingConfig signingConfigs.dogfood
-            buildConfigField "String", "APP_CENTER_SECRET", project.hasProperty("appCenterSecret") ? "\"$appCenterSecret\"" : ""
+            buildConfigField "String", "APP_CENTER_SECRET", project.hasProperty("appCenterSecret") ? "\"$appCenterSecret\"" : "\"\""
         }
     }
 }

--- a/fluentui_persona/src/main/res/values/dimens.xml
+++ b/fluentui_persona/src/main/res/values/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="fluentui_avatar_stack_space_xlarge">14dp</dimen>
     <dimen name="fluentui_avatar_stack_space_xxlarge">16dp</dimen>
     <!--Persona-->
-    <dimen name="fluentui_persona_horizontal_spacing">@dimen/fluentui_list_item_spacing</dimen>
-    <dimen name="fluentui_persona_horizontal_padding">@dimen/fluentui_list_item_horizontal_margin_regular</dimen>
+    <dimen name="fluentui_persona_horizontal_spacing">16dp</dimen>
+    <dimen name="fluentui_persona_horizontal_padding">@dimen/fluentui_content_inset</dimen>
 
     <!--PersonaChip-->
     <dimen name="fluentui_persona_chip_height">32dp</dimen>


### PR DESCRIPTION
### Platforms Impacted
- [x] Android

### Description of changes

Dimens-Removing listitems dimens dependency from persona
Fix syntax issue in build.gradle for appcenterscret variable

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)