### PR TITLE
Migration from Material's Text to Compose's BasicText

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AvatarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AvatarActivity.kt
@@ -3,8 +3,8 @@ package com.microsoft.fluentuidemo.demos
 import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.example.theme.token.AnonymousAccentAvatarTokens
 import com.example.theme.token.AnonymousAvatarTokens
@@ -34,7 +35,11 @@ class V2AvatarActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 Column(
@@ -44,10 +49,10 @@ class V2AvatarActivity : DemoActivity() {
                     var isActive by rememberSaveable { mutableStateOf(true) }
                     var isOOO by rememberSaveable { mutableStateOf(false) }
 
-                    Text(
+                    BasicText(
                         modifier = Modifier.padding(start = 16.dp),
                         text = "Avatar Cutout",
-                        color = Color(0xFF2886DE)
+                        style = TextStyle(color = Color(0xFF2886DE))
                     )
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AvatarCarouselActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AvatarCarouselActivity.kt
@@ -8,13 +8,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarCarouselSize
@@ -30,7 +31,11 @@ class V2AvatarCarouselActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 CreateAvatarCarouselActivityUI()
@@ -204,10 +209,10 @@ private fun CreateAvatarCarouselActivityUI() {
         verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier.padding(top = 8.dp)
     ) {
-        Text(
+        BasicText(
             modifier = Modifier.padding(start = 8.dp),
             text = "Large Avatar Carousel",
-            color = Color(0xFF2886DE)
+            style = TextStyle(color = Color(0xFF2886DE))
         )
         AvatarCarousel(
             avatarList = createAvatarPersons(mContext),
@@ -215,10 +220,10 @@ private fun CreateAvatarCarouselActivityUI() {
             modifier = Modifier.testTag("LargeCarousel")
         )
         Divider(Modifier.fillMaxWidth())
-        Text(
+        BasicText(
             modifier = Modifier.padding(start = 8.dp),
             text = "Medium Avatar Carousel with Presence indicator",
-            color = Color(0xFF2886DE)
+            style = TextStyle(color = Color(0xFF2886DE))
         )
         AvatarCarousel(
             avatarList = createAvatarPersons(mContext),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AvatarGroupActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AvatarGroupActivity.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -39,7 +39,11 @@ class V2AvatarGroupActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 Column(
@@ -98,7 +102,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                             text = "-",
                             contentDescription = "Max Visible Avatar $maxVisibleAvatar"
                         )
-                        Text("$maxVisibleAvatar")
+                        BasicText("$maxVisibleAvatar")
                         Button(
                             onClick = { maxVisibleAvatar++ },
                             enabled = (maxVisibleAvatar < group.members.size),
@@ -122,7 +126,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                     LazyColumn(modifier = Modifier.fillMaxWidth()) {
                         item {
                             Row(horizontalArrangement = Arrangement.Center) {
-                                Text(
+                                BasicText(
                                     "Stack Group Style",
                                     style = aliasTokens.typography[AliasTokens.TypographyTokens.Title2]
                                 )
@@ -134,7 +138,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 item {
-                                    Text("Size 16: ")
+                                    BasicText("Size 16: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -152,7 +156,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 20: ")
+                                    BasicText("Size 20: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -171,7 +175,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 24: ")
+                                    BasicText("Size 24: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -190,7 +194,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 32: ")
+                                    BasicText("Size 32: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -208,7 +212,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 40: ")
+                                    BasicText("Size 40: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -227,7 +231,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 56: ")
+                                    BasicText("Size 56: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -245,7 +249,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 72: ")
+                                    BasicText("Size 72: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -261,7 +265,7 @@ class V2AvatarGroupActivity : DemoActivity() {
 
                         item {
                             Row(horizontalArrangement = Arrangement.Center) {
-                                Text(
+                                BasicText(
                                     "Pile Group Style",
                                     style = aliasTokens.typography[AliasTokens.TypographyTokens.Title2]
                                 )
@@ -273,7 +277,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 16: ")
+                                    BasicText("Size 16: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -292,7 +296,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 20: ")
+                                    BasicText("Size 20: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -312,7 +316,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 24: ")
+                                    BasicText("Size 24: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -332,7 +336,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 32: ")
+                                    BasicText("Size 32: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -351,7 +355,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 40: ")
+                                    BasicText("Size 40: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -371,7 +375,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 item {
-                                    Text("Size 56: ")
+                                    BasicText("Size 56: ")
                                 }
                                 item {
                                     AvatarGroup(
@@ -389,7 +393,7 @@ class V2AvatarGroupActivity : DemoActivity() {
                                 verticalAlignment = Alignment.CenterVertically,
                                 modifier = Modifier.fillMaxSize()
                             ) {
-                                item { Text("Size 72: ") }
+                                item { BasicText("Size 72: ") }
                                 item {
                                     AvatarGroup(
                                         group,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BadgeActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BadgeActivity.kt
@@ -5,10 +5,11 @@ import android.view.LayoutInflater
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
@@ -26,7 +27,11 @@ class V2BadgeActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 val title1Font =
@@ -35,27 +40,24 @@ class V2BadgeActivity : DemoActivity() {
                     FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title2]
 
                 Column(Modifier.background(Color.Gray)) {
-                    Text(
+                    BasicText(
                         text = resources.getString(R.string.badge_notification_badge),
-                        style = title1Font,
-                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(),
+                        style = title1Font.merge(TextStyle(color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value())),
                         modifier = Modifier.padding(8.dp)
 
                     )
                     Row(Modifier.padding(16.dp), verticalAlignment = CenterVertically) {
-                        Text(
+                        BasicText(
                             text = resources.getString(R.string.badge_notification_dot),
-                            style = title2Font,
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value()
+                            style = title2Font.merge(TextStyle(color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value()))
                         )
                         Spacer(modifier = Modifier.width(16.dp))
                         Badge()
                     }
                     Row(Modifier.padding(16.dp), verticalAlignment = CenterVertically) {
-                        Text(
+                        BasicText(
                             text = resources.getString(R.string.badge_notification_character),
-                            style = title2Font,
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value()
+                            style = title2Font.merge(TextStyle(color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value()))
                         )
                         Spacer(modifier = Modifier.width(16.dp))
                         LazyRow {
@@ -90,11 +92,14 @@ class V2BadgeActivity : DemoActivity() {
                         }
                     }
                     Row(Modifier.padding(16.dp)) {
-                        Text(
+                        BasicText(
                             text = "List",
-                            style = title2Font,
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                themeMode = ThemeMode.Auto
+                            style = title2Font.merge(
+                                TextStyle(
+                                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                        themeMode = ThemeMode.Auto
+                                    )
+                                )
                             )
                         )
                         Spacer(modifier = Modifier.width(16.dp))

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BasicControlsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BasicControlsActivity.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.theme.token.MyAliasTokens
@@ -35,7 +36,11 @@ class V2BasicControlsActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         val context = this
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
@@ -54,14 +59,16 @@ class V2BasicControlsActivity : DemoActivity() {
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text(
+                        BasicText(
                             text = "Toggle Switch enable",
-                            fontWeight = FontWeight.Bold,
                             modifier = Modifier
                                 .weight(1F)
                                 .focusable(false),
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                themeMode = ThemeMode.Auto
+                            style = TextStyle(
+                                color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                    themeMode = ThemeMode.Auto
+                                ),
+                                fontWeight = FontWeight.Bold
                             )
                         )
                         ToggleSwitch(onValueChange = {
@@ -77,14 +84,16 @@ class V2BasicControlsActivity : DemoActivity() {
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text(
+                        BasicText(
                             text = "Toggle Global/Alias Theme",
-                            fontWeight = FontWeight.Bold,
                             modifier = Modifier
                                 .weight(1F)
                                 .focusable(false),
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                themeMode = ThemeMode.Auto
+                            style = TextStyle(
+                                fontWeight = FontWeight.Bold,
+                                color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                    themeMode = ThemeMode.Auto
+                                )
                             )
                         )
                         ToggleSwitch(
@@ -109,14 +118,16 @@ class V2BasicControlsActivity : DemoActivity() {
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text(
+                        BasicText(
                             text = "Toggle Global/Alias Theme",
-                            fontWeight = FontWeight.Bold,
                             modifier = Modifier
                                 .weight(1F)
                                 .focusable(false),
-                            color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                themeMode = ThemeMode.Auto
+                            style = TextStyle(
+                                fontWeight = FontWeight.Bold,
+                                color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                    themeMode = ThemeMode.Auto
+                                )
                             )
                         )
                         CheckBox(enabled = enabled, checked = !checked, onCheckedChanged = {
@@ -145,14 +156,16 @@ class V2BasicControlsActivity : DemoActivity() {
                                     indication = null
                                 )
                         ) {
-                            Text(
+                            BasicText(
                                 text = theme,
-                                fontWeight = FontWeight.Bold,
                                 modifier = Modifier
                                     .weight(1F)
                                     .focusable(false),
-                                color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                    themeMode = ThemeMode.Auto
+                                style = TextStyle(
+                                    fontWeight = FontWeight.Bold,
+                                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                        themeMode = ThemeMode.Auto
+                                    )
                                 )
                             )
                             RadioButton(enabled = enabled,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.runtime.*
@@ -19,6 +19,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -52,7 +53,11 @@ class V2BottomSheetActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 CreateActivityUI()
@@ -190,11 +195,13 @@ private fun CreateActivityUI() {
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
+                BasicText(
                     text = "Expandable",
                     modifier = Modifier.weight(1F),
-                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
                 ToggleSwitch(checkedState = expandableState,
@@ -207,11 +214,13 @@ private fun CreateActivityUI() {
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
+                BasicText(
                     text = "Show Handle",
                     modifier = Modifier.weight(1F),
-                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
                 ToggleSwitch(checkedState = showHandleState,
@@ -224,11 +233,13 @@ private fun CreateActivityUI() {
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
+                BasicText(
                     text = "Slide Over",
                     modifier = Modifier.weight(1F),
-                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
                 ToggleSwitch(checkedState = slideOverState,
@@ -241,11 +252,13 @@ private fun CreateActivityUI() {
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
+                BasicText(
                     text = "Peek Height $peekHeightState",
                     modifier = Modifier.weight(1F),
-                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
                 Button(
@@ -268,7 +281,7 @@ private fun CreateActivityUI() {
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
+                BasicText(
                     text = "Note: When 'Slide Over' is On then Peek Height max limit is restricted to half of screen size. When 'Slide Over' is off then bottomSheet height does not vary with content height. It either open at peek height or expand to fullest or hide at bottom",
                     modifier = Modifier.weight(1F)
                 )
@@ -276,22 +289,26 @@ private fun CreateActivityUI() {
 
 
             Row {
-                Text(
+                BasicText(
                     text = "Select SheetContent",
-                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.weight(1F),
-                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        fontWeight = FontWeight.Bold,
+                        color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
             }
 
             Row {
-                Text(
+                BasicText(
                     text = "From ItemListContentBuilder",
                     modifier = Modifier.weight(1F),
-                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
 
@@ -304,11 +321,13 @@ private fun CreateActivityUI() {
                 )
             }
             Row {
-                Text(
+                BasicText(
                     text = "Using AndroidView",
                     modifier = Modifier.weight(1F),
-                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
 
@@ -321,11 +340,13 @@ private fun CreateActivityUI() {
                 )
             }
             Row {
-                Text(
+                BasicText(
                     text = "Compose Content",
                     modifier = Modifier.weight(1F),
-                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
 
@@ -385,10 +406,12 @@ private fun CreateActivityUI() {
 
             )
             {
-                Text(
+                BasicText(
                     text = context.resources.getString(R.string.large_scrollable_text),
-                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                        themeMode = ThemeMode.Auto
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
                     )
                 )
             }
@@ -442,7 +465,7 @@ fun content2(bottomSheetState: BottomSheetState): @Composable () -> Unit = {
         repeat(no.value) {
             item {
                 Spacer(Modifier.height(10.dp))
-                Text("list item $it")
+                BasicText("list item $it")
             }
         }
     }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
@@ -6,8 +6,8 @@ import android.widget.Toast
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.outlined.Favorite
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.example.theme.token.MyAliasTokens
 import com.example.theme.token.MyButtonTokens
@@ -42,7 +43,11 @@ class V2ButtonsActivity : DemoActivity() {
         super.onCreate(savedInstanceState)
 
         val context = this
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             var fabState by rememberSaveable { mutableStateOf(FABState.Expanded) }
 
@@ -52,10 +57,12 @@ class V2ButtonsActivity : DemoActivity() {
             ) {
                 FluentTheme {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
+                        BasicText(
                             "Button to update Theme via Global & Alias token",
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                themeMode
+                            style = TextStyle(
+                                color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                    themeMode
+                                )
                             )
                         )
 
@@ -103,10 +110,12 @@ class V2ButtonsActivity : DemoActivity() {
 
                 LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     item {
-                        Text(
+                        BasicText(
                             "Activity level customization with Auto theme",
-                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                themeMode
+                            style = TextStyle(
+                                color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                    themeMode
+                                )
                             )
                         )
 
@@ -144,10 +153,12 @@ class V2ButtonsActivity : DemoActivity() {
 
                     item {
                         FluentTheme {
-                            Text(
+                            BasicText(
                                 "Button with selected theme, auto mode and overridden control token",
-                                color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                    themeMode
+                                style = TextStyle(
+                                    color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                        themeMode
+                                    )
                                 )
                             )
                             CreateButtons(MyButtonTokens())

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Call
 import androidx.compose.material.icons.outlined.LocationOn
@@ -48,7 +48,11 @@ class V2CardNudgeActivity : DemoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val context = this
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 var swipeLeft: Boolean by rememberSaveable { mutableStateOf(false) }
@@ -271,9 +275,9 @@ class V2CardNudgeActivity : DemoActivity() {
                             outlineMode = outlineEnabled
                         )
                         if (swipeLeft)
-                            Text(leftSwiped)
+                            BasicText(leftSwiped)
                         else if (swipeRight)
-                            Text(rightSwiped)
+                            BasicText(rightSwiped)
                     }
                 }
             }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ContextualCommandBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ContextualCommandBarActivity.kt
@@ -8,8 +8,8 @@ import android.view.LayoutInflater
 import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -52,7 +52,11 @@ class V2ContextualCommandBarActivity : DemoActivity() {
         super.onCreate(savedInstanceState)
 
         val context = this
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             val click: (() -> Unit) =
                 { Toast.makeText(context, "Click", Toast.LENGTH_SHORT).show() }
@@ -231,7 +235,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                         CenterHorizontally
                     ), verticalAlignment = CenterVertically
                 ) {
-                    Text(text = "Action Button")
+                    BasicText(text = "Action Button")
                     ToggleSwitch(
                         onValueChange =
                         {
@@ -282,7 +286,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                     TextField(
                         value = text,
                         onValueChange = { text = it },
-                        label = { Text("Type your text here") },
+                        label = { BasicText("Type your text here") },
                         modifier = Modifier
                             .onKeyEvent { keyEvent ->
                                 when (keyEvent.nativeKeyEvent.keyCode) {
@@ -320,7 +324,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title1]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -332,7 +336,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title2]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -344,7 +348,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title3]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -356,7 +360,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Body1]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -401,7 +405,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title1]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -413,7 +417,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title2]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -425,7 +429,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Title3]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp
@@ -437,7 +441,7 @@ class V2ContextualCommandBarActivity : DemoActivity() {
                                     item {
                                         val font =
                                             FluentTheme.aliasTokens.typography[AliasTokens.TypographyTokens.Body1]
-                                        Text(
+                                        BasicText(
                                             modifier = Modifier.padding(
                                                 horizontal = 8.dp,
                                                 vertical = 4.dp

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -8,14 +8,15 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -48,7 +49,11 @@ class V2DrawerActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 CreateActivityUI()
@@ -358,10 +363,12 @@ private fun getDynamicDrawerContent(): @Composable ((close: () -> Unit) -> Unit)
             repeat(no.value) {
                 item {
                     Spacer(Modifier.height(10.dp))
-                    Text(
+                    BasicText(
                         text = "Item $it",
-                        color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                            themeMode = ThemeMode.Auto
+                        style = TextStyle(
+                            color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                themeMode = ThemeMode.Auto
+                            )
                         )
                     )
                 }
@@ -416,7 +423,7 @@ private fun getDrawerInDrawerContent(): @Composable ((() -> Unit) -> Unit) {
             val drawerStateB = rememberDrawerState()
 
             var selectedBehaviorType by remember { mutableStateOf(BehaviorType.BOTTOM_SLIDE_OVER) }
-            Text("Select Drawer Type", fontWeight = FontWeight.Bold)
+            BasicText("Select Drawer Type", style = TextStyle(fontWeight = FontWeight.Bold))
             Row(modifier = Modifier
                 .clickable { selectedBehaviorType = BehaviorType.TOP }
                 .clearAndSetSemantics { contentDescription = "Top" }
@@ -427,7 +434,7 @@ private fun getDrawerInDrawerContent(): @Composable ((() -> Unit) -> Unit) {
                     },
                     selected = selectedBehaviorType == BehaviorType.TOP
                 )
-                Text(text = "Top")
+                BasicText(text = "Top")
             }
             Row(modifier = Modifier
                 .clickable { selectedBehaviorType = BehaviorType.BOTTOM }
@@ -439,7 +446,7 @@ private fun getDrawerInDrawerContent(): @Composable ((() -> Unit) -> Unit) {
                     },
                     selected = selectedBehaviorType == BehaviorType.BOTTOM
                 )
-                Text(text = "Bottom")
+                BasicText(text = "Bottom")
             }
             Row(modifier = Modifier
                 .clickable { selectedBehaviorType = BehaviorType.LEFT_SLIDE_OVER }
@@ -451,7 +458,7 @@ private fun getDrawerInDrawerContent(): @Composable ((() -> Unit) -> Unit) {
                     },
                     selected = selectedBehaviorType == BehaviorType.LEFT_SLIDE_OVER
                 )
-                Text(text = "Left Slide Over")
+                BasicText(text = "Left Slide Over")
             }
             Row(modifier = Modifier
                 .clickable { selectedBehaviorType = BehaviorType.RIGHT_SLIDE_OVER }
@@ -463,7 +470,7 @@ private fun getDrawerInDrawerContent(): @Composable ((() -> Unit) -> Unit) {
                     },
                     selected = selectedBehaviorType == BehaviorType.RIGHT_SLIDE_OVER
                 )
-                Text(text = "Right Slide Over")
+                BasicText(text = "Right Slide Over")
             }
             Row(modifier = Modifier
                 .clickable { selectedBehaviorType = BehaviorType.BOTTOM_SLIDE_OVER }
@@ -475,7 +482,7 @@ private fun getDrawerInDrawerContent(): @Composable ((() -> Unit) -> Unit) {
                     },
                     selected = selectedBehaviorType == BehaviorType.BOTTOM_SLIDE_OVER
                 )
-                Text(text = "Bottom Slide Over")
+                BasicText(text = "Bottom Slide Over")
             }
 
             //Button on Outer Drawer Surface

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -6,8 +6,8 @@ import android.view.LayoutInflater
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -46,7 +46,11 @@ class V2ListItemActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 CreateListActivityUI(this)
@@ -707,5 +711,5 @@ private fun GetAvatar(size: AvatarSize, image: Int) {
 
 @Composable
 private fun RightViewText(text: String) {
-    return Text(text = text)
+    return BasicText(text = text)
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
@@ -6,14 +6,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -126,10 +127,12 @@ fun Menu(context: Context, xOffset: Dp, yOffset: Dp, contentText: String, count:
         ) {
             Column(Modifier.verticalScroll(rememberScrollState())) {
                 repeat(count) {
-                    Text(
+                    BasicText(
                         text = "$contentText ${it + 1}",
-                        color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                            themeMode = ThemeMode.Auto
+                        style = TextStyle(
+                            color = FluentTheme.aliasTokens.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                themeMode = ThemeMode.Auto
+                            )
                         )
                     )
                 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2PersonaActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2PersonaActivity.kt
@@ -7,10 +7,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
@@ -27,7 +28,11 @@ class V2PersonaActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 CreatePersonaActivityUI(this)
@@ -57,10 +62,10 @@ class V2PersonaActivity : DemoActivity() {
                 LazyColumn {
                     item {
                         Column {
-                            Text(
+                            BasicText(
                                 modifier = Modifier.padding(start = 8.dp, top = 16.dp),
                                 text = "One line Persona view with small Avatar",
-                                color = Color(0xFF2886DE)
+                                style = TextStyle(color = Color(0xFF2886DE))
                             )
                             Persona(
                                 person = person1,
@@ -77,10 +82,10 @@ class V2PersonaActivity : DemoActivity() {
                     }
                     item {
                         Column {
-                            Text(
+                            BasicText(
                                 modifier = Modifier.padding(start = 8.dp, top = 16.dp),
                                 text = "Two line Persona view with large Avatar",
-                                color = Color(0xFF2886DE)
+                                style = TextStyle(color = Color(0xFF2886DE))
                             )
                             Persona(
                                 person = person2,
@@ -97,10 +102,10 @@ class V2PersonaActivity : DemoActivity() {
                     }
                     item {
                         Column {
-                            Text(
+                            BasicText(
                                 modifier = Modifier.padding(start = 8.dp, top = 16.dp),
                                 text = "Three line Persona View with Xlarge Avatar",
-                                color = Color(0xFF2886DE)
+                                style = TextStyle(color = Color(0xFF2886DE))
                             )
                             Persona(
                                 person = person3,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2PersonaChipActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2PersonaChipActivity.kt
@@ -6,13 +6,14 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -35,7 +36,11 @@ class V2PersonaChipActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 createPersonaChipActivityUI()
@@ -132,10 +137,12 @@ class V2PersonaChipActivity : DemoActivity() {
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
+                        BasicText(
                             text = "Enable/Disable close button on selected state",
-                            color = brandTextColor,
-                            fontSize = 10.sp
+                            style = TextStyle(
+                                color = brandTextColor,
+                                fontSize = 10.sp
+                            )
                         )
                         ToggleSwitch(
                             modifier = Modifier.testTag("switch"),
@@ -145,11 +152,17 @@ class V2PersonaChipActivity : DemoActivity() {
                     }
                 }
                 item {
-                    Text(text = "Basic Persona chip", color = brandTextColor, fontSize = 20.sp)
+                    BasicText(
+                        text = "Basic Persona chip",
+                        style = TextStyle(color = brandTextColor, fontSize = 20.sp)
+                    )
                 }
                 item {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text(text = "Person Chip Neutral", color = textColor)
+                        BasicText(
+                            text = "Person Chip Neutral",
+                            style = TextStyle(color = textColor)
+                        )
                         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             PersonaChip(
                                 person = createPersonWithName(),
@@ -167,7 +180,7 @@ class V2PersonaChipActivity : DemoActivity() {
                                 } else null
                             )
                         }
-                        Text(text = "Person Chip Brand", color = textColor)
+                        BasicText(text = "Person Chip Brand", style = TextStyle(color = textColor))
                         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             PersonaChip(
                                 modifier = Modifier.testTag("small persona chip"),
@@ -187,7 +200,7 @@ class V2PersonaChipActivity : DemoActivity() {
                                 } else null
                             )
                         }
-                        Text(text = "Person Chip Danger", color = textColor)
+                        BasicText(text = "Person Chip Danger", style = TextStyle(color = textColor))
                         LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             item {
                                 PersonaChip(
@@ -209,7 +222,10 @@ class V2PersonaChipActivity : DemoActivity() {
                                 )
                             }
                         }
-                        Text(text = "Person Chip Severe Warning", color = textColor)
+                        BasicText(
+                            text = "Person Chip Severe Warning",
+                            style = TextStyle(color = textColor)
+                        )
                         LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             item {
                                 PersonaChip(
@@ -231,7 +247,10 @@ class V2PersonaChipActivity : DemoActivity() {
                                 )
                             }
                         }
-                        Text(text = "Person Chip Warning", color = textColor)
+                        BasicText(
+                            text = "Person Chip Warning",
+                            style = TextStyle(color = textColor)
+                        )
                         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             PersonaChip(
                                 modifier = Modifier.testTag("ann persona chip"),
@@ -250,7 +269,10 @@ class V2PersonaChipActivity : DemoActivity() {
                                 } else null
                             )
                         }
-                        Text(text = "Person Chip Success", color = textColor)
+                        BasicText(
+                            text = "Person Chip Success",
+                            style = TextStyle(color = textColor)
+                        )
                         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             PersonaChip(
                                 person = createPersonWithName(),
@@ -268,7 +290,10 @@ class V2PersonaChipActivity : DemoActivity() {
                                 } else null
                             )
                         }
-                        Text(text = "Person Chip Disabled", color = textColor)
+                        BasicText(
+                            text = "Person Chip Disabled",
+                            style = TextStyle(color = textColor)
+                        )
                         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             PersonaChip(
                                 person = createPersonWithName(),
@@ -296,15 +321,20 @@ class V2PersonaChipActivity : DemoActivity() {
                     }
                 }
                 item {
-                    Text(
+                    BasicText(
                         text = "SearchBox Basic Persona chip",
-                        color = brandTextColor,
-                        fontSize = 20.sp
+                        style = TextStyle(
+                            color = brandTextColor,
+                            fontSize = 20.sp
+                        )
                     )
                 }
                 item {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text(text = "Persona chip Neutral", color = textColor)
+                        BasicText(
+                            text = "Persona chip Neutral",
+                            style = TextStyle(color = textColor)
+                        )
                         SearchBarPersonaChip(
                             person = createPersonWithName(),
                             size = PersonaChipSize.Small,
@@ -314,7 +344,7 @@ class V2PersonaChipActivity : DemoActivity() {
                                 { onClickToast() }
                             } else null
                         )
-                        Text(text = "Persona chip Brand", color = textColor)
+                        BasicText(text = "Persona chip Brand", style = TextStyle(color = textColor))
                         SearchBarPersonaChip(
                             person = createPersonWithName(),
                             style = FluentStyle.Brand,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ProgressActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ProgressActivity.kt
@@ -4,12 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -31,7 +32,11 @@ class V2ProgressActivity : DemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             FluentTheme {
                 CreateProgressActivityUI()
@@ -96,19 +101,21 @@ private fun CreateProgressActivityUI() {
 @Composable
 private fun LinearProgressIndicatorExample(brandTextColor: Color, textColor: Color) {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        Text(
+        BasicText(
             modifier = Modifier.padding(top = 16.dp),
             text = "ProgressIndicators",
-            color = brandTextColor,
-            fontSize = 20.sp
+            style = TextStyle(
+                color = brandTextColor,
+                fontSize = 20.sp
+            )
         )
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            Text(
+            BasicText(
                 text = "XXXSmall - 2dp",
-                color = textColor
+                style = TextStyle(color = textColor)
             )
             LinearProgressIndicator(modifier = Modifier.width(240.dp))
         }
@@ -123,9 +130,9 @@ private fun CircularProgressIndicatorExamples(textColor: Color) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            Text(
+            BasicText(
                 text = "XSmall - 12dp", modifier = Modifier.width(100.dp),
-                color = textColor
+                style = TextStyle(color = textColor)
             )
             CircularProgressIndicator(style = FluentStyle.Brand)
             CircularProgressIndicator()
@@ -135,9 +142,9 @@ private fun CircularProgressIndicatorExamples(textColor: Color) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            Text(
+            BasicText(
                 text = "Small - 16dp", modifier = Modifier.width(100.dp),
-                color = textColor
+                style = TextStyle(color = textColor)
             )
             CircularProgressIndicator(
                 size = CircularProgressIndicatorSize.XSmall,
@@ -152,9 +159,9 @@ private fun CircularProgressIndicatorExamples(textColor: Color) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            Text(
+            BasicText(
                 text = "Medium - 24dp", modifier = Modifier.width(100.dp),
-                color = textColor
+                style = TextStyle(color = textColor)
             )
             CircularProgressIndicator(
                 size = CircularProgressIndicatorSize.Medium,
@@ -169,9 +176,9 @@ private fun CircularProgressIndicatorExamples(textColor: Color) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            Text(
+            BasicText(
                 text = "Large - 32dp", modifier = Modifier.width(100.dp),
-                color = textColor
+                style = TextStyle(color = textColor)
             )
             CircularProgressIndicator(
                 size = CircularProgressIndicatorSize.Large,
@@ -186,9 +193,9 @@ private fun CircularProgressIndicatorExamples(textColor: Color) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            Text(
+            BasicText(
                 text = "XLarge - 36dp", modifier = Modifier.width(100.dp),
-                color = textColor
+                style = TextStyle(color = textColor)
             )
             CircularProgressIndicator(
                 CircularProgressIndicatorSize.XLarge,
@@ -208,16 +215,18 @@ private fun DeterminateProgressIndicatorExamples(
     linearProgress: Float,
     circularProgress: Float
 ) {
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp),
         text = "Determinate ProgressIndicator",
-        color = brandTextColor,
-        fontSize = 18.sp
+        style = TextStyle(
+            color = brandTextColor,
+            fontSize = 18.sp
+        )
     )
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
         text = "Linear ProgressIndicator",
-        color = textColor
+        style = TextStyle(color = textColor)
     )
     Row(
         Modifier.height(24.dp),
@@ -225,12 +234,15 @@ private fun DeterminateProgressIndicatorExamples(
         horizontalArrangement = Arrangement.spacedBy(32.dp)
     ) {
         LinearProgressIndicator(linearProgress, modifier = Modifier.width(240.dp))
-        Text(text = "" + "%.0f".format(linearProgress * 100) + "%", color = textColor)
+        BasicText(
+            text = "" + "%.0f".format(linearProgress * 100) + "%",
+            style = TextStyle(color = textColor)
+        )
     }
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp, bottom = 16.dp),
         text = "Circular ProgressIndicator",
-        color = textColor
+        style = TextStyle(color = textColor)
     )
     Row(
         Modifier.height(24.dp),
@@ -242,22 +254,27 @@ private fun DeterminateProgressIndicatorExamples(
             size = CircularProgressIndicatorSize.XLarge,
             style = FluentStyle.Brand
         )
-        Text(text = "" + "%.0f".format(circularProgress * 100) + "%", color = textColor)
+        BasicText(
+            text = "" + "%.0f".format(circularProgress * 100) + "%",
+            style = TextStyle(color = textColor)
+        )
     }
 }
 
 @Composable
 private fun IndeterminateProgressIndicatorExamples(brandTextColor: Color, textColor: Color) {
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp),
         text = "InDeterminate ProgressIndicator",
-        color = brandTextColor,
-        fontSize = 18.sp
+        style = TextStyle(
+            color = brandTextColor,
+            fontSize = 18.sp
+        )
     )
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
         text = "Linear ProgressIndicator",
-        color = textColor
+        style = TextStyle(color = textColor)
     )
     Row(
         Modifier.height(24.dp),
@@ -266,10 +283,10 @@ private fun IndeterminateProgressIndicatorExamples(brandTextColor: Color, textCo
     ) {
         LinearProgressIndicator(modifier = Modifier.width(240.dp))
     }
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp, bottom = 16.dp),
         text = "Circular ProgressIndicator",
-        color = textColor
+        style = TextStyle(color = textColor)
     )
     Row(
         Modifier.height(24.dp),
@@ -285,16 +302,18 @@ private fun IndeterminateProgressIndicatorExamples(brandTextColor: Color, textCo
 
 @Composable
 private fun shimmerExamples(brandTextColor: Color, textColor: Color) {
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp),
         text = "Shimmer",
-        color = brandTextColor,
-        fontSize = 18.sp
+        style = TextStyle(
+            color = brandTextColor,
+            fontSize = 18.sp
+        )
     )
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp),
         text = "Box shimmer",
-        color = textColor
+        style = TextStyle(color = textColor)
     )
     Row(
         modifier = Modifier
@@ -315,10 +334,10 @@ private fun shimmerExamples(brandTextColor: Color, textColor: Color) {
             Shimmer(modifier = Modifier.size(200.dp, 12.dp))
         }
     }
-    Text(
+    BasicText(
         modifier = Modifier.padding(top = 16.dp),
         text = "Circle shimmer",
-        color = textColor
+        style = TextStyle(color = textColor)
     )
     Row(
         modifier = Modifier

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TabBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TabBarActivity.kt
@@ -3,7 +3,7 @@ package com.microsoft.fluentuidemo.demos
 import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
@@ -13,6 +13,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.AppThemeController
 import com.microsoft.fluentui.theme.FluentTheme
@@ -41,7 +42,11 @@ class V2TabBarActivity : DemoActivity() {
         super.onCreate(savedInstanceState)
 
         val context = this
-        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(LayoutInflater.from(container.context), container,true)
+        val v2ActivityComposeBinding = V2ActivityComposeBinding.inflate(
+            LayoutInflater.from(container.context),
+            container,
+            true
+        )
         v2ActivityComposeBinding.composeHere.setContent {
             var selectedIndex by rememberSaveable { mutableStateOf(0) }
             var showHomeBadge by rememberSaveable { mutableStateOf(true) }
@@ -114,11 +119,13 @@ class V2TabBarActivity : DemoActivity() {
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.fillMaxWidth()
                         ) {
-                            Text(
+                            BasicText(
                                 text = resources.getString(R.string.tabBar_vertical),
                                 modifier = Modifier.weight(1F),
-                                color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                    themeMode = ThemeMode.Auto
+                                style = TextStyle(
+                                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                        themeMode = ThemeMode.Auto
+                                    )
                                 )
                             )
                             RadioButton(
@@ -134,11 +141,13 @@ class V2TabBarActivity : DemoActivity() {
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.fillMaxWidth()
                         ) {
-                            Text(
+                            BasicText(
                                 text = resources.getString(R.string.tabBar_horizontal),
                                 modifier = Modifier.weight(1F),
-                                color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                    themeMode = ThemeMode.Auto
+                                style = TextStyle(
+                                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                        themeMode = ThemeMode.Auto
+                                    )
                                 )
                             )
                             RadioButton(
@@ -154,11 +163,13 @@ class V2TabBarActivity : DemoActivity() {
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.fillMaxWidth()
                         ) {
-                            Text(
+                            BasicText(
                                 text = resources.getString(R.string.tabBar_no_text),
                                 modifier = Modifier.weight(1F),
-                                color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                                    themeMode = ThemeMode.Auto
+                                style = TextStyle(
+                                    color = AppThemeController.aliasTokens.value!!.neutralForegroundColor[AliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                        themeMode = ThemeMode.Auto
+                                    )
                                 )
                             )
                             RadioButton(

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -27,6 +27,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -569,11 +570,12 @@ private fun CommandItemComposable(
                     )
                 ), contentAlignment = Alignment.Center
         ) {
-            Text(
+            BasicText(
                 item.label,
                 modifier = Modifier.clearAndSetSemantics { },
-                style = fontTypography,
-                color = foregroundColor,
+                style = fontTypography.merge(
+                    TextStyle(color = foregroundColor)
+                ),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -133,18 +133,21 @@ fun Button(
                 )
 
             if (text != null)
-                Text(
+                BasicText(
                     text = text,
                     modifier = Modifier.clearAndSetSemantics { },
-                    color = token.textColor(buttonInfo = buttonInfo)
-                        .getColorByState(
-                            enabled = enabled,
-                            selected = false,
-                            interactionSource = interactionSource
-                        ),
                     style = token.typography(buttonInfo).merge(
                         TextStyle(
                             platformStyle = PlatformTextStyle(includeFontPadding = false)
+                        )
+                    ).merge(
+                        TextStyle(
+                            color = token.textColor(buttonInfo = buttonInfo)
+                                .getColorByState(
+                                    enabled = enabled,
+                                    selected = false,
+                                    interactionSource = interactionSource
+                                )
                         )
                     ),
                     maxLines = 1,

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -18,6 +18,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -143,14 +144,17 @@ fun FloatingActionButton(
                 )
 
             AnimatedVisibility(isFabExpanded) {
-                Text(
+                BasicText(
                     text = text!!,
                     modifier = Modifier.clearAndSetSemantics { },
-                    style = token.typography(fabInfo),
-                    color = token.textColor(fabInfo = fabInfo).getColorByState(
-                        enabled = enabled,
-                        selected = false,
-                        interactionSource = interactionSource
+                    style = token.typography(fabInfo).merge(
+                        TextStyle(
+                            color = token.textColor(fabInfo = fabInfo).getColorByState(
+                                enabled = enabled,
+                                selected = false,
+                                interactionSource = interactionSource
+                            )
+                        )
                     ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.*
@@ -135,7 +136,7 @@ object ListItem {
         backgroundColor: Color
     ) {
         PlaceholderForActionText(actionTextComposable = {
-            Text(
+            BasicText(
                 text = actionText,
                 style = actionTextTypography,
             )
@@ -169,15 +170,14 @@ object ListItem {
                     Surface(
                         onClick = onClick, color = backgroundColor
                     ) {
-                        Text(
+                        BasicText(
                             text = actionText,
-                            style = actionTextTypography,
-                            color = actionTextColor
+                            style = actionTextTypography.merge(TextStyle(color = actionTextColor))
                         )
                     }
                 })
             )
-            Text(
+            BasicText(
                 text = text, inlineContent = inlineContent
             )
         }
@@ -341,10 +341,9 @@ object ListItem {
                             }
                         }
 
-                        Text(
+                        BasicText(
                             text = text,
-                            style = primaryTextTypography,
-                            color = primaryTextColor,
+                            style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                             maxLines = textMaxLines,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -357,10 +356,9 @@ object ListItem {
                     }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         if (subText != null && textAlignment == ListItemTextAlignment.Regular) {
-                            Text(
+                            BasicText(
                                 text = subText,
-                                style = subTextTypography,
-                                color = subTextColor,
+                                style = subTextTypography.merge(TextStyle(color = subTextColor)),
                                 maxLines = subTextMaxLines,
                                 overflow = TextOverflow.Ellipsis
                             )
@@ -383,10 +381,9 @@ object ListItem {
                                     }
                                 }
                                 if (secondarySubText != null) {
-                                    Text(
+                                    BasicText(
                                         text = secondarySubText,
-                                        style = secondarySubTextTypography,
-                                        color = secondarySubTextColor,
+                                        style = secondarySubTextTypography.merge(TextStyle(color = secondarySubTextColor)),
                                         maxLines = secondarySubTextMaxLines,
                                         overflow = TextOverflow.Ellipsis
                                     )
@@ -541,10 +538,9 @@ object ListItem {
                                         .rotate(rotationState),
                                     tint = chevronTint)
                             }
-                            Text(
+                            BasicText(
                                 text = title,
-                                style = primaryTextTypography,
-                                color = primaryTextColor,
+                                style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                                 maxLines = titleMaxLines,
                                 overflow = TextOverflow.Ellipsis
                             )
@@ -553,12 +549,11 @@ object ListItem {
                     }
                     Row(Modifier.padding(end = padding.calculateEndPadding(LocalLayoutDirection.current))) {
                         if (accessoryTextTitle != null) {
-                            Text(
+                            BasicText(
                                 text = accessoryTextTitle,
                                 Modifier.clickable(role = Role.Button,
                                     onClick = accessoryTextOnClick ?: {}),
-                                color = actionTextColor,
-                                style = actionTextTypography
+                                style = actionTextTypography.merge(TextStyle(color = actionTextColor))
                             )
                         }
                     }
@@ -702,10 +697,9 @@ object ListItem {
                         backgroundColor = backgroundColor
                     )
                 } else {
-                    Text(
+                    BasicText(
                         text = description,
-                        color = descriptionTextColor,
-                        style = descriptionTextTypography
+                        style = descriptionTextTypography.merge(TextStyle(color = descriptionTextColor))
                     )
                 }
             }
@@ -804,7 +798,7 @@ object ListItem {
                     .background(backgroundColor)
                     .focusable(true), verticalAlignment = Alignment.Bottom
             ) {
-                Text(
+                BasicText(
                     text = title,
                     modifier = Modifier
                         .padding(
@@ -813,14 +807,13 @@ object ListItem {
                             bottom = padding.calculateBottomPadding()
                         )
                         .weight(1f),
-                    style = primaryTextTypography,
-                    color = primaryTextColor,
+                    style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                     maxLines = titleMaxLines,
                     overflow = TextOverflow.Ellipsis
                 )
 
                 if (accessoryTextTitle != null) {
-                    Text(
+                    BasicText(
                         text = accessoryTextTitle,
                         Modifier
                             .padding(
@@ -830,8 +823,7 @@ object ListItem {
                             .clickable(
                                 role = Role.Button,
                                 onClick = accessoryTextOnClick ?: {}),
-                        color = actionTextColor,
-                        style = actionTextTypography
+                        style = actionTextTypography.merge(TextStyle(color = actionTextColor))
                     )
                 }
                 if (trailingAccessoryView != null) {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -107,7 +108,7 @@ fun TabItem(
                 iconContent()
             }
 
-            Text(
+            BasicText(
                 text = title,
                 modifier = Modifier
                     .constrainAs(textConstrain) {
@@ -116,8 +117,7 @@ fun TabItem(
                         width = Dimension.preferredWrapContent
                     }
                     .padding(start = 8.dp),
-                color = textColor,
-                textAlign = TextAlign.Center,
+                style = TextStyle(color = textColor, textAlign = TextAlign.Center),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1
             )
@@ -201,10 +201,9 @@ fun TabItem(
             badgeWithIcon()
             if (textAlignment == TabTextAlignment.VERTICAL) {
                 Spacer(modifier = Modifier.height(2.dp))
-                Text(
+                BasicText(
                     text = title,
-                    color = textColor,
-                    textAlign = TextAlign.Center
+                    style = TextStyle(color = textColor, textAlign = TextAlign.Center)
                 )
             }
         }

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -82,12 +82,12 @@ fun Badge(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
         ) {
-            Text(
+            BasicText(
                 text,
                 modifier = Modifier.padding(paddingValues),
-                color = textColor,
                 style = typography.merge(
                     TextStyle(
+                        color = textColor,
                         platformStyle = PlatformTextStyle(
                             includeFontPadding = false
                         )

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.ripple.rememberRipple
@@ -172,7 +172,7 @@ fun CardNudge(
                     .weight(1F)
                     .padding(start = 16.dp)
             ) {
-                Text(
+                BasicText(
                     metadata.message,
                     style = token.titleTypography(cardNudgeInfo),
                 )
@@ -196,7 +196,7 @@ fun CardNudge(
                         }
 
                         if (!metadata.accentText.isNullOrBlank()) {
-                            Text(
+                            BasicText(
                                 metadata.accentText,
                                 style = token.accentTypography(cardNudgeInfo),
                                 modifier = Modifier.testTag(ACCENT_TEXT)
@@ -204,7 +204,7 @@ fun CardNudge(
                         }
 
                         if (!metadata.subTitle.isNullOrBlank()) {
-                            Text(
+                            BasicText(
                                 metadata.subTitle,
                                 style = token.subtitleTypography(cardNudgeInfo),
                                 modifier = Modifier.testTag(SUBTITLE)

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.ripple.rememberRipple
@@ -165,7 +165,7 @@ fun Snackbar(
             }
 
             if (metadata.subTitle.isNullOrBlank()) {
-                Text(
+                BasicText(
                     text = metadata.message,
                     modifier = Modifier
                         .weight(1F)
@@ -178,11 +178,11 @@ fun Snackbar(
                         .weight(1F)
                         .padding(start = 16.dp, top = 12.dp, bottom = 12.dp)
                 ) {
-                    Text(
+                    BasicText(
                         text = metadata.message,
                         style = token.titleTypography(snackBarInfo)
                     )
-                    Text(
+                    BasicText(
                         text = metadata.subTitle,
                         style = token.subtitleTypography(snackBarInfo),
                         modifier = Modifier.testTag(SUBTITLE)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,6 +19,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -124,9 +125,10 @@ fun Avatar(
                     )
                 }
                 personInitials.isNotEmpty() -> {
-                    Text(personInitials,
-                        style = fontTextStyle,
-                        color = foregroundColor,
+                    BasicText(personInitials,
+                        style = fontTextStyle.merge(
+                            TextStyle(color = foregroundColor)
+                        ),
                         modifier = Modifier
                             .clearAndSetSemantics { })
                 }
@@ -278,9 +280,8 @@ fun Avatar(
                         }
                 )
             } else if (group.groupName.isNotEmpty()) {
-                Text(group.getInitials(),
-                    style = fontTextStyle,
-                    color = foregroundColor,
+                BasicText(group.getInitials(),
+                    style = fontTextStyle.merge(TextStyle(color = foregroundColor)),
                     modifier = Modifier.clearAndSetSemantics { })
             } else {
                 Icon(
@@ -335,9 +336,8 @@ fun Avatar(
                 .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            Text("+${overflowCount}",
-                style = fontTextStyle,
-                color = token.foregroundColor(avatarInfo),
+            BasicText("+${overflowCount}",
+                style = fontTextStyle.merge(TextStyle(color = token.foregroundColor(avatarInfo))),
                 modifier = Modifier.clearAndSetSemantics { })
         }
 

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.persona.R
@@ -156,11 +157,14 @@ fun AvatarCarousel(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.Center
                 ) {
-                    Text(
+                    BasicText(
                         modifier = Modifier.clearAndSetSemantics { },
                         text = item.person.firstName,
-                        color = if (item.enabled) textColor.rest else textColor.disabled,
-                        style = textStyle,
+                        style = textStyle.merge(
+                            TextStyle(
+                                color = if (item.enabled) textColor.rest else textColor.disabled
+                            )
+                        ),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -173,11 +177,14 @@ fun AvatarCarousel(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
                     ) {
-                        Text(
+                        BasicText(
                             modifier = Modifier.clearAndSetSemantics { },
                             text = item.person.lastName,
-                            color = if (item.enabled) subTextColor.rest else subTextColor.disabled,
-                            style = subTextStyle,
+                            style = subTextStyle.merge(
+                                TextStyle(
+                                    color = if (item.enabled) subTextColor.rest else subTextColor.disabled
+                                )
+                            ),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.ripple.rememberRipple
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.persona.R
 import com.microsoft.fluentui.theme.FluentTheme
@@ -120,10 +121,11 @@ fun PersonaChip(
                     Avatar(person = person, size = avatarSize)
                 }
             }
-            Text(
+            BasicText(
                 text = person.getLabel(),
-                color = textColor,
-                style = typography
+                style = typography.merge(
+                    TextStyle(color = textColor)
+                )
             )
         }
     }

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.ripple.rememberRipple
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.persona.R
 import com.microsoft.fluentui.theme.FluentTheme
@@ -122,11 +123,14 @@ fun SearchBarPersonaChip(
                     Avatar(person = person, size = avatarSize)
                 }
             }
-            Text(
+            BasicText(
                 modifier = Modifier.padding(bottom = 2.dp),//Vertically center align text
                 text = person.getLabel(),
-                color = textColor,
-                style = fontStyle
+                style = fontStyle.merge(
+                    TextStyle(
+                        color = textColor
+                    )
+                )
             )
         }
     }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tablayout.R
@@ -179,13 +180,14 @@ fun PillButton(
                 )
             } else {
                 Spacer(Modifier.requiredWidth(GlobalTokens.size(GlobalTokens.SizeTokens.Size160)))
-                Text(
+                BasicText(
                     pillMetaData.text,
                     modifier = Modifier
                         .weight(1F)
                         .clearAndSetSemantics { },
-                    color = textColor,
-                    style = fontStyle,
+                    style = fontStyle.merge(
+                        TextStyle(color = textColor)
+                    ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -160,11 +160,11 @@ fun AppBar(
                                         Modifier
                                 ), verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
+                            BasicText(
                                 text = title,
-                                color = token.titleTextColor(appBarInfo),
                                 style = titleTextStyle.merge(
                                     TextStyle(
+                                        color = token.titleTextColor(appBarInfo),
                                         platformStyle = PlatformTextStyle(includeFontPadding = true)
                                     )
                                 ),
@@ -199,13 +199,13 @@ fun AppBar(
                                         ),
                                     tint = token.subtitleIconColor(appBarInfo)
                                 )
-                            Text(
+                            BasicText(
                                 subTitle,
-                                color = token.subtitleTextColor(
-                                    appBarInfo
-                                ),
                                 style = subtitleTextStyle.merge(
                                     TextStyle(
+                                        color = token.subtitleTextColor(
+                                            appBarInfo
+                                        ),
                                         platformStyle = PlatformTextStyle(includeFontPadding = true)
                                     )
                                 ),
@@ -226,14 +226,14 @@ fun AppBar(
                         }
                     }
                 } else {
-                    Text(
+                    BasicText(
                         text = title,
                         modifier = Modifier
                             .padding(token.textPadding(appBarInfo))
                             .weight(1F),
-                        color = token.titleTextColor(appBarInfo),
                         style = titleTextStyle.merge(
                             TextStyle(
+                                color = token.titleTextColor(appBarInfo),
                                 platformStyle = PlatformTextStyle(
                                     includeFontPadding = true
                                 )

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -257,7 +257,7 @@ fun SearchBar(
                             }
                         }
                         .padding(horizontal = 8.dp)
-                        .semantics {contentDescription = searchHint},
+                        .semantics { contentDescription = searchHint },
                     textStyle = token.typography(searchBarInfo).merge(
                         TextStyle(
                             color = token.textColor(searchBarInfo),
@@ -273,10 +273,10 @@ fun SearchBar(
                                 Alignment.CenterStart
                         ) {
                             if (queryText.isEmpty()) {
-                                Text(
+                                BasicText(
                                     searchHint,
-                                    style = token.typography(searchBarInfo),
-                                    color = token.textColor(searchBarInfo)
+                                    style = token.typography(searchBarInfo)
+                                        .merge(TextStyle(color = token.textColor(searchBarInfo)))
                                 )
                             }
                         }


### PR DESCRIPTION
### Problem 
In order to remove Material dependency, we need to move Material's Text to Compose's Basic Text.

### Root cause 
Material developed Text API to simplify the formatting. They brought the TextStyle Parameters outside as API params. Since our typography tokens output textStyle, we can use the BasicText API reducing the dependency on Material.

### Fix
1. Update all imports
2. Replace Text API calls with BasicText.
3. Since color is not an API param in BasicText, we needed to merge it as TextStyle and passback to style

### Validations
Manual Validation and Automated Tests

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
