### PR TITLE
Implementation for TextField

### DIFF
--- a/FluentUI.Demo/src/main/AndroidManifest.xml
+++ b/FluentUI.Demo/src/main/AndroidManifest.xml
@@ -49,6 +49,9 @@
         <activity android:name="com.microsoft.fluentuidemo.demos.V2SegmentedControlActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2SnackbarActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2TabBarActivity" />
+        <activity
+            android:name="com.microsoft.fluentuidemo.demos.V2TextFieldActivity"
+            android:windowSoftInputMode="adjustResize" />
         <activity android:name="com.microsoft.fluentuidemo.demos.ActionBarLayoutActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.AppBarLayoutActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.AvatarViewActivity" />

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/Demos.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/Demos.kt
@@ -31,6 +31,7 @@ const val V2SEARCHBAR = "V2 SearchBar"
 const val V2SEGMENTED_CONTROL = "V2 SegmentedControl"
 const val V2SNACKBAR = "V2 Snackbar"
 const val V2TABBAR = "V2 TabBar"
+const val V2TEXTFIELD = "V2 TextField"
 const val ACTION_BAR_LAYOUT = "ActionBarLayout"
 const val APP_BAR_LAYOUT = "AppBarLayout"
 const val V2APP_BAR_LAYOUT = "V2 AppBarLayout"
@@ -79,6 +80,7 @@ val DEMOS = arrayListOf(
     Demo(V2SEGMENTED_CONTROL, V2SegmentedControlActivity::class),
     Demo(V2SNACKBAR, V2SnackbarActivity::class),
     Demo(V2TABBAR, V2TabBarActivity::class),
+    Demo(V2TEXTFIELD, V2TextFieldActivity::class),
     Demo(ACTION_BAR_LAYOUT, ActionBarLayoutActivity::class),
     Demo(APP_BAR_LAYOUT, AppBarLayoutActivity::class),
     Demo(AVATAR_VIEW, AvatarViewActivity::class),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -267,8 +267,8 @@ class V2TextFieldActivity : DemoActivity() {
                             hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
                             label = if (label) resources.getString(R.string.fluentui_label) else null,
                             assistiveText = if (assistiveText) resources.getString(R.string.fluentui_assistive_text) else null,
-                            leadingPrimaryIcon = if (leftIcon) Icons.Outlined.Email else null,
-                            leadingSecondaryIcon = if (leftIcon) Icons.Filled.Email else null,
+                            leadingRestIcon = if (leftIcon) Icons.Outlined.Email else null,
+                            leadingFocusIcon = if (leftIcon) Icons.Filled.Email else null,
                             trailingAccessoryText = if (secondaryText) resources.getString(R.string.fluentui_secondary) else null,
                             errorString = if (errorText) resources.getString(R.string.fluentui_error_string) else null,
                             trailingAccessoryIcon = FluentIcon(

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -13,11 +13,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.outlined.Email
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -27,6 +24,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.microsoft.fluentui.icons.SearchBarIcons
 import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
+import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.tokenized.controls.TextField
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
@@ -66,218 +64,222 @@ class V2TextFieldActivity : DemoActivity() {
 
             val resources = LocalContext.current.resources
 
-            Column {
-                ListItem.SectionHeader(
-                    title = getDemoAppString(DemoAppStrings.ModifiableParameters),
-                    enableChevron = true,
-                    enableContentOpenCloseTransition = true,
-                    chevronOrientation = ChevronOrientation(90f, 0f),
-                ) {
-                    LazyColumn(Modifier.fillMaxHeight(0.5F)) {
-                        item {
-                            PillBar(
-                                mutableListOf(
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_text),
-                                        onClick = { keyboardType = KeyboardType.Text },
-                                        selected = keyboardType == KeyboardType.Text
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_ascii),
-                                        onClick = { keyboardType = KeyboardType.Ascii },
-                                        selected = keyboardType == KeyboardType.Ascii
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_number),
-                                        onClick = { keyboardType = KeyboardType.Number },
-                                        selected = keyboardType == KeyboardType.Number
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_phone),
-                                        onClick = { keyboardType = KeyboardType.Phone },
-                                        selected = keyboardType == KeyboardType.Phone
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_uri),
-                                        onClick = { keyboardType = KeyboardType.Uri },
-                                        selected = keyboardType == KeyboardType.Uri
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_email),
-                                        onClick = { keyboardType = KeyboardType.Email },
-                                        selected = keyboardType == KeyboardType.Email
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_password),
-                                        onClick = { keyboardType = KeyboardType.Password },
-                                        selected = keyboardType == KeyboardType.Password
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_number_password),
-                                        onClick = { keyboardType = KeyboardType.NumberPassword },
-                                        selected = keyboardType == KeyboardType.NumberPassword
-                                    ),
-                                    PillMetaData(
-                                        text = resources.getString(R.string.fluentui_keyboard_decimal),
-                                        onClick = { keyboardType = KeyboardType.Decimal },
-                                        selected = keyboardType == KeyboardType.Decimal
+            FluentTheme {
+                Column {
+                    ListItem.SectionHeader(
+                        title = getDemoAppString(DemoAppStrings.ModifiableParameters),
+                        enableChevron = true,
+                        enableContentOpenCloseTransition = true,
+                        chevronOrientation = ChevronOrientation(90f, 0f),
+                    ) {
+                        LazyColumn(Modifier.fillMaxHeight(0.5F)) {
+                            item {
+                                PillBar(
+                                    mutableListOf(
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_text),
+                                            onClick = { keyboardType = KeyboardType.Text },
+                                            selected = keyboardType == KeyboardType.Text
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_ascii),
+                                            onClick = { keyboardType = KeyboardType.Ascii },
+                                            selected = keyboardType == KeyboardType.Ascii
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_number),
+                                            onClick = { keyboardType = KeyboardType.Number },
+                                            selected = keyboardType == KeyboardType.Number
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_phone),
+                                            onClick = { keyboardType = KeyboardType.Phone },
+                                            selected = keyboardType == KeyboardType.Phone
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_uri),
+                                            onClick = { keyboardType = KeyboardType.Uri },
+                                            selected = keyboardType == KeyboardType.Uri
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_email),
+                                            onClick = { keyboardType = KeyboardType.Email },
+                                            selected = keyboardType == KeyboardType.Email
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_password),
+                                            onClick = { keyboardType = KeyboardType.Password },
+                                            selected = keyboardType == KeyboardType.Password
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_number_password),
+                                            onClick = {
+                                                keyboardType = KeyboardType.NumberPassword
+                                            },
+                                            selected = keyboardType == KeyboardType.NumberPassword
+                                        ),
+                                        PillMetaData(
+                                            text = resources.getString(R.string.fluentui_keyboard_decimal),
+                                            onClick = { keyboardType = KeyboardType.Decimal },
+                                            selected = keyboardType == KeyboardType.Decimal
+                                        )
                                     )
                                 )
-                            )
-                        }
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_icon),
-                                subText = if (label)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            leftIcon = it
-                                        },
-                                        checkedState = leftIcon
-                                    )
-                                }
-                            )
-                        }
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_icon),
+                                    subText = if (label)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                leftIcon = it
+                                            },
+                                            checkedState = leftIcon
+                                        )
+                                    }
+                                )
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_hint),
-                                subText = if (hintText)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            hintText = it
-                                        },
-                                        checkedState = hintText
-                                    )
-                                }
-                            )
-                        }
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_hint),
+                                    subText = if (hintText)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                hintText = it
+                                            },
+                                            checkedState = hintText
+                                        )
+                                    }
+                                )
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_label),
-                                subText = if (label)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            label = it
-                                        },
-                                        checkedState = label
-                                    )
-                                }
-                            )
-                        }
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_label),
+                                    subText = if (label)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                label = it
+                                            },
+                                            checkedState = label
+                                        )
+                                    }
+                                )
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_assistive_text),
-                                subText = if (label)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            assistiveText = it
-                                        },
-                                        checkedState = assistiveText
-                                    )
-                                }
-                            )
-                        }
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_assistive_text),
+                                    subText = if (label)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                assistiveText = it
+                                            },
+                                            checkedState = assistiveText
+                                        )
+                                    }
+                                )
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_secondary),
-                                subText = if (label)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            secondaryText = it
-                                        },
-                                        checkedState = secondaryText
-                                    )
-                                }
-                            )
-                        }
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_secondary),
+                                    subText = if (label)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                secondaryText = it
+                                            },
+                                            checkedState = secondaryText
+                                        )
+                                    }
+                                )
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_password_mode),
-                                subText = if (label)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            passwordMode = it
-                                        },
-                                        checkedState = passwordMode
-                                    )
-                                }
-                            )
-                        }
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_password_mode),
+                                    subText = if (label)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                passwordMode = it
+                                            },
+                                            checkedState = passwordMode
+                                        )
+                                    }
+                                )
+                            }
 
-                        item {
-                            ListItem.Item(
-                                text = resources.getString(R.string.fluentui_error),
-                                subText = if (label)
-                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                                else
-                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                                trailingAccessoryView = {
-                                    ToggleSwitch(
-                                        onValueChange = {
-                                            errorText = it
-                                        },
-                                        checkedState = errorText
-                                    )
-                                }
-                            )
+                            item {
+                                ListItem.Item(
+                                    text = resources.getString(R.string.fluentui_error),
+                                    subText = if (label)
+                                        LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                    else
+                                        LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                    trailingAccessoryView = {
+                                        ToggleSwitch(
+                                            onValueChange = {
+                                                errorText = it
+                                            },
+                                            checkedState = errorText
+                                        )
+                                    }
+                                )
+                            }
                         }
                     }
-                }
 
-                val focusManager = LocalFocusManager.current
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable { focusManager.clearFocus() }) {
-                    TextField(
-                        value,
-                        { value = it },
-                        hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
-                        label = if (label) resources.getString(R.string.fluentui_label) else null,
-                        assistiveText = if (assistiveText) resources.getString(R.string.fluentui_assistive_text) else null,
-                        leadingPrimaryIcon = if (leftIcon) Icons.Outlined.Email else null,
-                        leadingSecondaryIcon = if (leftIcon) Icons.Filled.Email else null,
-                        trailingAccessoryText = if (secondaryText) resources.getString(R.string.fluentui_secondary) else null,
-                        errorString = if (errorText) resources.getString(R.string.fluentui_error_string) else null,
-                        trailingAccessoryIcon = FluentIcon(
-                            SearchBarIcons.Dismisscircle,
-                            contentDescription = resources.getString(R.string.fluentui_clear_text)
-                        ),
-                        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                        keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
-                        visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
-                    )
+                    val focusManager = LocalFocusManager.current
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable { focusManager.clearFocus() }) {
+                        TextField(
+                            value,
+                            { value = it },
+                            hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
+                            label = if (label) resources.getString(R.string.fluentui_label) else null,
+                            assistiveText = if (assistiveText) resources.getString(R.string.fluentui_assistive_text) else null,
+                            leadingPrimaryIcon = if (leftIcon) Icons.Outlined.Email else null,
+                            leadingSecondaryIcon = if (leftIcon) Icons.Filled.Email else null,
+                            trailingAccessoryText = if (secondaryText) resources.getString(R.string.fluentui_secondary) else null,
+                            errorString = if (errorText) resources.getString(R.string.fluentui_error_string) else null,
+                            trailingAccessoryIcon = FluentIcon(
+                                SearchBarIcons.Dismisscircle,
+                                contentDescription = resources.getString(R.string.fluentui_clear_text)
+                            ),
+                            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+                            keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
+                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
+                        )
+                    }
                 }
             }
         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -1,0 +1,278 @@
+package com.microsoft.fluentuidemo.demos
+
+import android.os.Bundle
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import com.microsoft.fluentui.icons.SearchBarIcons
+import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
+import com.microsoft.fluentui.theme.token.FluentIcon
+import com.microsoft.fluentui.tokenized.controls.TextField
+import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
+import com.microsoft.fluentui.tokenized.listitem.ChevronOrientation
+import com.microsoft.fluentui.tokenized.listitem.ListItem
+import com.microsoft.fluentui.tokenized.segmentedcontrols.PillBar
+import com.microsoft.fluentui.tokenized.segmentedcontrols.PillMetaData
+import com.microsoft.fluentuidemo.DemoActivity
+import com.microsoft.fluentuidemo.R
+import com.microsoft.fluentuidemo.util.DemoAppStrings
+import com.microsoft.fluentuidemo.util.getDemoAppString
+
+class V2TextFieldActivity : DemoActivity() {
+    override val contentLayoutId: Int
+        get() = R.layout.v2_activity_compose
+    override val contentNeedsScrollableContainer: Boolean
+        get() = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val composeHere = findViewById<ComposeView>(R.id.compose_here)
+        val context = this
+
+        composeHere.setContent {
+            var value by rememberSaveable { mutableStateOf("") }
+            var leftIcon by rememberSaveable { mutableStateOf(true) }
+            var hintText by rememberSaveable { mutableStateOf(true) }
+            var label by rememberSaveable { mutableStateOf(true) }
+            var assisstiveText by rememberSaveable { mutableStateOf(true) }
+            var secondaryText by rememberSaveable { mutableStateOf(true) }
+            var errorText by rememberSaveable { mutableStateOf(false) }
+            var passwordMode by rememberSaveable { mutableStateOf(false) }
+            var keyboardType by remember { mutableStateOf(KeyboardType.Text) }
+
+            val resources = LocalContext.current.resources
+
+            Column {
+                ListItem.SectionHeader(
+                    title = getDemoAppString(DemoAppStrings.ModifiableParameters),
+                    enableChevron = true,
+                    enableContentOpenCloseTransition = true,
+                    chevronOrientation = ChevronOrientation(90f, 0f),
+                ) {
+                    LazyColumn(Modifier.fillMaxHeight(0.5F)) {
+                        item {
+                            PillBar(
+                                mutableListOf(
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_text),
+                                        onClick = { keyboardType = KeyboardType.Text },
+                                        selected = keyboardType == KeyboardType.Text
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_ascii),
+                                        onClick = { keyboardType = KeyboardType.Ascii },
+                                        selected = keyboardType == KeyboardType.Ascii
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_number),
+                                        onClick = { keyboardType = KeyboardType.Number },
+                                        selected = keyboardType == KeyboardType.Number
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_phone),
+                                        onClick = { keyboardType = KeyboardType.Phone },
+                                        selected = keyboardType == KeyboardType.Phone
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_uri),
+                                        onClick = { keyboardType = KeyboardType.Uri },
+                                        selected = keyboardType == KeyboardType.Uri
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_email),
+                                        onClick = { keyboardType = KeyboardType.Email },
+                                        selected = keyboardType == KeyboardType.Email
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_password),
+                                        onClick = { keyboardType = KeyboardType.Password },
+                                        selected = keyboardType == KeyboardType.Password
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_number_password),
+                                        onClick = { keyboardType = KeyboardType.NumberPassword },
+                                        selected = keyboardType == KeyboardType.NumberPassword
+                                    ),
+                                    PillMetaData(
+                                        text = resources.getString(R.string.fluentui_keyboard_decimal),
+                                        onClick = { keyboardType = KeyboardType.Decimal },
+                                        selected = keyboardType == KeyboardType.Decimal
+                                    )
+                                )
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_icon),
+                                subText = if (label)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            leftIcon = it
+                                        },
+                                        checkedState = leftIcon
+                                    )
+                                }
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_hint),
+                                subText = if (hintText)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            hintText = it
+                                        },
+                                        checkedState = hintText
+                                    )
+                                }
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_label),
+                                subText = if (label)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            label = it
+                                        },
+                                        checkedState = label
+                                    )
+                                }
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_assistive_text),
+                                subText = if (label)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            assisstiveText = it
+                                        },
+                                        checkedState = assisstiveText
+                                    )
+                                }
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_secondary),
+                                subText = if (label)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            secondaryText = it
+                                        },
+                                        checkedState = secondaryText
+                                    )
+                                }
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_password_mode),
+                                subText = if (label)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            passwordMode = it
+                                        },
+                                        checkedState = passwordMode
+                                    )
+                                }
+                            )
+                        }
+
+                        item {
+                            ListItem.Item(
+                                text = resources.getString(R.string.fluentui_error),
+                                subText = if (label)
+                                    LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                                trailingAccessoryView = {
+                                    ToggleSwitch(
+                                        onValueChange = {
+                                            errorText = it
+                                        },
+                                        checkedState = errorText
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+
+                val focusManager = LocalFocusManager.current
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                    TextField(
+                        value,
+                        { value = it },
+                        hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
+                        label = if (label) resources.getString(R.string.fluentui_label) else null,
+                        assistiveText = if (assisstiveText) resources.getString(R.string.fluentui_assistive_text) else null,
+                        leftPrimaryIcon = if (leftIcon) Icons.Outlined.Email else null,
+                        leftSecondaryIcon = if (leftIcon) Icons.Filled.Email else null,
+                        rightAccessoryText = if (secondaryText) resources.getString(R.string.fluentui_secondary) else null,
+                        errorString = if (errorText) resources.getString(R.string.fluentui_error_string) else null,
+                        rightAccessoryIcon = FluentIcon(
+                            SearchBarIcons.Dismisscircle,
+                            contentDescription = resources.getString(R.string.fluentui_clear_text)
+                        ),
+                        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+                        keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
+                        visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
+                    )
+                }
+            }
+        }
+    }
+}

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -13,8 +13,11 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.outlined.Email
-import androidx.compose.runtime.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -130,7 +133,7 @@ class V2TextFieldActivity : DemoActivity() {
                             item {
                                 ListItem.Item(
                                     text = resources.getString(R.string.fluentui_icon),
-                                    subText = if (label)
+                                    subText = if (leftIcon)
                                         LocalContext.current.resources.getString(R.string.fluentui_enabled)
                                     else
                                         LocalContext.current.resources.getString(R.string.fluentui_disabled),
@@ -184,7 +187,7 @@ class V2TextFieldActivity : DemoActivity() {
                             item {
                                 ListItem.Item(
                                     text = resources.getString(R.string.fluentui_assistive_text),
-                                    subText = if (label)
+                                    subText = if (assistiveText)
                                         LocalContext.current.resources.getString(R.string.fluentui_enabled)
                                     else
                                         LocalContext.current.resources.getString(R.string.fluentui_disabled),
@@ -202,7 +205,7 @@ class V2TextFieldActivity : DemoActivity() {
                             item {
                                 ListItem.Item(
                                     text = resources.getString(R.string.fluentui_secondary),
-                                    subText = if (label)
+                                    subText = if (secondaryText)
                                         LocalContext.current.resources.getString(R.string.fluentui_enabled)
                                     else
                                         LocalContext.current.resources.getString(R.string.fluentui_disabled),
@@ -220,7 +223,7 @@ class V2TextFieldActivity : DemoActivity() {
                             item {
                                 ListItem.Item(
                                     text = resources.getString(R.string.fluentui_password_mode),
-                                    subText = if (label)
+                                    subText = if (passwordMode)
                                         LocalContext.current.resources.getString(R.string.fluentui_enabled)
                                     else
                                         LocalContext.current.resources.getString(R.string.fluentui_disabled),
@@ -238,7 +241,7 @@ class V2TextFieldActivity : DemoActivity() {
                             item {
                                 ListItem.Item(
                                     text = resources.getString(R.string.fluentui_error),
-                                    subText = if (label)
+                                    subText = if (errorText)
                                         LocalContext.current.resources.getString(R.string.fluentui_enabled)
                                     else
                                         LocalContext.current.resources.getString(R.string.fluentui_disabled),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -2,6 +2,7 @@ package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -57,7 +58,7 @@ class V2TextFieldActivity : DemoActivity() {
             var leftIcon by rememberSaveable { mutableStateOf(true) }
             var hintText by rememberSaveable { mutableStateOf(true) }
             var label by rememberSaveable { mutableStateOf(true) }
-            var assisstiveText by rememberSaveable { mutableStateOf(true) }
+            var assistiveText by rememberSaveable { mutableStateOf(true) }
             var secondaryText by rememberSaveable { mutableStateOf(true) }
             var errorText by rememberSaveable { mutableStateOf(false) }
             var passwordMode by rememberSaveable { mutableStateOf(false) }
@@ -189,9 +190,9 @@ class V2TextFieldActivity : DemoActivity() {
                                 trailingAccessoryView = {
                                     ToggleSwitch(
                                         onValueChange = {
-                                            assisstiveText = it
+                                            assistiveText = it
                                         },
-                                        checkedState = assisstiveText
+                                        checkedState = assistiveText
                                     )
                                 }
                             )
@@ -254,18 +255,22 @@ class V2TextFieldActivity : DemoActivity() {
                 }
 
                 val focusManager = LocalFocusManager.current
-                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable { focusManager.clearFocus() }) {
                     TextField(
                         value,
                         { value = it },
                         hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
                         label = if (label) resources.getString(R.string.fluentui_label) else null,
-                        assistiveText = if (assisstiveText) resources.getString(R.string.fluentui_assistive_text) else null,
-                        leftPrimaryIcon = if (leftIcon) Icons.Outlined.Email else null,
-                        leftSecondaryIcon = if (leftIcon) Icons.Filled.Email else null,
-                        rightAccessoryText = if (secondaryText) resources.getString(R.string.fluentui_secondary) else null,
+                        assistiveText = if (assistiveText) resources.getString(R.string.fluentui_assistive_text) else null,
+                        leadingPrimaryIcon = if (leftIcon) Icons.Outlined.Email else null,
+                        leadingSecondaryIcon = if (leftIcon) Icons.Filled.Email else null,
+                        trailingAccessoryText = if (secondaryText) resources.getString(R.string.fluentui_secondary) else null,
                         errorString = if (errorText) resources.getString(R.string.fluentui_error_string) else null,
-                        rightAccessoryIcon = FluentIcon(
+                        trailingAccessoryIcon = FluentIcon(
                             SearchBarIcons.Dismisscircle,
                             contentDescription = resources.getString(R.string.fluentui_clear_text)
                         ),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -1,6 +1,7 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -18,7 +19,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.KeyboardType
@@ -35,22 +35,24 @@ import com.microsoft.fluentui.tokenized.segmentedcontrols.PillBar
 import com.microsoft.fluentui.tokenized.segmentedcontrols.PillMetaData
 import com.microsoft.fluentuidemo.DemoActivity
 import com.microsoft.fluentuidemo.R
+import com.microsoft.fluentuidemo.databinding.V2ActivityComposeBinding
 import com.microsoft.fluentuidemo.util.DemoAppStrings
 import com.microsoft.fluentuidemo.util.getDemoAppString
 
 class V2TextFieldActivity : DemoActivity() {
-    override val contentLayoutId: Int
-        get() = R.layout.v2_activity_compose
     override val contentNeedsScrollableContainer: Boolean
         get() = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val composeHere = findViewById<ComposeView>(R.id.compose_here)
-        val context = this
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
 
-        composeHere.setContent {
+        v2ActivityComposeBinding.composeHere.setContent {
             var value by rememberSaveable { mutableStateOf("") }
             var leftIcon by rememberSaveable { mutableStateOf(true) }
             var hintText by rememberSaveable { mutableStateOf(true) }

--- a/fluentui_controls/build.gradle
+++ b/fluentui_controls/build.gradle
@@ -48,6 +48,8 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':fluentui_core')
+    implementation project(':fluentui_listitem')
+    implementation project(':fluentui_icons')
 
     implementation 'androidx.core:core-ktx:1.7.0'
 

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.core.R
 import com.microsoft.fluentui.icons.SearchBarIcons
 import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
+import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.DividerInfo
@@ -45,25 +47,25 @@ fun TextField(
     hintText: String? = null,
     label: String? = null,
     assistiveText: String? = null,
-    rightAccessoryText: String? = null,
+    trailingAccessoryText: String? = null,
     errorString: String? = null,
-    leftPrimaryIcon: ImageVector? = null,
-    leftSecondaryIcon: ImageVector? = null,
-    leftIconContentDescription: String? = null,
-    rightAccessoryIcon: FluentIcon? = FluentIcon(
+    leadingPrimaryIcon: ImageVector? = null,
+    leadingSecondaryIcon: ImageVector? = null,
+    leadingIconContentDescription: String? = null,
+    trailingAccessoryIcon: FluentIcon? = FluentIcon(
         SearchBarIcons.Dismisscircle,
         contentDescription = LocalContext.current.resources.getString(R.string.fluentui_clear_text)
     ),
     keyboardOptions: KeyboardOptions = KeyboardOptions(),
     keyboardActions: KeyboardActions = KeyboardActions(),
     visualTransformation: VisualTransformation = VisualTransformation.None,
-    textFieldTokens: TextFieldTokens = TextFieldTokens()
+    textFieldTokens: TextFieldTokens = (FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TextField] as TextFieldTokens)
 ) {
     var isFocused: Boolean by rememberSaveable { mutableStateOf(false) }
 
     val textFieldInfo = TextFieldInfo(
         isStatusError = !errorString.isNullOrBlank(),
-        hasIcon = (leftPrimaryIcon != null),
+        hasIcon = (leadingPrimaryIcon != null),
         isFocused = isFocused,
         textAvailable = value.isNotEmpty()
     )
@@ -93,15 +95,15 @@ fun TextField(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            if (leftPrimaryIcon != null) {
+            if (leadingPrimaryIcon != null) {
                 Icon(
-                    if (isFocused && errorString.isNullOrBlank() && leftSecondaryIcon != null)
-                        leftSecondaryIcon
+                    if (isFocused && errorString.isNullOrBlank() && leadingSecondaryIcon != null)
+                        leadingSecondaryIcon
                     else
-                        leftPrimaryIcon,
-                    leftIconContentDescription,
-                    modifier = Modifier.size(textFieldTokens.leftIconSize(textFieldInfo)),
-                    tint = textFieldTokens.leftIconColor(textFieldInfo)
+                        leadingPrimaryIcon,
+                    leadingIconContentDescription,
+                    modifier = Modifier.size(textFieldTokens.leadingIconSize(textFieldInfo)),
+                    tint = textFieldTokens.leadingIconColor(textFieldInfo)
                 )
                 Spacer(Modifier.requiredWidth(16.dp))
             }
@@ -136,11 +138,12 @@ fun TextField(
                                 ) {
                                     BasicText(
                                         hintText,
-                                        style = textFieldTokens.hintTextTypography(textFieldInfo).merge(
-                                            TextStyle(
-                                                color = textFieldTokens.hintColor(textFieldInfo)
+                                        style = textFieldTokens.hintTextTypography(textFieldInfo)
+                                            .merge(
+                                                TextStyle(
+                                                    color = textFieldTokens.hintColor(textFieldInfo)
+                                                )
                                             )
-                                        )
                                     )
                                 }
                             }
@@ -154,36 +157,39 @@ fun TextField(
                         ),
                         cursorBrush = textFieldTokens.cursorColor(textFieldInfo)
                     )
-                    if (!rightAccessoryText.isNullOrBlank()) {
+                    if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))
                         BasicText(
-                            rightAccessoryText,
+                            trailingAccessoryText,
                             modifier = Modifier.padding(vertical = 12.dp),
-                            style = textFieldTokens.rightAccessoryTextTypography(textFieldInfo).merge(
-                                TextStyle(
-                                    color = textFieldTokens.rightAccessoryTextColor(textFieldInfo)
+                            style = textFieldTokens.trailingAccessoryTextTypography(textFieldInfo)
+                                .merge(
+                                    TextStyle(
+                                        color = textFieldTokens.trailingAccessoryTextColor(
+                                            textFieldInfo
+                                        )
+                                    )
                                 )
-                            )
                         )
                     }
-                    if (value.isNotBlank() && rightAccessoryIcon?.isIconAvailable() == true) {
+                    if (value.isNotBlank() && trailingAccessoryIcon?.isIconAvailable() == true) {
                         Icon(
-                            rightAccessoryIcon,
+                            trailingAccessoryIcon,
                             Modifier
                                 .clickable(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = LocalIndication.current,
                                     enabled = true,
-                                    onClickLabel = rightAccessoryIcon.contentDescription,
+                                    onClickLabel = trailingAccessoryIcon.contentDescription,
                                     role = Role.Button
                                 ) {
-                                    if (rightAccessoryIcon.onClick != null)
-                                        rightAccessoryIcon.onClick!!.invoke()
+                                    if (trailingAccessoryIcon.onClick != null)
+                                        trailingAccessoryIcon.onClick!!.invoke()
                                     else
                                         onValueChange("")
                                 }
                                 .padding(8.dp)
-                                .size(textFieldTokens.rightIconSize(textFieldInfo))
+                                .size(textFieldTokens.trailingIconSize(textFieldInfo))
                         )
                     }
                 }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.LayoutDirection
@@ -39,6 +41,38 @@ import com.microsoft.fluentui.theme.token.controlTokens.TextFieldInfo
 import com.microsoft.fluentui.theme.token.controlTokens.TextFieldTokens
 import com.microsoft.fluentui.tokenized.divider.Divider
 
+/**
+ * API to create a customized TextField for users to edit text via software and hardware keyboard
+ * which has support for label, assistive text, error strings.
+ *
+ * Whenever the user edits the text, onValueChange is called with the most up to date string
+ * with which developer is expected to update their state.
+ *
+ * It is crucial that the value provided in the onValueChange is fed back into BasicTextField
+ * in order to have the final state of the text being displayed.
+ *
+ * @param value Input String text to be shown in TextField
+ * @param onValueChange The callback that is triggered when the input service updates the text.
+ * An updated text comes as a parameter of the callback
+ * @param modifier Optional modifier for the TextField
+ * @param hintText Hint to be shown on TextField. Displayed when [value] is empty and TextField
+ * doesn't have focus.
+ * @param label String which acts as a description for the TextField.
+ * @param assistiveText String which assists users with the TextField
+ * @param trailingAccessoryText String to be placed towards the end of TextField as secondary text.
+ * @param errorString String to describe the error. TextField goes in error mode if this is provided.
+ * @param leadingRestIcon Icon which is displayed when the textField is in rest state.
+ * @param leadingFocusIcon Icon which is displayed when the textField is in focus state.
+ * @param leadingIconContentDescription String which acts as content description for leading icon.
+ * @param trailingAccessoryIcon Icon which is displayed towards the end of textField and mainly
+ * acts as dismiss icon.
+ * @param keyboardOptions software keyboard options that contains configuration such as [KeyboardType] and [ImeAction].
+ * @param keyboardActions when the input service emits an IME action, the corresponding callback is called.
+ * Note that this IME action may be different from what you specified in [KeyboardOptions.imeAction].
+ * @param visualTransformation he visual transformation filter for changing the visual representation
+ * of the input. By default no visual transformation is applied.
+ * @param textFieldTokens Optional Tokens to customize appearance of TextField.
+ */
 @Composable
 fun TextField(
     value: String,
@@ -59,8 +93,11 @@ fun TextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions(),
     keyboardActions: KeyboardActions = KeyboardActions(),
     visualTransformation: VisualTransformation = VisualTransformation.None,
-    textFieldTokens: TextFieldTokens = (FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TextField] as TextFieldTokens)
+    textFieldTokens: TextFieldTokens? = null
 ) {
+    val token = textFieldTokens
+        ?: (FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TextField] as TextFieldTokens)
+
     var isFocused: Boolean by rememberSaveable { mutableStateOf(false) }
 
     val textFieldInfo = TextFieldInfo(
@@ -80,18 +117,18 @@ fun TextField(
                 }
             }
         }
-        .background(textFieldTokens.backgroundColor(textFieldInfo))
-        .padding(textFieldTokens.leftRightPadding(textFieldInfo))) {
+        .background(token.backgroundColor(textFieldInfo))
+        .padding(token.leftRightPadding(textFieldInfo))) {
         if (!label.isNullOrBlank()) {
             Spacer(Modifier.requiredHeight(12.dp))
             BasicText(
                 label,
-                style = textFieldTokens.labelTypography(textFieldInfo).merge(
+                style = token.labelTypography(textFieldInfo).merge(
                     TextStyle(
-                        color = textFieldTokens.labelColor(textFieldInfo)
+                        color = token.labelColor(textFieldInfo)
                     )
                 ),
-                modifier = Modifier.padding(textFieldTokens.labelPadding(textFieldInfo))
+                modifier = Modifier.padding(token.labelPadding(textFieldInfo))
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -102,8 +139,8 @@ fun TextField(
                     else
                         leadingPrimaryIcon,
                     leadingIconContentDescription,
-                    modifier = Modifier.size(textFieldTokens.leadingIconSize(textFieldInfo)),
-                    tint = textFieldTokens.leadingIconColor(textFieldInfo)
+                    modifier = Modifier.size(token.leadingIconSize(textFieldInfo)),
+                    tint = token.leadingIconColor(textFieldInfo)
                 )
                 Spacer(Modifier.requiredWidth(16.dp))
             }
@@ -138,10 +175,10 @@ fun TextField(
                                 ) {
                                     BasicText(
                                         hintText,
-                                        style = textFieldTokens.hintTextTypography(textFieldInfo)
+                                        style = token.hintTextTypography(textFieldInfo)
                                             .merge(
                                                 TextStyle(
-                                                    color = textFieldTokens.hintColor(textFieldInfo)
+                                                    color = token.hintColor(textFieldInfo)
                                                 )
                                             )
                                     )
@@ -149,23 +186,23 @@ fun TextField(
                             }
                             innerTextField()
                         },
-                        textStyle = textFieldTokens.inputTextTypography(textFieldInfo).merge(
+                        textStyle = token.inputTextTypography(textFieldInfo).merge(
                             TextStyle(
-                                color = textFieldTokens.inputTextColor(textFieldInfo),
+                                color = token.inputTextColor(textFieldInfo),
                                 textDirection = TextDirection.ContentOrLtr
                             )
                         ),
-                        cursorBrush = textFieldTokens.cursorColor(textFieldInfo)
+                        cursorBrush = token.cursorColor(textFieldInfo)
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))
                         BasicText(
                             trailingAccessoryText,
                             modifier = Modifier.padding(vertical = 12.dp),
-                            style = textFieldTokens.trailingAccessoryTextTypography(textFieldInfo)
+                            style = token.trailingAccessoryTextTypography(textFieldInfo)
                                 .merge(
                                     TextStyle(
-                                        color = textFieldTokens.trailingAccessoryTextColor(
+                                        color = token.trailingAccessoryTextColor(
                                             textFieldInfo
                                         )
                                     )
@@ -189,12 +226,12 @@ fun TextField(
                                         onValueChange("")
                                 }
                                 .padding(8.dp)
-                                .size(textFieldTokens.trailingIconSize(textFieldInfo))
+                                .size(token.trailingIconSize(textFieldInfo))
                         )
                     }
                 }
                 Divider(
-                    height = textFieldTokens.strokeWidth(textFieldInfo),
+                    height = token.strokeWidth(textFieldInfo),
                     dividerToken = object : DividerTokens() {
                         @Composable
                         override fun verticalPadding(dividerInfo: DividerInfo): PaddingValues {
@@ -203,7 +240,7 @@ fun TextField(
 
                         @Composable
                         override fun dividerColor(dividerInfo: DividerInfo): Color =
-                            textFieldTokens.dividerColor(textFieldInfo)
+                            token.dividerColor(textFieldInfo)
                     }
                 )
             }
@@ -211,12 +248,12 @@ fun TextField(
         if (!assistiveText.isNullOrBlank() || !errorString.isNullOrBlank()) {
             BasicText(
                 errorString ?: assistiveText!!,
-                style = textFieldTokens.assistiveTextTypography(textFieldInfo).merge(
+                style = token.assistiveTextTypography(textFieldInfo).merge(
                     TextStyle(
-                        color = textFieldTokens.assistiveTextColor(textFieldInfo)
+                        color = token.assistiveTextColor(textFieldInfo)
                     )
                 ),
-                modifier = Modifier.padding(textFieldTokens.assistiveTextPadding(textFieldInfo))
+                modifier = Modifier.padding(token.assistiveTextPadding(textFieldInfo))
             )
         }
     }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -83,8 +83,8 @@ fun TextField(
     assistiveText: String? = null,
     trailingAccessoryText: String? = null,
     errorString: String? = null,
-    leadingPrimaryIcon: ImageVector? = null,
-    leadingSecondaryIcon: ImageVector? = null,
+    leadingRestIcon: ImageVector? = null,
+    leadingFocusIcon: ImageVector? = null,
     leadingIconContentDescription: String? = null,
     trailingAccessoryIcon: FluentIcon? = FluentIcon(
         SearchBarIcons.Dismisscircle,
@@ -102,7 +102,7 @@ fun TextField(
 
     val textFieldInfo = TextFieldInfo(
         isStatusError = !errorString.isNullOrBlank(),
-        hasIcon = (leadingPrimaryIcon != null),
+        hasIcon = (leadingRestIcon != null),
         isFocused = isFocused,
         textAvailable = value.isNotEmpty()
     )
@@ -132,12 +132,12 @@ fun TextField(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            if (leadingPrimaryIcon != null) {
+            if (leadingRestIcon != null) {
                 Icon(
-                    if (isFocused && errorString.isNullOrBlank() && leadingSecondaryIcon != null)
-                        leadingSecondaryIcon
+                    if (isFocused && errorString.isNullOrBlank() && leadingFocusIcon != null)
+                        leadingFocusIcon
                     else
-                        leadingPrimaryIcon,
+                        leadingRestIcon,
                     leadingIconContentDescription,
                     modifier = Modifier.size(token.leadingIconSize(textFieldInfo)),
                     tint = token.leadingIconColor(textFieldInfo)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -1,0 +1,217 @@
+package com.microsoft.fluentui.tokenized.controls
+
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextDirection
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.microsoft.fluentui.core.R
+import com.microsoft.fluentui.icons.SearchBarIcons
+import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
+import com.microsoft.fluentui.theme.token.FluentIcon
+import com.microsoft.fluentui.theme.token.Icon
+import com.microsoft.fluentui.theme.token.controlTokens.DividerInfo
+import com.microsoft.fluentui.theme.token.controlTokens.DividerTokens
+import com.microsoft.fluentui.theme.token.controlTokens.TextFieldInfo
+import com.microsoft.fluentui.theme.token.controlTokens.TextFieldTokens
+import com.microsoft.fluentui.tokenized.divider.Divider
+
+@Composable
+fun TextField(
+    value: String,
+    onValueChange: ((String) -> Unit),
+    modifier: Modifier = Modifier,
+    hintText: String? = null,
+    label: String? = null,
+    assistiveText: String? = null,
+    rightAccessoryText: String? = null,
+    errorString: String? = null,
+    leftPrimaryIcon: ImageVector? = null,
+    leftSecondaryIcon: ImageVector? = null,
+    leftIconContentDescription: String? = null,
+    rightAccessoryIcon: FluentIcon? = FluentIcon(
+        SearchBarIcons.Dismisscircle,
+        contentDescription = LocalContext.current.resources.getString(R.string.fluentui_clear_text)
+    ),
+    keyboardOptions: KeyboardOptions = KeyboardOptions(),
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    textFieldTokens: TextFieldTokens = TextFieldTokens()
+) {
+    var isFocused: Boolean by rememberSaveable { mutableStateOf(false) }
+
+    val textFieldInfo = TextFieldInfo(
+        isStatusError = !errorString.isNullOrBlank(),
+        hasIcon = (leftPrimaryIcon != null),
+        isFocused = isFocused,
+        textAvailable = value.isNotEmpty()
+    )
+
+    val focusRequester = remember { FocusRequester() }
+
+    Column(modifier = modifier
+        .onFocusChanged { focusState ->
+            when {
+                focusState.isFocused -> {
+                    focusRequester.requestFocus()
+                }
+            }
+        }
+        .background(textFieldTokens.backgroundColor(textFieldInfo))
+        .padding(textFieldTokens.leftRightPadding(textFieldInfo))) {
+        if (!label.isNullOrBlank()) {
+            Spacer(Modifier.requiredHeight(12.dp))
+            BasicText(
+                label,
+                style = textFieldTokens.labelTypography(textFieldInfo).merge(
+                    TextStyle(
+                        color = textFieldTokens.labelColor(textFieldInfo)
+                    )
+                ),
+                modifier = Modifier.padding(textFieldTokens.labelPadding(textFieldInfo))
+            )
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (leftPrimaryIcon != null) {
+                Icon(
+                    if (isFocused && errorString.isNullOrBlank() && leftSecondaryIcon != null)
+                        leftSecondaryIcon
+                    else
+                        leftPrimaryIcon,
+                    leftIconContentDescription,
+                    modifier = Modifier.size(textFieldTokens.leftIconSize(textFieldInfo)),
+                    tint = textFieldTokens.leftIconColor(textFieldInfo)
+                )
+                Spacer(Modifier.requiredWidth(16.dp))
+            }
+            Column(Modifier.weight(1F)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    BasicTextField(
+                        value = value,
+                        onValueChange = onValueChange,
+                        modifier = Modifier
+                            .padding(vertical = 12.dp)
+                            .weight(1F)
+                            .focusRequester(focusRequester)
+                            .onFocusChanged { state ->
+                                isFocused = false
+                                when {
+                                    state.isFocused ->
+                                        isFocused = true
+                                }
+                            },
+                        singleLine = true,
+                        keyboardOptions = keyboardOptions,
+                        keyboardActions = keyboardActions,
+                        visualTransformation = visualTransformation,
+                        decorationBox = @Composable { innerTextField ->
+                            if (value.isEmpty() && !hintText.isNullOrBlank()) {
+                                Box(
+                                    Modifier.fillMaxWidth(),
+                                    contentAlignment = if (LocalLayoutDirection.current == LayoutDirection.Rtl)
+                                        Alignment.CenterEnd
+                                    else
+                                        Alignment.CenterStart
+                                ) {
+                                    BasicText(
+                                        hintText,
+                                        style = textFieldTokens.hintTextTypography(textFieldInfo).merge(
+                                            TextStyle(
+                                                color = textFieldTokens.hintColor(textFieldInfo)
+                                            )
+                                        )
+                                    )
+                                }
+                            }
+                            innerTextField()
+                        },
+                        textStyle = textFieldTokens.inputTextTypography(textFieldInfo).merge(
+                            TextStyle(
+                                color = textFieldTokens.inputTextColor(textFieldInfo),
+                                textDirection = TextDirection.ContentOrLtr
+                            )
+                        ),
+                        cursorBrush = textFieldTokens.cursorColor(textFieldInfo)
+                    )
+                    if (!rightAccessoryText.isNullOrBlank()) {
+                        Spacer(Modifier.requiredWidth(8.dp))
+                        BasicText(
+                            rightAccessoryText,
+                            modifier = Modifier.padding(vertical = 12.dp),
+                            style = textFieldTokens.rightAccessoryTextTypography(textFieldInfo).merge(
+                                TextStyle(
+                                    color = textFieldTokens.rightAccessoryTextColor(textFieldInfo)
+                                )
+                            )
+                        )
+                    }
+                    if (value.isNotBlank() && rightAccessoryIcon?.isIconAvailable() == true) {
+                        Icon(
+                            rightAccessoryIcon,
+                            Modifier
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = LocalIndication.current,
+                                    enabled = true,
+                                    onClickLabel = rightAccessoryIcon.contentDescription,
+                                    role = Role.Button
+                                ) {
+                                    if (rightAccessoryIcon.onClick != null)
+                                        rightAccessoryIcon.onClick!!.invoke()
+                                    else
+                                        onValueChange("")
+                                }
+                                .padding(8.dp)
+                                .size(textFieldTokens.rightIconSize(textFieldInfo))
+                        )
+                    }
+                }
+                Divider(
+                    height = textFieldTokens.strokeWidth(textFieldInfo),
+                    dividerToken = object : DividerTokens() {
+                        @Composable
+                        override fun verticalPadding(dividerInfo: DividerInfo): PaddingValues {
+                            return PaddingValues(0.dp)
+                        }
+
+                        @Composable
+                        override fun dividerColor(dividerInfo: DividerInfo): Color =
+                            textFieldTokens.dividerColor(textFieldInfo)
+                    }
+                )
+            }
+        }
+        if (!assistiveText.isNullOrBlank() || !errorString.isNullOrBlank()) {
+            BasicText(
+                errorString ?: assistiveText!!,
+                style = textFieldTokens.assistiveTextTypography(textFieldInfo).merge(
+                    TextStyle(
+                        color = textFieldTokens.assistiveTextColor(textFieldInfo)
+                    )
+                ),
+                modifier = Modifier.padding(textFieldTokens.assistiveTextPadding(textFieldInfo))
+            )
+        }
+    }
+}

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
@@ -43,7 +43,8 @@ class ControlTokens {
         Snackbar,
         TabBar,
         TabItem,
-        ToggleSwitch
+        TextField,
+        ToggleSwitch,
     }
 
     val tokens: TokenSet<ControlType, ControlToken> by lazy {
@@ -77,6 +78,7 @@ class ControlTokens {
                 ControlType.Snackbar -> SnackBarTokens()
                 ControlType.TabBar -> TabBarTokens()
                 ControlType.TabItem -> TabItemTokens()
+                ControlType.TextField -> TextFieldTokens()
                 ControlType.ToggleSwitch -> ToggleSwitchTokens()
             }
         }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -3,7 +3,6 @@ package com.microsoft.fluentui.theme.token
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.ui.Modifier
@@ -50,7 +49,7 @@ data class FluentIcon(
 }
 
 /**
- * Wrapper over Material's Icon API to incorporate FluentIcon class.
+ * Wrapper over Icon API to incorporate FluentIcon class.
  * Icon tint provided in FluentIcon override's the value provided in API.
  *
  * @param icon [FluentIcon] object to be displayed.
@@ -78,14 +77,13 @@ fun Icon(
 }
 
 /**
- * Icon component that draws [imageVector] using [tint], defaulting to [LocalContentColor]. For a
- * clickable icon, see [IconButton].
+ * Icon component that draws [imageVector] using [tint].
  *
  * @param imageVector [ImageVector] to draw inside this Icon
  * @param contentDescription text used by accessibility services to describe what this icon
  * represents. This should always be provided unless this icon is used for decorative purposes,
  * and does not represent a meaningful action that a user can take. This text should be
- * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * localized.
  * @param modifier optional [Modifier] for this Icon
  * @param tint tint to be applied to [imageVector]. If [Color.Unspecified] is provided, then no
  *  tint is applied
@@ -98,7 +96,7 @@ fun Icon(
     modifier: Modifier = Modifier,
     tint: Color = Color.Unspecified
 ) {
-    androidx.compose.material.Icon(
+    Icon(
         painter = rememberVectorPainter(imageVector),
         contentDescription = contentDescription,
         modifier = modifier,
@@ -107,14 +105,13 @@ fun Icon(
 }
 
 /**
- * Icon component that draws a [painter] using [tint], defaulting to [LocalContentColor]. For a
- * clickable icon, see [IconButton].
+ * Icon component that draws a [painter] using [tint].
  *
  * @param painter [Painter] to draw inside this Icon
  * @param contentDescription text used by accessibility services to describe what this icon
  * represents. This should always be provided unless this icon is used for decorative purposes,
  * and does not represent a meaningful action that a user can take. This text should be
- * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * localized.
  * @param modifier optional [Modifier] for this Icon
  * @param tint tint to be applied to [painter]. If [Color.Unspecified] is provided, then no
  *  tint is applied

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -1,13 +1,27 @@
 package com.microsoft.fluentui.theme.token
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.Icon
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.paint
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toolingGraphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.ThemeMode
@@ -62,3 +76,89 @@ fun Icon(
         tint = icon.tint ?: tint
     )
 }
+
+/**
+ * Icon component that draws [imageVector] using [tint], defaulting to [LocalContentColor]. For a
+ * clickable icon, see [IconButton].
+ *
+ * @param imageVector [ImageVector] to draw inside this Icon
+ * @param contentDescription text used by accessibility services to describe what this icon
+ * represents. This should always be provided unless this icon is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier optional [Modifier] for this Icon
+ * @param tint tint to be applied to [imageVector]. If [Color.Unspecified] is provided, then no
+ *  tint is applied
+ */
+@Composable
+@NonRestartableComposable
+fun Icon(
+    imageVector: ImageVector,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
+    androidx.compose.material.Icon(
+        painter = rememberVectorPainter(imageVector),
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint
+    )
+}
+
+/**
+ * Icon component that draws a [painter] using [tint], defaulting to [LocalContentColor]. For a
+ * clickable icon, see [IconButton].
+ *
+ * @param painter [Painter] to draw inside this Icon
+ * @param contentDescription text used by accessibility services to describe what this icon
+ * represents. This should always be provided unless this icon is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier optional [Modifier] for this Icon
+ * @param tint tint to be applied to [painter]. If [Color.Unspecified] is provided, then no
+ *  tint is applied
+ */
+@Composable
+fun Icon(
+    painter: Painter,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
+    // TODO: b/149735981 semantics for content description
+    val colorFilter = if (tint == Color.Unspecified) null else ColorFilter.tint(tint)
+    val semantics = if (contentDescription != null) {
+        Modifier.semantics {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        }
+    } else {
+        Modifier
+    }
+    Box(
+        modifier
+            .toolingGraphicsLayer()
+            .defaultSizeFor(painter)
+            .paint(
+                painter,
+                colorFilter = colorFilter,
+                contentScale = ContentScale.Fit
+            )
+            .then(semantics)
+    )
+}
+
+private fun Modifier.defaultSizeFor(painter: Painter) =
+    this.then(
+        if (painter.intrinsicSize == Size.Unspecified || painter.intrinsicSize.isInfinite()) {
+            DefaultIconSizeModifier
+        } else {
+            Modifier
+        }
+    )
+
+private fun Size.isInfinite() = width.isInfinite() && height.isInfinite()
+
+// Default icon size, for icons with no intrinsic size information
+private val DefaultIconSizeModifier = Modifier.size(24.dp)

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
@@ -1,8 +1,11 @@
 package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.AliasTokens
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -26,4 +29,12 @@ open class DividerTokens : ControlToken, Parcelable {
             themeMode = FluentTheme.themeMode
         )
     }
+
+    @Composable
+    open fun verticalPadding(dividerInfo: DividerInfo): PaddingValues {
+        return PaddingValues(vertical = 8.dp)
+    }
+
+    @Composable
+    open fun startIndent(dividerInfo: DividerInfo): Dp = 0.dp
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
@@ -31,7 +31,7 @@ open class TextFieldTokens : ControlToken, Parcelable {
     }
 
     @Composable
-    open fun leftIconColor(textFieldInfo: TextFieldInfo): Color {
+    open fun leadingIconColor(textFieldInfo: TextFieldInfo): Color {
         return if (textFieldInfo.isFocused && !textFieldInfo.isStatusError)
             FluentTheme.aliasTokens.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value()
         else
@@ -104,12 +104,12 @@ open class TextFieldTokens : ControlToken, Parcelable {
     }
 
     @Composable
-    open fun rightAccessoryTextColor(textFieldInfo: TextFieldInfo): Color {
+    open fun trailingAccessoryTextColor(textFieldInfo: TextFieldInfo): Color {
         return FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground2].value()
     }
 
     @Composable
-    open fun rightAccessoryTextTypography(textFieldInfo: TextFieldInfo): TextStyle {
+    open fun trailingAccessoryTextTypography(textFieldInfo: TextFieldInfo): TextStyle {
         return FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Body1]
     }
 
@@ -125,7 +125,7 @@ open class TextFieldTokens : ControlToken, Parcelable {
     open fun labelPadding(textFieldInfo: TextFieldInfo): PaddingValues {
         return if (textFieldInfo.hasIcon)
             PaddingValues(
-                start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160) + this.leftIconSize(
+                start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160) + this.leadingIconSize(
                     textFieldInfo
                 )
             )
@@ -136,7 +136,7 @@ open class TextFieldTokens : ControlToken, Parcelable {
     open fun assistiveTextPadding(textFieldInfo: TextFieldInfo): PaddingValues {
         return if (textFieldInfo.hasIcon)
             PaddingValues(
-                start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160) + this.leftIconSize(
+                start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160) + this.leadingIconSize(
                     textFieldInfo
                 ),
                 top = GlobalTokens.size(GlobalTokens.SizeTokens.Size40),
@@ -149,11 +149,11 @@ open class TextFieldTokens : ControlToken, Parcelable {
     }
 
     @Composable
-    open fun leftIconSize(textFieldInfo: TextFieldInfo): Dp =
+    open fun leadingIconSize(textFieldInfo: TextFieldInfo): Dp =
         GlobalTokens.iconSize(GlobalTokens.IconSizeTokens.IconSize240)
 
     @Composable
-    open fun rightIconSize(textFieldInfo: TextFieldInfo): Dp =
+    open fun trailingIconSize(textFieldInfo: TextFieldInfo): Dp =
         GlobalTokens.iconSize(GlobalTokens.IconSizeTokens.IconSize240)
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
@@ -1,0 +1,163 @@
+package com.microsoft.fluentui.theme.token.controlTokens
+
+import android.os.Parcelable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.token.AliasTokens
+import com.microsoft.fluentui.theme.token.ControlInfo
+import com.microsoft.fluentui.theme.token.ControlToken
+import com.microsoft.fluentui.theme.token.GlobalTokens
+import kotlinx.parcelize.Parcelize
+
+data class TextFieldInfo(
+    val isStatusError: Boolean = false,
+    val hasIcon: Boolean = true,
+    val isFocused: Boolean = false,
+    val textAvailable: Boolean = false
+) : ControlInfo
+
+@Parcelize
+open class TextFieldTokens : ControlToken, Parcelable {
+
+    @Composable
+    open fun backgroundColor(textFieldInfo: TextFieldInfo): Color {
+        return FluentTheme.aliasTokens.neutralBackgroundColor[AliasTokens.NeutralBackgroundColorTokens.Background1].value()
+    }
+
+    @Composable
+    open fun leftIconColor(textFieldInfo: TextFieldInfo): Color {
+        return if (textFieldInfo.isFocused && !textFieldInfo.isStatusError)
+            FluentTheme.aliasTokens.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value()
+        else
+            FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground2].value()
+
+    }
+
+    @Composable
+    open fun cursorColor(textFieldInfo: TextFieldInfo): Brush {
+        return SolidColor(FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground3].value())
+    }
+
+    @Composable
+    open fun dividerColor(textFieldInfo: TextFieldInfo): Color {
+        return if (textFieldInfo.isStatusError)
+            FluentTheme.aliasTokens.errorAndStatusColor[AliasTokens.ErrorAndStatusColorTokens.DangerForeground1].value()
+        else if (textFieldInfo.isFocused)
+            FluentTheme.aliasTokens.brandStroke[AliasTokens.BrandStrokeColorTokens.BrandStroke1].value()
+        else
+            FluentTheme.aliasTokens.neutralStrokeColor[AliasTokens.NeutralStrokeColorTokens.Stroke2].value()
+
+    }
+
+    @Composable
+    open fun labelColor(textFieldInfo: TextFieldInfo): Color {
+        return if (textFieldInfo.isStatusError)
+            FluentTheme.aliasTokens.errorAndStatusColor[AliasTokens.ErrorAndStatusColorTokens.DangerForeground1].value()
+        else if (textFieldInfo.isFocused)
+            FluentTheme.aliasTokens.brandForegroundColor[AliasTokens.BrandForegroundColorTokens.BrandForeground1].value()
+        else
+            FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground2].value()
+    }
+
+    @Composable
+    open fun labelTypography(textFieldInfo: TextFieldInfo): TextStyle {
+        return FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Caption2]
+    }
+
+    @Composable
+    open fun assistiveTextColor(textFieldInfo: TextFieldInfo): Color {
+        return if (textFieldInfo.isStatusError)
+            FluentTheme.aliasTokens.errorAndStatusColor[AliasTokens.ErrorAndStatusColorTokens.DangerForeground1].value()
+        else
+            FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground2].value()
+    }
+
+    @Composable
+    open fun assistiveTextTypography(textFieldInfo: TextFieldInfo): TextStyle {
+        return FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Caption2]
+    }
+
+    @Composable
+    open fun hintColor(textFieldInfo: TextFieldInfo): Color {
+        return FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground2].value()
+    }
+
+    @Composable
+    open fun hintTextTypography(textFieldInfo: TextFieldInfo): TextStyle {
+        return FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Body1]
+    }
+
+    @Composable
+    open fun inputTextColor(textFieldInfo: TextFieldInfo): Color {
+        return FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value()
+    }
+
+    @Composable
+    open fun inputTextTypography(textFieldInfo: TextFieldInfo): TextStyle {
+        return FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Body1]
+    }
+
+    @Composable
+    open fun rightAccessoryTextColor(textFieldInfo: TextFieldInfo): Color {
+        return FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground2].value()
+    }
+
+    @Composable
+    open fun rightAccessoryTextTypography(textFieldInfo: TextFieldInfo): TextStyle {
+        return FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Body1]
+    }
+
+    @Composable
+    open fun leftRightPadding(textFieldInfo: TextFieldInfo): PaddingValues {
+        return PaddingValues(
+            start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160),
+            end = GlobalTokens.size(GlobalTokens.SizeTokens.Size160)
+        )
+    }
+
+    @Composable
+    open fun labelPadding(textFieldInfo: TextFieldInfo): PaddingValues {
+        return if (textFieldInfo.hasIcon)
+            PaddingValues(
+                start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160) + this.leftIconSize(
+                    textFieldInfo
+                )
+            )
+        else PaddingValues(GlobalTokens.size(GlobalTokens.SizeTokens.SizeNone))
+    }
+
+    @Composable
+    open fun assistiveTextPadding(textFieldInfo: TextFieldInfo): PaddingValues {
+        return if (textFieldInfo.hasIcon)
+            PaddingValues(
+                start = GlobalTokens.size(GlobalTokens.SizeTokens.Size160) + this.leftIconSize(
+                    textFieldInfo
+                ),
+                top = GlobalTokens.size(GlobalTokens.SizeTokens.Size40),
+                bottom = GlobalTokens.size(GlobalTokens.SizeTokens.Size40)
+            )
+        else PaddingValues(
+            top = GlobalTokens.size(GlobalTokens.SizeTokens.Size40),
+            bottom = GlobalTokens.size(GlobalTokens.SizeTokens.Size40)
+        )
+    }
+
+    @Composable
+    open fun leftIconSize(textFieldInfo: TextFieldInfo): Dp =
+        GlobalTokens.iconSize(GlobalTokens.IconSizeTokens.IconSize240)
+
+    @Composable
+    open fun rightIconSize(textFieldInfo: TextFieldInfo): Dp =
+        GlobalTokens.iconSize(GlobalTokens.IconSizeTokens.IconSize240)
+
+    @Composable
+    open fun strokeWidth(textFieldInfo: TextFieldInfo): Dp =
+        GlobalTokens.strokeWidth(GlobalTokens.StrokeWidthTokens.StrokeWidth05)
+
+}

--- a/fluentui_core/src/main/res/values/strings.xml
+++ b/fluentui_core/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Describes the primary and secondary Strings -->
+    <string name="fluentui_primary">Primary</string>
+    <string name="fluentui_secondary">Secondary</string>
     <!-- Describes dismiss behaviour -->
     <string name="fluentui_dismiss">Dismiss</string>
     <!-- Describes selected action-->
@@ -46,21 +49,29 @@
     <string name="fluentui_warning">Warning</string>
     <!-- Describes the type - Danger-->
     <string name="fluentui_danger">Danger</string>
+    <!-- Describes the error string -->
+    <string name="fluentui_error_string">There has been an error</string>
+    <string name="fluentui_error">Error</string>
+    <!-- Describes the hint Text -->
+    <string name="fluentui_hint">Hint</string>
     <!--name of the icon -->
     <string name="fluentui_chevron">Chevron</string>
     <!-- Describes the outline design of control -->
     <string name="fluentui_outline">Outline</string>
 
-    <!--Describes the control - RadioButton -->
+    <!--Describes the control -->
     <string name="fluentui_radio_button">Radio Button</string>
+    <string name="fluentui_label">Label</string>
 
     <!--types of control -->
     <string name="fluentui_large">Large</string>
     <string name="fluentui_medium">Medium</string>
     <string name="fluentui_small">Small</string>
+    <string name="fluentui_password_mode">Password Mode</string>
 
     <!-- Decribes the subtitle component of list -->
     <string name="fluentui_subtitle">Subtitle</string>
+    <string name="fluentui_assistive_text">Assistive Text</string>
 
     <!-- Decribes the title component of list -->
     <string name="fluentui_title">Title</string>
@@ -76,4 +87,15 @@
     <string name="fluentui_timeout">Timed Out</string>
     <string name="fluentui_left_swiped">Left Swiped</string>
     <string name="fluentui_right_swiped">Right Swiped</string>
+
+    <!-- Describes the Keyboard Types -->
+    <string name="fluentui_keyboard_text">Text</string>
+    <string name="fluentui_keyboard_ascii">ASCII</string>
+    <string name="fluentui_keyboard_number">Number</string>
+    <string name="fluentui_keyboard_phone">Phone</string>
+    <string name="fluentui_keyboard_uri">URI</string>
+    <string name="fluentui_keyboard_email">Email</string>
+    <string name="fluentui_keyboard_password">Password</string>
+    <string name="fluentui_keyboard_number_password">NumberPassword</string>
+    <string name="fluentui_keyboard_decimal">Decimal</string>
 </resources>

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
@@ -21,18 +21,28 @@ fun Divider(
         dividerToken
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Divider] as DividerTokens
     val dividerInfo = DividerInfo()
+    
     Column(
         Modifier
             .fillMaxWidth()
-            .background(token.background(dividerInfo = dividerInfo))
+            .background(token.background(dividerInfo))
             .focusable(false)
             .padding(vertical = 8.dp)
     ) {
         Box(
             Modifier
                 .fillMaxWidth()
-                .requiredHeight(height)
-                .background(token.dividerColor(dividerInfo = dividerInfo))
-        )
+                .background(token.background(dividerInfo))
+                .focusable(false)
+                .padding(token.verticalPadding(dividerInfo))
+        ) {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .requiredHeight(height)
+                    .background(token.dividerColor(dividerInfo))
+                    .padding(start = token.startIndent(dividerInfo))
+            )
+        }
     }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
@@ -21,28 +21,20 @@ fun Divider(
         dividerToken
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Divider] as DividerTokens
     val dividerInfo = DividerInfo()
-    
+
     Column(
         Modifier
             .fillMaxWidth()
             .background(token.background(dividerInfo))
             .focusable(false)
-            .padding(vertical = 8.dp)
+            .padding(token.verticalPadding(dividerInfo))
     ) {
         Box(
             Modifier
                 .fillMaxWidth()
-                .background(token.background(dividerInfo))
-                .focusable(false)
-                .padding(token.verticalPadding(dividerInfo))
-        ) {
-            Box(
-                Modifier
-                    .fillMaxWidth()
-                    .requiredHeight(height)
-                    .background(token.dividerColor(dividerInfo))
-                    .padding(start = token.startIndent(dividerInfo))
-            )
-        }
+                .requiredHeight(height)
+                .background(token.dividerColor(dividerInfo))
+                .padding(start = token.startIndent(dividerInfo))
+        )
     }
 }


### PR DESCRIPTION
Platforms Impacted
 - Android
 
Description of changes
1. Implemented TextField for FluentUI Android. 
2. Added Padding Token to Divider Control.

Verification
Visual Verification done by peers. 
TestAPK link: https://appcenter.ms/users/mayankmishra/apps/FluentTestApp/distribute/releases/36 

Pull request checklist
This PR has considered:
1. Light and Dark appearances
2. VoiceOver and Keyboard Accessibility
3. Internationalization and Right to Left layouts
4. Size classes and window sizes (notched devices, multitasking, different window sizes, etc)