### PR TITLE
listitem fixes

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -32,6 +32,7 @@ import com.microsoft.fluentui.tokenized.persona.Avatar
 import com.microsoft.fluentui.tokenized.persona.AvatarGroup
 import com.microsoft.fluentui.tokenized.persona.Group
 import com.microsoft.fluentui.tokenized.persona.Person
+import com.microsoft.fluentui.tokenized.progress.LinearProgressIndicator
 import com.microsoft.fluentuidemo.DemoActivity
 import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.R.drawable
@@ -527,7 +528,7 @@ fun ThreeLineListAccessoryViewContent(
             text = primaryText,
             subText = secondaryText,
             secondarySubText = tertiaryText,
-            progressIndicator = { ProgressBar() },
+            progressIndicator = { LinearProgressIndicator() },
             primaryTextLeadingIcons = oneTextIcon20(),
             secondarySubTextTailingIcons = twoTextIcons16(),
             leadingAccessoryView = { LeftViewAvatar(Size56) },

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -118,6 +118,9 @@ open class ListItemTokens : ControlToken, Parcelable {
                     ),
                     disabled = FluentTheme.aliasTokens.neutralForegroundColor[ForegroundDisable1].value(
                         themeMode = FluentTheme.themeMode
+                    ),
+                    pressed = FluentTheme.aliasTokens.neutralForegroundColor[Foreground1].value(
+                        themeMode = FluentTheme.themeMode
                     )
                 )
 
@@ -128,6 +131,9 @@ open class ListItemTokens : ControlToken, Parcelable {
                     ),
                     disabled = FluentTheme.aliasTokens.neutralForegroundColor[ForegroundDisable1].value(
                         themeMode = FluentTheme.themeMode
+                    ),
+                    pressed = FluentTheme.aliasTokens.neutralForegroundColor[Foreground2].value(
+                        themeMode = FluentTheme.themeMode
                     )
                 )
             SubText ->
@@ -136,6 +142,9 @@ open class ListItemTokens : ControlToken, Parcelable {
                         themeMode = FluentTheme.themeMode
                     ),
                     disabled = FluentTheme.aliasTokens.neutralForegroundColor[ForegroundDisable1].value(
+                        themeMode = FluentTheme.themeMode
+                    ),
+                    pressed = FluentTheme.aliasTokens.neutralForegroundColor[Foreground2].value(
                         themeMode = FluentTheme.themeMode
                     )
                 )
@@ -146,6 +155,9 @@ open class ListItemTokens : ControlToken, Parcelable {
                     ),
                     disabled = FluentTheme.aliasTokens.neutralForegroundColor[ForegroundDisable1].value(
                         themeMode = FluentTheme.themeMode
+                    ),
+                    pressed = FluentTheme.aliasTokens.neutralForegroundColor[Foreground2].value(
+                        themeMode = FluentTheme.themeMode
                     )
                 )
             ActionText -> StateColor(
@@ -154,6 +166,9 @@ open class ListItemTokens : ControlToken, Parcelable {
                 ),
                 disabled = FluentTheme.aliasTokens.brandForegroundColor[BrandForegroundDisabled1].value(
                     themeMode = FluentTheme.themeMode
+                ),
+                pressed = FluentTheme.aliasTokens.brandForegroundColor[BrandForeground1].value(
+                    themeMode = FluentTheme.themeMode
                 )
             )
             DescriptionText -> StateColor(
@@ -161,6 +176,9 @@ open class ListItemTokens : ControlToken, Parcelable {
                     themeMode = FluentTheme.themeMode
                 ),
                 disabled = FluentTheme.aliasTokens.neutralForegroundColor[ForegroundDisable1].value(
+                    themeMode = FluentTheme.themeMode
+                ),
+                pressed = FluentTheme.aliasTokens.neutralForegroundColor[Foreground3].value(
                     themeMode = FluentTheme.themeMode
                 )
             )

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
-import androidx.compose.material.Icon
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -23,12 +21,12 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.*
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.*
 import com.microsoft.fluentui.icons.ListItemIcons
 import com.microsoft.fluentui.icons.listitemicons.Chevron
 import com.microsoft.fluentui.theme.FluentTheme
@@ -108,6 +106,28 @@ object ListItem {
 
     }
 
+    /*
+    This function calculates the placeholder width for action text
+     */
+    @Composable
+    fun PlaceholderForActionText(
+        actionTextComposable: @Composable () -> Unit,
+        content: @Composable (width: Dp) -> Unit,
+    ) {
+        SubcomposeLayout { constraints ->
+            val calculatedWidth = subcompose("textToCalculate", actionTextComposable)[0]
+                .measure(Constraints()).width.toDp()
+
+            val contentPlaceable = subcompose("inlineText") {
+                content(calculatedWidth)
+            }[0].measure(constraints)
+            layout(contentPlaceable.width, contentPlaceable.height) {
+                contentPlaceable.place(0, 0)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
     @Composable
     private fun InlineText(
         description: String,
@@ -116,51 +136,65 @@ object ListItem {
         descriptionTextColor: Color,
         actionTextColor: Color,
         descriptionTextSize: FontInfo,
-        actionTextSize: FontInfo
+        actionTextSize: FontInfo,
+        backgroundColor: Color
     ) {
-        val text = buildAnnotatedString {
-            if (description.isNotEmpty()) {
-                withStyle(
-                    style = SpanStyle(
-                        color = descriptionTextColor,
-                        fontSize = descriptionTextSize.fontSize.size,
-                        fontWeight = descriptionTextSize.weight
-                    )
-                ) {
-                    append("$description ")
-                }
+        PlaceholderForActionText(
+            actionTextComposable = {
+                Text(
+                    text = actionText,
+                    fontSize = actionTextSize.fontSize.size,
+                    fontWeight = actionTextSize.weight
+                )
             }
-            appendInlineContent(actionText, "text")
+        ) { measuredWidth ->
+            val text = buildAnnotatedString {
+                if (description.isNotEmpty()) {
+                    withStyle(
+                        style = SpanStyle(
+                            color = descriptionTextColor,
+                            fontSize = descriptionTextSize.fontSize.size,
+                            fontWeight = descriptionTextSize.weight
+                        )
+                    ) {
+                        append("$description ")
+                    }
+                }
+                appendInlineContent(actionText, actionText)
+            }
+            val widthInDp: TextUnit = with(LocalDensity.current) {
+                measuredWidth.toSp()
+            }
+            val inlineContent = mapOf(
+                Pair(
+                    actionText,
+                    InlineTextContent(
+                        Placeholder(
+                            width = widthInDp,
+                            height = 16.sp,
+                            placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+                        )
+                    ) {
+                        Surface(
+                            onClick = onClick,
+                            color = backgroundColor
+                        ) {
+                            Text(
+                                text = actionText,
+                                fontSize = actionTextSize.fontSize.size,
+                                fontWeight = actionTextSize.weight,
+                                color = actionTextColor
+                            )
+                        }
+                    }
+                )
+            )
+            Text(
+                text = text,
+                inlineContent = inlineContent
+            )
         }
 
-        val inlineContent = mapOf(
-            Pair(
-                actionText,
-                InlineTextContent(
-                    Placeholder(
-                        width = 50.sp,
-                        height = 20.sp,
-                        placeholderVerticalAlign = PlaceholderVerticalAlign.TextTop
-                    )
-                ) {
-                    Text(
-                        text = actionText,
-                        modifier = Modifier.clickable(
-                            enabled = true,
-                            onClickLabel = actionText,
-                            role = Role.Button,
-                            onClick = onClick
-                        ),
-                        fontSize = actionTextSize.fontSize.size,
-                        color = actionTextColor
-                    )
-                }
-            )
-        )
-        Text(
-            text = text,
-            inlineContent = inlineContent
-        )
     }
 
     /**
@@ -680,7 +714,8 @@ object ListItem {
                             actionTextSize = actionTextSize,
                             actionTextColor = actionTextColor,
                             descriptionTextColor = textColor,
-                            descriptionTextSize = textSize
+                            descriptionTextSize = textSize,
+                            backgroundColor = backgroundColor
                         )
                     } else {
                         Text(

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -160,14 +160,15 @@ object ListItem {
                         append("$description ")
                     }
                 }
-                appendInlineContent(actionText, actionText)
+                //below alternate text will be replaced by composable
+                appendInlineContent("key", actionText)
             }
             val widthInDp: TextUnit = with(LocalDensity.current) {
                 measuredWidth.toSp()
             }
             val inlineContent = mapOf(
                 Pair(
-                    actionText,
+                    "key",
                     InlineTextContent(
                         Placeholder(
                             width = widthInDp,
@@ -706,7 +707,7 @@ object ListItem {
                         .padding(verticalPadding)
                         .weight(1f)
                 ) {
-                    if (actionText != null) {
+                    if (!actionText.isNullOrBlank()) {
                         InlineText(
                             description = description,
                             actionText = actionText,


### PR DESCRIPTION
### Platforms Impacted
- [ ] Android

### Description of changes
Fixed bug: 7152975
Fixed issue with perosna and lisitem: text color wrong on pressed state
Fixed issue with lisitem, sectiondescription action text placeholder width
Added fluent progressbar in the listitem activity
(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)