### PR TITLE
Remove unused tokenautocomplete dependency from calendar and others modules

### DIFF
--- a/fluentui_calendar/build.gradle
+++ b/fluentui_calendar/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     implementation "com.google.android.material:material:$materialVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.jakewharton.threetenabp:threetenabp:$threetenabpVersion"
-    implementation "com.splitwise:tokenautocomplete:$tokenautocompleteVersion"
     implementation "com.microsoft.device:dualscreen-layout:$duoVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$extJunitVersion"

--- a/fluentui_others/build.gradle
+++ b/fluentui_others/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     implementation "com.google.android.material:material:$materialVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.jakewharton.threetenabp:threetenabp:$threetenabpVersion"
-    implementation "com.splitwise:tokenautocomplete:$tokenautocompleteVersion"
     implementation "com.microsoft.device:dualscreen-layout:$duoVersion"
 
     testImplementation "junit:junit:$junitVersion"


### PR DESCRIPTION
## Overview

Remove unused `tokenautocomplete` dependency from calendar and others modules

This allows consuming apps that do not also use peoplepicker to drop Jetifier.

### Platforms Impacted
- [x] Android

### Description of changes

Removes `com.splitwise.tokenautocomplete` dependency from `fluentui_calendar` and `fluentuiothers` modules. It is still legitimately used in the `peoplepicker` module however.

AFAICT when #93 was merged, this should have been removed then, but was missed.

The `2.X` and `3.X` version of this library still use Android Support libs under the hood, so this is stopping consumers of Fluent from dropping Jetifier (which slows down compile times). The `peoplepicker` module still uses this library.

#193 attempts to bump the version but the `4.X` release is still in pre-release (and that is 15+ months old, so I am doubtful it will see the time of day).

So as long as apps are consuming the modules (as opposed to the entire `FluentUi` package and _don't_ use `peoplepicker`, this should allow them to drop Jetifier.

### Verification

- Validated building of the respective modules, and the demo app.

- [Screencast](https://drive.google.com/file/d/1hRPZSDFvnq7nnCmWuXONIdyXX3TcnVa6/view?usp=sharing) of the Calendar, AppBarLayout, Bottom Nav controls in the demo app (AFAICT the relevant controls for these modules) 

### Pull request checklist

This PR has considered:
~~- [ ] Light and Dark appearances~~
~~- [ ] VoiceOver and Keyboard Accessibility~~
~~- [ ] Internationalization and Right to Left layouts~~
~~- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)~~