### PR TITLE
Version title update in Demo App Subtitle

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/DemoListActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/DemoListActivity.kt
@@ -56,7 +56,7 @@ class DemoListActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         searchbar = Searchbar(this)
         searchbar.onQueryTextListener = this
         demoListBinding.appBar.accessoryView = searchbar
-    }git
+    }
 
     override fun onQueryTextSubmit(query: String): Boolean {
         return false

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/DemoListActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/DemoListActivity.kt
@@ -51,12 +51,12 @@ class DemoListActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
     }
 
     private fun setupAppBar() {
-        demoListBinding.appBar.toolbar.subtitle = BuildConfig.VERSION_NAME
+        demoListBinding.appBar.toolbar.subtitle = "SDK Version: ${BuildConfig.VERSION_NAME}"
 
         searchbar = Searchbar(this)
         searchbar.onQueryTextListener = this
         demoListBinding.appBar.accessoryView = searchbar
-    }
+    }git
 
     override fun onQueryTextSubmit(query: String): Boolean {
         return false

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/DemoListActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/DemoListActivity.kt
@@ -51,7 +51,7 @@ class DemoListActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
     }
 
     private fun setupAppBar() {
-        demoListBinding.appBar.toolbar.subtitle = "SDK Version: ${BuildConfig.VERSION_NAME}"
+        demoListBinding.appBar.toolbar.subtitle = String.format(getString(R.string.sdk_version, BuildConfig.VERSION_NAME))
 
         searchbar = Searchbar(this)
         searchbar.onQueryTextListener = this

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -756,6 +756,8 @@
     <string name="caption">Caption is Regular 12sp</string>
 
     <!--Common-->
+    <!-- UI Label for SDK Version -->
+    <string name="sdk_version">SDK Version: %s</string>
     <!--UI Label for Toast message-->
     <string name="common_list">Item %d</string>
     <!--UI Label for Toast message-->


### PR DESCRIPTION
### Problem 
DemoApp Appbar doesn't talkback version id with description "SDK Version"

### Root cause 
Subtitle text doesn't mention SDK Version.

### Fix
Add SDK Version to subtitle text.

### Validations
Validated with Talkback and Visual Text.

### Screenshots
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Screenshot_20230426_115152_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/234487144-8a03b1e4-9e8e-4317-8d8e-a48fa544ce89.jpg)|![Screenshot_20230425_171828_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/234267411-2bf6461f-6a93-4bb6-be91-e65a8583ab6b.jpg)|

### Pull request checklist
This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and RTL layouts
- [x] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
