### PR TITLE
Shwshar1508/people picker bug fix

### DIFF
--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerView.kt
@@ -125,6 +125,20 @@ class PeoplePickerView : TemplateView {
             field = value
             updateViews()
         }
+
+    /**
+     * Custom width for drop down suggestion Personas List
+     * For tablet requirement, client might need to paas WRAP_CONTENT as per their design need
+     * default value would be MATCH_PARENT here
+     */
+    var customDropDownWidth: Int = LayoutParams.MATCH_PARENT
+        set(value) {
+            if (field == value)
+                return
+            field = value
+            updateViews()
+        }
+
     /**
      * Collapse the [PeoplePickerTextView] to a single line when it loses focus.
      */
@@ -238,7 +252,10 @@ class PeoplePickerView : TemplateView {
             PeoplePickerPersonaChipClickStyle.SELECT.ordinal
         )
         personaChipClickStyle = PeoplePickerPersonaChipClickStyle.values()[personaChipClickStyleOrdinal]
-
+        customDropDownWidth = styledAttrs.getInt(
+                R.styleable.PeoplePickerView_fluentui_customDropDownWidth,
+                LayoutParams.MATCH_PARENT
+        )
         styledAttrs.recycle()
     }
 
@@ -254,7 +271,7 @@ class PeoplePickerView : TemplateView {
 
         // Fixed properties for TokenCompleteTextView.
         peoplePickerTextView?.apply {
-            dropDownWidth = ViewGroup.LayoutParams.MATCH_PARENT
+            dropDownWidth = customDropDownWidth
             allowCollapse = this@PeoplePickerView.allowCollapse
             isLongClickable = true
             setTokenListener(TokenListener(this@PeoplePickerView))
@@ -307,9 +324,25 @@ class PeoplePickerView : TemplateView {
     private fun updateViews() {
         if(label.isBlank()) {
             labelTextView?.visibility = GONE
+            peoplePickerTextView?.let {
+                it.setPaddingRelative(
+                        resources.getDimensionPixelSize(R.dimen.fluentui_people_picker_horizontal_padding),
+                        it.paddingTop,
+                        it.paddingEnd,
+                        it.paddingBottom
+                )
+            }
         } else {
             labelTextView?.visibility = VISIBLE
             labelTextView?.text = label
+            peoplePickerTextView?.let {
+                it.setPaddingRelative(
+                        0,
+                        it.paddingTop,
+                        it.paddingEnd,
+                        it.paddingBottom
+                )
+            }
         }
         peoplePickerTextView?.apply {
             valueHint = this@PeoplePickerView.valueHint

--- a/fluentui_peoplepicker/src/main/res/layout/view_people_picker.xml
+++ b/fluentui_peoplepicker/src/main/res/layout/view_people_picker.xml
@@ -13,9 +13,7 @@
     android:layout_marginBottom="@dimen/fluentui_people_picker_vertical_padding"
     android:background="?attr/fluentuiPeoplePickerBackgroundColor"
     android:gravity="center_vertical"
-    android:orientation="horizontal"
-    android:paddingStart="@dimen/fluentui_people_picker_horizontal_padding"
-    android:paddingEnd="@dimen/fluentui_people_picker_horizontal_padding">
+    android:orientation="horizontal">
 
     <TextView
         android:id="@+id/people_picker_label"
@@ -25,6 +23,7 @@
         android:labelFor="@id/people_picker_text_view"
         android:gravity="center_vertical"
         android:minHeight="@dimen/fluentui_min_touch_size"
+        android:paddingStart="@dimen/fluentui_people_picker_horizontal_padding"
         android:textAppearance="@style/TextAppearance.FluentUI.PeoplePickerLabel"
         tools:text="@string/people_picker_sample_label" />
 
@@ -39,6 +38,7 @@
         android:imeOptions="flagNoExtractUi|actionDone"
         android:minHeight="@dimen/fluentui_min_touch_size"
         android:paddingTop="@dimen/fluentui_people_picker_text_view_padding"
+        android:paddingEnd="@dimen/fluentui_people_picker_horizontal_padding"
         android:paddingBottom="@dimen/fluentui_people_picker_text_view_padding"
         android:popupBackground="@drawable/people_picker_popup_background"
         android:popupElevation="@dimen/fluentui_people_picker_popup_elevation"

--- a/fluentui_peoplepicker/src/main/res/values/attrs.xml
+++ b/fluentui_peoplepicker/src/main/res/values/attrs.xml
@@ -28,5 +28,10 @@
         <enum name="select_deselect" value="3"/>
     </attr>
 
+  <!-- fluentui_customDropDownWidth for custom width -->
+   <attr name="fluentui_customDropDownWidth" format="dimension">
+        <enum name="match_parent" value="-1" />
+        <enum name="wrap_content" value="-2" />
+   </attr>
 
 </resources>

--- a/fluentui_peoplepicker/src/main/res/values/attrs_people_picker.xml
+++ b/fluentui_peoplepicker/src/main/res/values/attrs_people_picker.xml
@@ -11,5 +11,6 @@
         <attr name="fluentui_showHint"/>
         <attr name="fluentui_characterThreshold"/>
         <attr name="fluentui_personaChipClickStyle"/>
+        <attr name="fluentui_customDropDownWidth"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
### Platforms Impacted
- Android

### Description of changes

Width of dropDownList of Persona Suggestions can be either WRAP_CONTENT or MATCH_PARENT now

Client can pass this as param in **fluentui_customDropDownWidth**

Before it was set to MATCH_PARENT hard code
Default value will still be MATCH_PARENT

There are also few changes regarding padding, in case when client is not using Label 

### Verification
these changes are tested on Nexus 9 tablet and Pixel 4 simulator
Attaching after changes screenshot of Mobile and tablet from List Android Client app

![Screenshot 2022-09-26 at 2 32 27 PM](https://user-images.githubusercontent.com/112982033/192236767-3676f299-e10e-4a43-bf2f-1cfbd80ccf83.png)

