### PR TITLE
PeoplePickerView bug fix.

### DIFF
--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/persona/AvatarView.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/persona/AvatarView.kt
@@ -15,7 +15,6 @@ import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import androidx.appcompat.widget.AppCompatImageView
 import android.util.AttributeSet
-import android.util.Log
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
 
 enum class AvatarStyle {
@@ -285,6 +284,14 @@ open class AvatarView : AppCompatImageView {
             super.setImageDrawable(drawable)
     }
 
+    fun clearAvatarImage(){
+        avatarImageBitmap = null
+        avatarImageDrawable = null
+        avatarImageResourceId = null
+        avatarImageUri = null
+        super.setImageDrawable(null)
+    }
+
     override fun setImageBitmap(bitmap: Bitmap?) {
         if (bitmap == null)
             return
@@ -337,6 +344,7 @@ open class AvatarView : AppCompatImageView {
 }
 
 fun AvatarView.setAvatar(avatar: IAvatar) {
+    clearAvatarImage()
     name = avatar.name
     email = avatar.email
     avatarImageBitmap = avatar.avatarImageBitmap

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/persona/PersonaView.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/persona/PersonaView.kt
@@ -125,6 +125,14 @@ class PersonaView : ListItemView {
 
     private val avatarView = AvatarView(context)
 
+    fun clearAvatarImage(){
+        avatarImageBitmap = null
+        avatarImageDrawable = null
+        avatarImageResourceId = null
+        avatarImageUri = null
+        avatarView.clearAvatarImage()
+    }
+
     @JvmOverloads
     constructor(appContext: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(appContext, attrs, defStyleAttr) {
         val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.PersonaView)
@@ -185,6 +193,7 @@ class PersonaView : ListItemView {
 }
 
 fun PersonaView.setPersona(persona: IPersona) {
+    clearAvatarImage()
     name = persona.name
     email = persona.email
     subtitle = persona.subtitle


### PR DESCRIPTION
Clear avatar image before setting it in PersonaView & AvatarView. With this PeoplePickerView persona list update with correct avatar in PersonaView on change of query text.

Before:

https://user-images.githubusercontent.com/97503451/210718964-181603e5-b1e0-4170-bf54-2e4ef17f653c.mp4

After:

https://user-images.githubusercontent.com/97503451/210719089-37c03f7d-20cc-4238-986e-4c5111f40fef.mp4



