### PR TITLE
[Screen reader - TemplateView]: Keyboard and Talkback focus not in sync on 'Template list' and 'Regular List' while navigate using tab key.

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_template_view.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_template_view.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) Microsoft Corporation. All rights reserved.
   ~ Licensed under the MIT License.
   -->
@@ -47,7 +46,8 @@
             android:layout_weight="1"
             android:showDividers="middle"
             android:divider="@drawable/demo_divider"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:focusable="true">
 
             <TextView
                 android:layout_width="match_parent"
@@ -80,7 +80,8 @@
             android:layout_weight="1"
             android:showDividers="middle"
             android:divider="@drawable/demo_divider"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:focusable="true">
 
             <TextView
                 android:layout_width="match_parent"


### PR DESCRIPTION
### Problem 
[Screen reader - TemplateView]: Keyboard and Talkback focus not in sync on 'Template list' and 'Regular List' while navigate using tab key.

### Root cause 
LinearLayout for TemplateView Activity which contains recycler View was not set as focusable.

### Fix
Made the concerned LinearLayout focusable.

### Validations
Visual Validation

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
| Linear Layout wasn't getting focus | Linear Layout is getting focus                          |
|![Screenshot_20230426_114900_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/234486481-84b1bbc0-ec56-4404-8168-97f1e4eb1db9.jpg)|![Screenshot_20230426_114211_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/234486135-496fffdb-3137-491a-8afe-0d2b3f4d863e.jpg)|


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
