### PR TITLE
Shwshar1508 searchbar action view fix

### DIFF
--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
@@ -18,6 +18,7 @@ import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.LinearLayout
+import android.widget.RelativeLayout
 import com.microsoft.fluentui.topappbars.R
 import com.microsoft.fluentui.appbarlayout.AppBarLayout
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
@@ -148,7 +149,7 @@ open class Searchbar : TemplateView, SearchView.OnQueryTextListener {
 
     override val templateId: Int = R.layout.view_searchbar
 
-    private var searchbar: FrameLayout? = null
+    private var searchbar: RelativeLayout? = null
     private var searchViewContainer: LinearLayout? = null
     private var searchIcon: ImageView? = null
     private var searchBackButton: ImageButton? = null
@@ -307,7 +308,7 @@ open class Searchbar : TemplateView, SearchView.OnQueryTextListener {
         )
 
         // Search view container
-        val searchViewContainerLayoutParams = searchViewContainer?.layoutParams as? FrameLayout.LayoutParams
+        val searchViewContainerLayoutParams = searchViewContainer?.layoutParams as? RelativeLayout.LayoutParams
         val searchViewContainerMarginStartResourceId = if (hasFocus() || isActionMenuView) {
             if (isActionMenuView)
                 R.dimen.fluentui_searchbar_search_view_action_view_margin_start

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/search/Searchbar.kt
@@ -277,7 +277,7 @@ open class Searchbar : TemplateView, SearchView.OnQueryTextListener {
         else
             R.dimen.fluentui_searchbar_search_view_container_margin_end
 
-        val lp = searchViewContainer?.layoutParams as? FrameLayout.LayoutParams ?: return
+        val lp = searchViewContainer?.layoutParams as? RelativeLayout.LayoutParams ?: return
         lp.marginEnd = context.resources.getDimension(searchViewContainerMarginEndResourceId).toInt()
         searchViewContainer?.layoutParams = lp
     }

--- a/fluentui_topappbars/src/main/res/layout/view_searchbar.xml
+++ b/fluentui_topappbars/src/main/res/layout/view_searchbar.xml
@@ -4,7 +4,7 @@
   ~ Licensed under the MIT License.
   -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/searchbar"
@@ -92,4 +92,4 @@
 
     </LinearLayout>
 
-</FrameLayout>
+</RelativeLayout>


### PR DESCRIPTION
### Platforms Impacted
- [ ] Android

### Description of changes

These change fix the bug in AppBarLayout, 
SearchBar -> ActionView type -> tap on search icon and start typing the text, cancel button appears at the center of the search bar instead of being at the right most ie. at the end of the SearchBar
We changed the root Layout from FrameLayout to RelativeLayout to fix this issue

### Verification

These changes are tested on Emulator Nexus 9 tablet, Samsung tablet and Pixel 4 emulator

Before screenshot:

![Screenshot 2022-09-08 at 2 14 10 PM](https://user-images.githubusercontent.com/112982033/189077885-d71eeb1b-a8db-4f2b-8814-6593775a8282.png)


After Screenshot:

![Screenshot 2022-09-08 at 2 09 45 PM](https://user-images.githubusercontent.com/112982033/189077945-3542733c-3032-4e61-9661-516de82e3ecf.png)


This bug is more evident for Tablet devices