### PR TITLE
Use Brush instead of Color for areas where gradient can be applied

### DIFF
--- a/FluentUI.Demo/src/main/java/com/example/theme/token/GradientTokens.kt
+++ b/FluentUI.Demo/src/main/java/com/example/theme/token/GradientTokens.kt
@@ -1,0 +1,37 @@
+package com.example.theme.token
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.StateBrush
+import com.microsoft.fluentui.theme.token.controlTokens.AppBarInfo
+import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
+import com.microsoft.fluentui.theme.token.controlTokens.FABInfo
+import com.microsoft.fluentui.theme.token.controlTokens.FABTokens
+
+private var gradient = Brush.linearGradient(
+    0.0f to Color(0xFF464FEB),
+    0.7f to Color(0xFF47CFFA),
+    0.92f to Color(0xFFB47CF8),
+    start = Offset.Zero,
+    end = Offset.Infinite
+)
+
+class MyAppBarToken : AppBarTokens() {
+    @Composable
+    override fun backgroundColor(info: AppBarInfo): Brush {
+        return if (info.style == FluentStyle.Brand) gradient else super.backgroundColor(info)
+    }
+}
+
+class MyFABToken : FABTokens() {
+    @Composable
+    override fun backgroundColor(info: FABInfo): StateBrush {
+        return StateBrush(
+            rest = gradient,
+            pressed = gradient,
+        )
+    }
+}

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
@@ -111,7 +111,7 @@ class V2ButtonsActivity : DemoActivity() {
                                 size = ButtonSize.Medium,
                                 onClick = {
                                     FluentTheme.updateControlTokens(
-                                        controlTokens.updateToken(
+                                        ControlTokens().updateToken(
                                             ControlTokens.ControlType.AppBar,
                                             MyAppBarToken()
                                         ).updateToken(

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.example.theme.token.MyAliasTokens
+import com.example.theme.token.MyAppBarToken
 import com.example.theme.token.MyButtonTokens
+import com.example.theme.token.MyFABToken
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.FluentTheme.themeMode
 import com.microsoft.fluentui.theme.token.AliasTokens
@@ -86,7 +88,7 @@ class V2ButtonsActivity : DemoActivity() {
                                         )
                                     )
                                 },
-                                text = "Set Default Theme"
+                                text = "Theme 1"
                             )
 
                             Button(
@@ -101,7 +103,24 @@ class V2ButtonsActivity : DemoActivity() {
                                         )
                                     )
                                 },
-                                text = "Set New Theme"
+                                text = "Theme 2"
+                            )
+
+                            Button(
+                                style = ButtonStyle.OutlinedButton,
+                                size = ButtonSize.Medium,
+                                onClick = {
+                                    FluentTheme.updateControlTokens(
+                                        controlTokens.updateToken(
+                                            ControlTokens.ControlType.AppBar,
+                                            MyAppBarToken()
+                                        ).updateToken(
+                                            ControlTokens.ControlType.FloatingActionButton,
+                                            MyFABToken()
+                                        )
+                                    )
+                                },
+                                text = "Theme 3"
                             )
                         }
                     }
@@ -157,7 +176,7 @@ class V2ButtonsActivity : DemoActivity() {
                             BasicText(
                                 "Button with selected theme, auto mode and overridden control token",
                                 style = TextStyle(
-                                    color = FluentTheme.aliasTokens.neutralForegroundColor[com.microsoft.fluentui.theme.token.FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                                    color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                                         themeMode
                                     )
                                 )
@@ -174,12 +193,12 @@ class V2ButtonsActivity : DemoActivity() {
                         .fillMaxSize()
                         .focusable(false)
                 ) {
-                    val fabText: String? = "FAB Text"
+                    val fabText = "FAB Text"
                     FloatingActionButton(
                         size = FABSize.Small,
                         state = fabState,
                         onClick = {
-                            var toastText = "No Text"
+                            val toastText: String
                             if (fabState == FABState.Expanded) {
                                 toastText = "FAB Collapsed"
                                 fabState = FABState.Collapsed

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -222,7 +222,7 @@ fun ContextualCommandBar(
                                                 .buttonBackgroundColor(
                                                     contextualCommandBarInfo
                                                 )
-                                                .getColorByState(
+                                                .getBrushByState(
                                                     enabled = item.enabled,
                                                     selected = item.selected,
                                                     interactionSource = interactionSource
@@ -349,7 +349,7 @@ fun ContextualCommandBar(
                                             .buttonBackgroundColor(
                                                 contextualCommandBarInfo
                                             )
-                                            .getColorByState(
+                                            .getBrushByState(
                                                 enabled = item.enabled,
                                                 selected = item.selected,
                                                 interactionSource = interactionSource

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -69,7 +69,7 @@ fun Button(
         onClick = onClick
     )
     val backgroundColor =
-        token.backgroundColor(buttonInfo = buttonInfo).getColorByState(
+        token.backgroundColor(buttonInfo = buttonInfo).getBrushByState(
             enabled = enabled,
             selected = false,
             interactionSource = interactionSource
@@ -95,7 +95,7 @@ fun Button(
         modifier
             .height(token.fixedHeight(buttonInfo))
             .background(
-                color = backgroundColor,
+                brush = backgroundColor,
                 shape = shape
             )
             .clip(shape)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
@@ -68,8 +69,8 @@ fun CheckBox(
             )
         )
 
-    val backgroundColor: Color =
-        token.backgroundColor(checkBoxInfo = checkBoxInfo).getColorByState(
+    val backgroundColor: Brush =
+        token.backgroundColor(checkBoxInfo = checkBoxInfo).getBrushByState(
             enabled = enabled,
             selected = checked,
             interactionSource = interactionSource

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
@@ -71,7 +71,7 @@ fun FloatingActionButton(
     )
     val isFabExpanded: Boolean =
         (text != null && text != "" && fabInfo.state == FABState.Expanded)
-    val backgroundColor = token.backgroundColor(fabInfo = fabInfo).getColorByState(
+    val backgroundColor = token.backgroundColor(fabInfo = fabInfo).getBrushByState(
         enabled = enabled,
         selected = false,
         interactionSource = interactionSource
@@ -109,7 +109,7 @@ fun FloatingActionButton(
                 shape = CircleShape
             )
             .background(
-                color = backgroundColor,
+                brush = backgroundColor,
                 shape = shape
             )
             .clip(shape)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
@@ -67,7 +67,7 @@ fun RadioButton(
 
     val outerStrokeColor =
         token.backgroundColor(radioButtonInfo = radioButtonInfo)
-            .getColorByState(
+            .getBrushByState(
                 enabled = enabled,
                 selected = selected,
                 interactionSource = interactionSource

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -239,7 +239,7 @@ fun TextField(
                         }
 
                         @Composable
-                        override fun dividerColor(dividerInfo: DividerInfo): Color =
+                        override fun dividerColor(dividerInfo: DividerInfo): Brush =
                             token.dividerColor(textFieldInfo)
                     }
                 )

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentColor.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentColor.kt
@@ -12,18 +12,23 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import com.microsoft.fluentui.theme.ThemeMode
 
-data class StateColor(
-    val rest: Color = Color.Unspecified,
-    val pressed: Color = Color.Unspecified,
-    val selected: Color = Color.Unspecified,
-    val focused: Color = Color.Unspecified,
-    val selectedPressed: Color = Color.Unspecified,
-    val selectedFocused: Color = Color.Unspecified,
-    val selectedDisabled: Color = Color.Unspecified,
-    val disabled: Color = Color.Unspecified
+private val unspecifiedColor = Color.Unspecified
+private val unspecifiedBrush = SolidColor(Color.Unspecified)
+
+class StateColor(
+    val rest: Color = unspecifiedColor,
+    val pressed: Color = unspecifiedColor,
+    val selected: Color = unspecifiedColor,
+    val focused: Color = unspecifiedColor,
+    val selectedPressed: Color = unspecifiedColor,
+    val selectedFocused: Color = unspecifiedColor,
+    val selectedDisabled: Color = unspecifiedColor,
+    val disabled: Color = unspecifiedColor
 ) {
     @Composable
     fun getColorByState(
@@ -61,6 +66,53 @@ data class StateColor(
     }
 }
 
+class StateBrush(
+    val rest: Brush = unspecifiedBrush,
+    val pressed: Brush = unspecifiedBrush,
+    val selected: Brush = unspecifiedBrush,
+    val focused: Brush = unspecifiedBrush,
+    val selectedPressed: Brush = unspecifiedBrush,
+    val selectedFocused: Brush = unspecifiedBrush,
+    val selectedDisabled: Brush = unspecifiedBrush,
+    val disabled: Brush = unspecifiedBrush,
+) {
+
+    @Composable
+    fun getBrushByState(
+        enabled: Boolean,
+        selected: Boolean,
+        interactionSource: InteractionSource
+    ): Brush {
+        if (enabled) {
+            val isPressed by interactionSource.collectIsPressedAsState()
+            if (selected && isPressed)
+                return this.selectedPressed
+            else if (isPressed)
+                return this.pressed
+
+            val isFocused by interactionSource.collectIsFocusedAsState()
+            if (selected && isFocused)
+                return this.selectedFocused
+            else if (isFocused)
+                return this.focused
+
+            val isHovered by interactionSource.collectIsHoveredAsState()
+            if (selected && isHovered)
+                return this.selectedFocused
+            if (isHovered)
+                return this.focused
+
+            if (selected)
+                return this.selected
+
+            return this.rest
+        } else if (selected)
+            return this.selectedDisabled
+        else
+            return this.disabled
+    }
+}
+
 data class FluentColor(
     val light: Color,
     val dark: Color = light,
@@ -68,6 +120,21 @@ data class FluentColor(
 
     @Composable
     fun value(themeMode: ThemeMode = com.microsoft.fluentui.theme.FluentTheme.themeMode): Color {
+        return when (themeMode) {
+            ThemeMode.Light -> light
+            ThemeMode.Dark -> dark
+            ThemeMode.Auto -> if (isSystemInDarkTheme()) dark else light
+        }
+    }
+}
+
+data class FluentBrush(
+    val light: Brush,
+    val dark: Brush = light,
+) {
+
+    @Composable
+    fun value(themeMode: ThemeMode = com.microsoft.fluentui.theme.FluentTheme.themeMode): Brush {
         return when (themeMode) {
             ThemeMode.Light -> light
             ThemeMode.Dark -> dark

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentColor.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentColor.kt
@@ -127,18 +127,3 @@ data class FluentColor(
         }
     }
 }
-
-data class FluentBrush(
-    val light: Brush,
-    val dark: Brush = light,
-) {
-
-    @Composable
-    fun value(themeMode: ThemeMode = com.microsoft.fluentui.theme.FluentTheme.themeMode): Brush {
-        return when (themeMode) {
-            ThemeMode.Light -> light
-            ThemeMode.Dark -> dark
-            ThemeMode.Auto -> if (isSystemInDarkTheme()) dark else light
-        }
-    }
-}

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -3,7 +3,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -28,22 +30,24 @@ data class AppBarInfo(
 open class AppBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(info: AppBarInfo): Color {
-        return when (info.style) {
-            FluentStyle.Neutral ->
-                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                    themeMode = FluentTheme.themeMode
-                )
-            FluentStyle.Brand ->
-                FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                        ThemeMode.Dark
+    open fun backgroundColor(info: AppBarInfo): Brush {
+        return SolidColor(
+            when (info.style) {
+                FluentStyle.Neutral ->
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                        themeMode = FluentTheme.themeMode
                     )
-                ).value(themeMode = FluentTheme.themeMode)
-        }
+                FluentStyle.Brand ->
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(themeMode = FluentTheme.themeMode)
+            }
+        )
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarCarouselTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarCarouselTokens.kt
@@ -2,6 +2,7 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -28,16 +29,22 @@ open class AvatarCarouselTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(avatarCarouselInfo: AvatarCarouselInfo): StateColor {
-        return StateColor(
-            rest = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                themeMode = FluentTheme.themeMode
+    open fun backgroundColor(avatarCarouselInfo: AvatarCarouselInfo): StateBrush {
+        return StateBrush(
+            rest = SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                    themeMode = FluentTheme.themeMode
+                )
             ),
-            pressed = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1Pressed].value(
-                themeMode = FluentTheme.themeMode
+            pressed = SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1Pressed].value(
+                    themeMode = FluentTheme.themeMode
+                )
             ),
-            disabled = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                themeMode = FluentTheme.themeMode
+            disabled = SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                    themeMode = FluentTheme.themeMode
+                )
             )
         )
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
@@ -3,7 +3,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
@@ -324,44 +326,46 @@ open class AvatarTokens(private val activityRingToken: ActivityRingsToken = Acti
     }
 
     @Composable
-    open fun backgroundColor(avatarInfo: AvatarInfo): Color {
-        return if (avatarInfo.isImageAvailable || avatarInfo.hasValidInitials) {
-            FluentColor(
-                light = calculatedColor(
-                    avatarInfo.calculatedColorKey,
-                    FluentGlobalTokens.SharedColorsTokens.Tint40
-                ),
-                dark = calculatedColor(
-                    avatarInfo.calculatedColorKey,
-                    FluentGlobalTokens.SharedColorsTokens.Shade30
+    open fun backgroundColor(avatarInfo: AvatarInfo): Brush {
+        return SolidColor(
+            if (avatarInfo.isImageAvailable || avatarInfo.hasValidInitials) {
+                FluentColor(
+                    light = calculatedColor(
+                        avatarInfo.calculatedColorKey,
+                        FluentGlobalTokens.SharedColorsTokens.Tint40
+                    ),
+                    dark = calculatedColor(
+                        avatarInfo.calculatedColorKey,
+                        FluentGlobalTokens.SharedColorsTokens.Shade30
+                    )
+                ).value(
+                    themeMode = themeMode
                 )
-            ).value(
-                themeMode = themeMode
-            )
-        } else if (avatarInfo.type == AvatarType.Overflow) {
-            aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                themeMode = themeMode
-            )
-        } else {
-            when (avatarStyle(avatarInfo)) {
-                AvatarStyle.Standard ->
-                    aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        themeMode = themeMode
-                    )
-                AvatarStyle.StandardInverted ->
-                    aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                        themeMode = themeMode
-                    )
-                AvatarStyle.Anonymous ->
-                    aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                        themeMode = themeMode
-                    )
-                AvatarStyle.AnonymousAccent ->
-                    aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(
-                        themeMode = themeMode
-                    )
+            } else if (avatarInfo.type == AvatarType.Overflow) {
+                aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    themeMode = themeMode
+                )
+            } else {
+                when (avatarStyle(avatarInfo)) {
+                    AvatarStyle.Standard ->
+                        aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                            themeMode = themeMode
+                        )
+                    AvatarStyle.StandardInverted ->
+                        aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                            themeMode = themeMode
+                        )
+                    AvatarStyle.Anonymous ->
+                        aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                            themeMode = themeMode
+                        )
+                    AvatarStyle.AnonymousAccent ->
+                        aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(
+                            themeMode = themeMode
+                        )
+                }
             }
-        }
+        )
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BadgeTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BadgeTokens.kt
@@ -4,7 +4,9 @@ import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -25,8 +27,8 @@ class BadgeInfo(val type: BadgeType) : ControlInfo
 open class BadgeTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(badgeInfo: BadgeInfo): Color {
-        return FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerBackground2].value()
+    open fun backgroundColor(badgeInfo: BadgeInfo): Brush {
+        return SolidColor(FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerBackground2].value())
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BottomSheetTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BottomSheetTokens.kt
@@ -2,7 +2,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -17,9 +19,11 @@ class BottomSheetInfo : ControlInfo
 open class BottomSheetTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(bottomSheetInfo: BottomSheetInfo): Color =
-        FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
-            themeMode = FluentTheme.themeMode
+    open fun backgroundColor(bottomSheetInfo: BottomSheetInfo): Brush =
+        SolidColor(
+            FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
@@ -9,6 +9,7 @@ import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -122,28 +123,38 @@ open class ButtonTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(buttonInfo: ButtonInfo): StateColor {
+    open fun backgroundColor(buttonInfo: ButtonInfo): StateBrush {
         return when (buttonInfo.style) {
             ButtonStyle.Button ->
-                StateColor(
-                    rest = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        themeMode = themeMode
+                StateBrush(
+                    rest = SolidColor(
+                        aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                            themeMode = themeMode
+                        )
                     ),
-                    pressed = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
-                        themeMode = themeMode
+                    pressed = SolidColor(
+                        aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
+                            themeMode = themeMode
+                        )
                     ),
-                    selected = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
-                        themeMode = themeMode
+                    selected = SolidColor(
+                        aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
+                            themeMode = themeMode
+                        )
                     ),
-                    focused = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        themeMode = themeMode
+                    focused = SolidColor(
+                        aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                            themeMode = themeMode
+                        )
                     ),
-                    disabled = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                        themeMode = themeMode
+                    disabled = SolidColor(
+                        aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                            themeMode = themeMode
+                        )
                     )
                 )
-            ButtonStyle.OutlinedButton -> StateColor()
-            ButtonStyle.TextButton -> StateColor()
+            ButtonStyle.OutlinedButton -> StateBrush()
+            ButtonStyle.TextButton -> StateBrush()
         }
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CardNudgeTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CardNudgeTokens.kt
@@ -2,7 +2,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -20,8 +22,8 @@ class CardNudgeInfo : ControlInfo
 open class CardNudgeTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(cardNudgeInfo: CardNudgeInfo): Color {
-        return aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.CanvasBackground].value()
+    open fun backgroundColor(cardNudgeInfo: CardNudgeInfo): Brush {
+        return SolidColor(aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.CanvasBackground].value())
     }
 
     @Composable
@@ -35,8 +37,8 @@ open class CardNudgeTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun iconBackgroundColor(cardNudgeInfo: CardNudgeInfo): Color {
-        return aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()
+    open fun iconBackgroundColor(cardNudgeInfo: CardNudgeInfo): Brush {
+        return SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value())
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CheckBoxTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CheckBoxTokens.kt
@@ -3,11 +3,13 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme.aliasTokens
 import com.microsoft.fluentui.theme.FluentTheme.themeMode
 import com.microsoft.fluentui.theme.token.*
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 data class CheckBoxInfo(
@@ -17,18 +19,27 @@ data class CheckBoxInfo(
 @Parcelize
 open class CheckBoxTokens : IControlToken, Parcelable {
 
+    @IgnoredOnParcel
     val fixedSize: Dp = 20.dp
+
+    @IgnoredOnParcel
     val fixedIconSize: Dp = 12.dp
+
+    @IgnoredOnParcel
     val fixedBorderRadius: Dp = 4.dp
 
     @Composable
-    open fun backgroundColor(checkBoxInfo: CheckBoxInfo): StateColor {
-        return StateColor(
-            selected = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+    open fun backgroundColor(checkBoxInfo: CheckBoxInfo): StateBrush {
+        return StateBrush(
+            selected = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            selectedDisabled = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundDisabled].value(
-                themeMode = themeMode
+            selectedDisabled = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundDisabled].value(
+                    themeMode = themeMode
+                )
             )
         )
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CircularProgressIndicatorTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CircularProgressIndicatorTokens.kt
@@ -2,7 +2,8 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -56,18 +57,20 @@ open class CircularProgressIndicatorTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun color(circularProgressIndicatorInfo: CircularProgressIndicatorInfo): Color {
-        return if (circularProgressIndicatorInfo.style == FluentStyle.Neutral) {
-            FluentColor(
-                light = FluentGlobalTokens.neutralColor(FluentGlobalTokens.NeutralColorTokens.Grey56),
-                dark = FluentGlobalTokens.neutralColor(FluentGlobalTokens.NeutralColorTokens.Grey72)
-            ).value(
-                themeMode = FluentTheme.themeMode
-            )
-        } else {
-            FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = FluentTheme.themeMode
-            )
-        }
+    open fun color(circularProgressIndicatorInfo: CircularProgressIndicatorInfo): Brush {
+        return SolidColor(
+            if (circularProgressIndicatorInfo.style == FluentStyle.Neutral) {
+                FluentColor(
+                    light = FluentGlobalTokens.neutralColor(FluentGlobalTokens.NeutralColorTokens.Grey56),
+                    dark = FluentGlobalTokens.neutralColor(FluentGlobalTokens.NeutralColorTokens.Grey72)
+                ).value(
+                    themeMode = FluentTheme.themeMode
+                )
+            } else {
+                FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = FluentTheme.themeMode
+                )
+            }
+        )
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ContextualCommandBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ContextualCommandBarTokens.kt
@@ -4,7 +4,9 @@ import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -20,9 +22,11 @@ class ContextualCommandBarInfo : ControlInfo
 open class ContextualCommandBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun actionButtonBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): Color {
-        return aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
-            themeMode = themeMode
+    open fun actionButtonBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): Brush {
+        return SolidColor(
+            aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
+                themeMode = themeMode
+            )
         )
     }
 
@@ -58,9 +62,11 @@ open class ContextualCommandBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun contextualCommandBarBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): Color {
-        return aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
-            themeMode = themeMode
+    open fun contextualCommandBarBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): Brush {
+        return SolidColor(
+            aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
+                themeMode = themeMode
+            )
         )
     }
 
@@ -120,35 +126,47 @@ open class ContextualCommandBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun buttonBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): StateColor {
-        return StateColor(
-            rest = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                themeMode = themeMode
-            ),
-            pressed = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
-                themeMode = themeMode
-            ),
-            focused = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                themeMode = themeMode
-            ),
-            selected = FluentColor(
-                light = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(
-                    themeMode = ThemeMode.Light
-                ),
-                dark = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
-                    themeMode = ThemeMode.Dark
+    open fun buttonBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): StateBrush {
+        return StateBrush(
+            rest = SolidColor(
+                aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    themeMode = themeMode
                 )
-            ).value(themeMode = themeMode),
-            selectedFocused = FluentColor(
-                light = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(
-                    themeMode = ThemeMode.Light
-                ),
-                dark = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
-                    themeMode = ThemeMode.Dark
+            ),
+            pressed = SolidColor(
+                aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
+                    themeMode = themeMode
                 )
-            ).value(themeMode = themeMode),
-            disabled = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                themeMode = themeMode
+            ),
+            focused = SolidColor(
+                aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    themeMode = themeMode
+                )
+            ),
+            selected = SolidColor(
+                FluentColor(
+                    light = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(
+                        themeMode = ThemeMode.Light
+                    ),
+                    dark = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
+                        themeMode = ThemeMode.Dark
+                    )
+                ).value(themeMode = themeMode)
+            ),
+            selectedFocused = SolidColor(
+                FluentColor(
+                    light = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(
+                        themeMode = ThemeMode.Light
+                    ),
+                    dark = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
+                        themeMode = ThemeMode.Dark
+                    )
+                ).value(themeMode = themeMode)
+            ),
+            disabled = SolidColor(
+                aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    themeMode = themeMode
+                )
             )
         )
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
@@ -3,7 +3,8 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -17,16 +18,20 @@ class DividerInfo : ControlInfo
 @Parcelize
 open class DividerTokens : IControlToken, Parcelable {
     @Composable
-    open fun background(dividerInfo: DividerInfo): Color {
-        return FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-            FluentTheme.themeMode
+    open fun background(dividerInfo: DividerInfo): Brush {
+        return SolidColor(
+            FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                FluentTheme.themeMode
+            )
         )
     }
 
     @Composable
-    open fun dividerColor(dividerInfo: DividerInfo): Color {
-        return FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value(
-            themeMode = FluentTheme.themeMode
+    open fun dividerColor(dividerInfo: DividerInfo): Brush {
+        return SolidColor(
+            FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
@@ -2,7 +2,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -24,9 +26,11 @@ data class DrawerInfo(val type: BehaviorType = BehaviorType.LEFT_SLIDE_OVER) : C
 open class DrawerTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(drawerInfo: DrawerInfo): Color =
-        FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
-            themeMode = FluentTheme.themeMode
+    open fun backgroundColor(drawerInfo: DrawerInfo): Brush =
+        SolidColor(
+            FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
@@ -9,6 +9,7 @@ import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -72,22 +73,32 @@ open class FABTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(fabInfo: FABInfo): StateColor {
-        return StateColor(
-            rest = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+    open fun backgroundColor(fabInfo: FABInfo): StateBrush {
+        return StateBrush(
+            rest = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            pressed = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
-                themeMode = themeMode
+            pressed = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Pressed].value(
+                    themeMode = themeMode
+                )
             ),
-            selected = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
-                themeMode = themeMode
+            selected = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1Selected].value(
+                    themeMode = themeMode
+                )
             ),
-            focused = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+            focused = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            disabled = aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                themeMode = themeMode
+            disabled = SolidColor(
+                aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    themeMode = themeMode
+                )
             )
         )
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -77,13 +78,17 @@ data class ListItemInfo(
 @Parcelize
 open class ListItemTokens : IControlToken, Parcelable {
     @Composable
-    open fun backgroundColor(listItemInfo: ListItemInfo): StateColor {
-        return StateColor(
-            rest = FluentTheme.aliasTokens.neutralBackgroundColor[Background1].value(
-                themeMode = FluentTheme.themeMode
+    open fun backgroundColor(listItemInfo: ListItemInfo): StateBrush {
+        return StateBrush(
+            rest = SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[Background1].value(
+                    themeMode = FluentTheme.themeMode
+                )
             ),
-            pressed = FluentTheme.aliasTokens.neutralBackgroundColor[Background1Pressed].value(
-                themeMode = FluentTheme.themeMode
+            pressed = SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[Background1Pressed].value(
+                    themeMode = FluentTheme.themeMode
+                )
             )
         )
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/MenuTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/MenuTokens.kt
@@ -2,7 +2,8 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -17,9 +18,11 @@ class MenuInfo : ControlInfo
 open class MenuTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(menuInfo: MenuInfo): Color =
-        FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
-            themeMode = FluentTheme.themeMode
+    open fun backgroundColor(menuInfo: MenuInfo): Brush =
+        SolidColor(
+            FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PersonaChipTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PersonaChipTokens.kt
@@ -2,6 +2,7 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -46,61 +47,89 @@ data class PersonaChipInfo(
 open class PersonaChipTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(personaChipInfo: PersonaChipControlInfo): StateColor {
+    open fun backgroundColor(personaChipInfo: PersonaChipControlInfo): StateBrush {
         personaChipInfo as PersonaChipInfo
         when (personaChipInfo.style) {
-            PersonaChipStyle.Neutral -> return StateColor(
-                rest = FluentTheme.aliasTokens.neutralBackgroundColor[Background5].value(
-                    themeMode = FluentTheme.themeMode
+            PersonaChipStyle.Neutral -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[Background5].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.neutralBackgroundColor[Background5Selected].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[Background5Selected].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                disabled = FluentTheme.aliasTokens.neutralBackgroundColor[Background5].value(
-                    themeMode = FluentTheme.themeMode
+                disabled = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[Background5].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            PersonaChipStyle.Brand -> return StateColor(
-                rest = FluentTheme.aliasTokens.brandBackgroundColor[BrandBackgroundTint].value(
-                    themeMode = FluentTheme.themeMode
+            PersonaChipStyle.Brand -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[BrandBackgroundTint].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.brandBackgroundColor[BrandBackground1].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[BrandBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                disabled = FluentTheme.aliasTokens.neutralBackgroundColor[Background5].value(
-                    themeMode = FluentTheme.themeMode
+                disabled = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[Background5].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            PersonaChipStyle.Danger -> return StateColor(
-                rest = FluentTheme.aliasTokens.errorAndStatusColor[DangerBackground1].value(
-                    themeMode = FluentTheme.themeMode
+            PersonaChipStyle.Danger -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[DangerBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.errorAndStatusColor[DangerBackground2].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[DangerBackground2].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            PersonaChipStyle.SevereWarning -> return StateColor(
-                rest = FluentTheme.aliasTokens.errorAndStatusColor[SevereBackground1].value(
-                    themeMode = FluentTheme.themeMode
+            PersonaChipStyle.SevereWarning -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[SevereBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.errorAndStatusColor[SevereBackground2].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[SevereBackground2].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            PersonaChipStyle.Warning -> return StateColor(
-                rest = FluentTheme.aliasTokens.errorAndStatusColor[WarningBackground1].value(
-                    themeMode = FluentTheme.themeMode
+            PersonaChipStyle.Warning -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[WarningBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.errorAndStatusColor[WarningBackground2].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[WarningBackground2].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            PersonaChipStyle.Success -> return StateColor(
-                rest = FluentTheme.aliasTokens.errorAndStatusColor[SuccessBackground1].value(
-                    themeMode = FluentTheme.themeMode
+            PersonaChipStyle.Success -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[SuccessBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.errorAndStatusColor[SuccessBackground2].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.errorAndStatusColor[SuccessBackground2].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
         }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillBarTokens.kt
@@ -2,7 +2,8 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.*
@@ -16,19 +17,23 @@ data class PillBarInfo(
 open class PillBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun background(pillBarInfo: PillBarInfo): Color {
+    open fun background(pillBarInfo: PillBarInfo): Brush {
         return when (pillBarInfo.style) {
-            FluentStyle.Neutral -> FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                FluentTheme.themeMode
-            )
-            FluentStyle.Brand -> FluentColor(
-                light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                    ThemeMode.Light
-                ),
-                dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                    ThemeMode.Dark
+            FluentStyle.Neutral -> SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                    FluentTheme.themeMode
                 )
-            ).value(FluentTheme.themeMode)
+            )
+            FluentStyle.Brand -> SolidColor(
+                FluentColor(
+                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        ThemeMode.Light
+                    ),
+                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                        ThemeMode.Dark
+                    )
+                ).value(FluentTheme.themeMode)
+            )
         }
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
@@ -3,6 +3,7 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -32,94 +33,122 @@ open class PillButtonTokens : IControlToken, Parcelable {
         FluentGlobalTokens.iconSize(FluentGlobalTokens.IconSizeTokens.IconSize200)
 
     @Composable
-    open fun backgroundColor(pillButtonInfo: PillButtonInfo): StateColor {
+    open fun backgroundColor(pillButtonInfo: PillButtonInfo): StateBrush {
         when (pillButtonInfo.style) {
-            FluentStyle.Neutral -> return StateColor(
-                rest = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                    themeMode = FluentTheme.themeMode
+            FluentStyle.Neutral -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                pressed = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
-                    themeMode = FluentTheme.themeMode
+                pressed = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selectedPressed = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                    themeMode = FluentTheme.themeMode
+                selectedPressed = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selectedDisabled = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                    themeMode = FluentTheme.themeMode
+                selectedDisabled = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                focused = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
-                    themeMode = FluentTheme.themeMode
+                focused = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                disabled = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                    themeMode = FluentTheme.themeMode
+                disabled = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            FluentStyle.Brand -> return StateColor(
-                rest = FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode),
+            FluentStyle.Brand -> return StateBrush(
+                rest = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                ),
 
-                pressed = FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2Pressed].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode),
+                pressed = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2Pressed].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                ),
 
-                selected = FluentColor(
-                    light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode),
+                selected = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                ),
 
-                selectedPressed = FluentColor(
-                    light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode),
+                selectedPressed = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Pressed].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                ),
 
-                selectedDisabled = FluentColor(
-                    light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode),
+                selectedDisabled = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                ),
 
-                focused = FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2Selected].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode),
+                focused = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2Selected].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5Selected].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                ),
 
-                disabled = FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                        ThemeMode.Dark
-                    )
-                ).value(FluentTheme.themeMode)
+                disabled = SolidColor(
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(FluentTheme.themeMode)
+                )
             )
         }
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillSwitchTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillSwitchTokens.kt
@@ -2,7 +2,8 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -19,19 +20,23 @@ data class PillSwitchInfo(
 open class PillSwitchTokens : PillBarTokens(), Parcelable {
 
     @Composable
-    open fun background(pillSwitchInfo: PillSwitchInfo): Color {
+    open fun background(pillSwitchInfo: PillSwitchInfo): Brush {
         return when (pillSwitchInfo.style) {
-            FluentStyle.Neutral -> FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                FluentTheme.themeMode
-            )
-            FluentStyle.Brand -> FluentColor(
-                light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
-                    ThemeMode.Light
-                ),
-                dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                    ThemeMode.Dark
+            FluentStyle.Neutral -> SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    FluentTheme.themeMode
                 )
-            ).value(FluentTheme.themeMode)
+            )
+            FluentStyle.Brand -> SolidColor(
+                FluentColor(
+                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
+                        ThemeMode.Light
+                    ),
+                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        ThemeMode.Dark
+                    )
+                ).value(FluentTheme.themeMode)
+            )
         }
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillTabsTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillTabsTokens.kt
@@ -2,7 +2,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -19,37 +21,41 @@ data class PillTabsInfo(
 open class PillTabsTokens : PillBarTokens(), Parcelable {
 
     @Composable
-    open fun background(pillTabsInfo: PillTabsInfo): Color {
-        return when (pillTabsInfo.style) {
-            FluentStyle.Neutral -> FluentColor(
-                light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                    ThemeMode.Light
-                ),
-                dark = Color.Unspecified
-            ).value(FluentTheme.themeMode)
-            FluentStyle.Brand -> FluentColor(
-                light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                    ThemeMode.Light
-                ),
-                dark = Color.Unspecified
-            ).value(FluentTheme.themeMode)
-        }
+    open fun background(pillTabsInfo: PillTabsInfo): Brush {
+        return SolidColor(
+            when (pillTabsInfo.style) {
+                FluentStyle.Neutral -> FluentColor(
+                    light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                        ThemeMode.Light
+                    ),
+                    dark = Color.Unspecified
+                ).value(FluentTheme.themeMode)
+                FluentStyle.Brand -> FluentColor(
+                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                        ThemeMode.Light
+                    ),
+                    dark = Color.Unspecified
+                ).value(FluentTheme.themeMode)
+            }
+        )
     }
 
     @Composable
-    open fun trackBackground(pillTabsInfo: PillTabsInfo): Color {
-        return when (pillTabsInfo.style) {
-            FluentStyle.Neutral -> FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                FluentTheme.themeMode
-            )
-            FluentStyle.Brand -> FluentColor(
-                light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
-                    ThemeMode.Light
-                ),
-                dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                    ThemeMode.Dark
+    open fun trackBackground(pillTabsInfo: PillTabsInfo): Brush {
+        return SolidColor(
+            when (pillTabsInfo.style) {
+                FluentStyle.Neutral -> FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    FluentTheme.themeMode
                 )
-            ).value(FluentTheme.themeMode)
-        }
+                FluentStyle.Brand -> FluentColor(
+                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
+                        ThemeMode.Light
+                    ),
+                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        ThemeMode.Dark
+                    )
+                ).value(FluentTheme.themeMode)
+            }
+        )
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/RadioButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/RadioButtonTokens.kt
@@ -2,13 +2,12 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme.aliasTokens
 import com.microsoft.fluentui.theme.FluentTheme.themeMode
-import com.microsoft.fluentui.theme.token.ControlInfo
-import com.microsoft.fluentui.theme.token.FluentAliasTokens
-import com.microsoft.fluentui.theme.token.IControlToken
-import com.microsoft.fluentui.theme.token.StateColor
+import com.microsoft.fluentui.theme.token.*
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 data class RadioButtonInfo(
@@ -18,36 +17,57 @@ data class RadioButtonInfo(
 @Parcelize
 open class RadioButtonTokens : IControlToken, Parcelable {
 
+    @IgnoredOnParcel
     open var innerCircleRadius = 5.dp
+
+    @IgnoredOnParcel
     open var outerCircleRadius = 10.dp
+
+    @IgnoredOnParcel
     open var strokeWidthInwards = 1.5.dp
 
     @Composable
-    open fun backgroundColor(radioButtonInfo: RadioButtonInfo): StateColor {
-        return StateColor(
-            rest = aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeAccessible].value(
-                themeMode = themeMode
+    open fun backgroundColor(radioButtonInfo: RadioButtonInfo): StateBrush {
+        return StateBrush(
+            rest = SolidColor(
+                aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeAccessible].value(
+                    themeMode = themeMode
+                )
             ),
-            focused = aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeAccessible].value(
-                themeMode = themeMode
+            focused = SolidColor(
+                aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeAccessible].value(
+                    themeMode = themeMode
+                )
             ),
-            selectedFocused = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+            selectedFocused = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            selected = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+            selected = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            selectedPressed = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+            selectedPressed = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            pressed = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                themeMode = themeMode
+            pressed = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                    themeMode = themeMode
+                )
             ),
-            selectedDisabled = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundDisabled].value(
-                themeMode = themeMode
+            selectedDisabled = SolidColor(
+                aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundDisabled].value(
+                    themeMode = themeMode
+                )
             ),
-            disabled = aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeDisabled].value(
-                themeMode = themeMode
+            disabled = SolidColor(
+                aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeDisabled].value(
+                    themeMode = themeMode
+                )
             )
         )
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarPersonaChipTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarPersonaChipTokens.kt
@@ -1,9 +1,11 @@
 package com.microsoft.fluentui.theme.token.controlTokens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.SolidColor
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.StateBrush
 import com.microsoft.fluentui.theme.token.StateColor
 import kotlinx.parcelize.Parcelize
 
@@ -16,38 +18,50 @@ data class SearchBarPersonaChipInfo(
 @Parcelize
 open class SearchBarPersonaChipTokens : PersonaChipTokens() {
     @Composable
-    override fun backgroundColor(searchBarPersonaChipInfo: PersonaChipControlInfo): StateColor {
-        searchBarPersonaChipInfo as SearchBarPersonaChipInfo
-        when (searchBarPersonaChipInfo.style) {
-            FluentStyle.Neutral -> return StateColor(
-                rest = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background6].value(
-                    themeMode = FluentTheme.themeMode
+    override fun backgroundColor(personaChipInfo: PersonaChipControlInfo): StateBrush {
+        personaChipInfo as SearchBarPersonaChipInfo
+        when (personaChipInfo.style) {
+            FluentStyle.Neutral -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background6].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.BackgroundInverted].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.BackgroundInverted].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                disabled = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background6].value(
-                    themeMode = FluentTheme.themeMode
+                disabled = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background6].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
-            FluentStyle.Brand -> return StateColor(
-                rest = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground3].value(
-                    themeMode = FluentTheme.themeMode
+            FluentStyle.Brand -> return StateBrush(
+                rest = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground3].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                selected = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-                    themeMode = FluentTheme.themeMode
+                selected = SolidColor(
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 ),
-                disabled = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground3].value(
-                    themeMode = FluentTheme.themeMode
+                disabled = SolidColor(
+                    FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground3].value(
+                        themeMode = FluentTheme.themeMode
+                    )
                 )
             )
         }
     }
 
     @Composable
-    override fun textColor(searchBarPersonaChipInfo: PersonaChipControlInfo): StateColor {
-        searchBarPersonaChipInfo as SearchBarPersonaChipInfo
-        when (searchBarPersonaChipInfo.style) {
+    override fun textColor(personaChipInfo: PersonaChipControlInfo): StateColor {
+        personaChipInfo as SearchBarPersonaChipInfo
+        when (personaChipInfo.style) {
             FluentStyle.Neutral -> return StateColor(
                 rest = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                     themeMode = FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
@@ -22,41 +22,45 @@ data class SearchBarInfo(
 open class SearchBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun inputBackgroundColor(searchBarInfo: SearchBarInfo): Color {
-        return when (searchBarInfo.style) {
-            FluentStyle.Neutral ->
-                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                    themeMode = FluentTheme.themeMode
-                )
-            FluentStyle.Brand ->
-                FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
-                        ThemeMode.Dark
+    open fun inputBackgroundColor(searchBarInfo: SearchBarInfo): Brush {
+        return SolidColor(
+            when (searchBarInfo.style) {
+                FluentStyle.Neutral ->
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                        themeMode = FluentTheme.themeMode
                     )
-                ).value(themeMode = FluentTheme.themeMode)
-        }
+                FluentStyle.Brand ->
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(themeMode = FluentTheme.themeMode)
+            }
+        )
     }
 
     @Composable
-    open fun backgroundColor(searchBarInfo: SearchBarInfo): Color {
-        return when (searchBarInfo.style) {
-            FluentStyle.Neutral ->
-                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                    themeMode = FluentTheme.themeMode
-                )
-            FluentStyle.Brand ->
-                FluentColor(
-                    light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                        ThemeMode.Light
-                    ),
-                    dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                        ThemeMode.Dark
+    open fun backgroundColor(searchBarInfo: SearchBarInfo): Brush {
+        return SolidColor(
+            when (searchBarInfo.style) {
+                FluentStyle.Neutral ->
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                        themeMode = FluentTheme.themeMode
                     )
-                ).value(themeMode = FluentTheme.themeMode)
-        }
+                FluentStyle.Brand ->
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(themeMode = FluentTheme.themeMode)
+            }
+        )
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SnackbarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SnackbarTokens.kt
@@ -2,7 +2,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -29,14 +31,16 @@ data class SnackBarInfo(
 open class SnackBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(snackBarInfo: SnackBarInfo): Color {
-        return when (snackBarInfo.style) {
-            SnackbarStyle.Neutral -> aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background4].value()
-            SnackbarStyle.Contrast -> aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.BackgroundDarkStatic].value()
-            SnackbarStyle.Accent -> aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()
-            SnackbarStyle.Warning -> aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.WarningBackground1].value()
-            SnackbarStyle.Danger -> aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerBackground1].value()
-        }
+    open fun backgroundColor(snackBarInfo: SnackBarInfo): Brush {
+        return SolidColor(
+            when (snackBarInfo.style) {
+                SnackbarStyle.Neutral -> aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background4].value()
+                SnackbarStyle.Contrast -> aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.BackgroundDarkStatic].value()
+                SnackbarStyle.Accent -> aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()
+                SnackbarStyle.Warning -> aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.WarningBackground1].value()
+                SnackbarStyle.Danger -> aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerBackground1].value()
+            }
+        )
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -2,7 +2,9 @@ package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -30,9 +32,11 @@ open class TabItemTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(tabItemInfo: TabItemInfo): Color {
-        return FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
-            FluentTheme.themeMode
+    open fun backgroundColor(tabItemInfo: TabItemInfo): Brush {
+        return SolidColor(
+            FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
+                FluentTheme.themeMode
+            )
         )
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
@@ -26,8 +26,8 @@ data class TextFieldInfo(
 open class TextFieldTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(textFieldInfo: TextFieldInfo): Color {
-        return FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value()
+    open fun backgroundColor(textFieldInfo: TextFieldInfo): Brush {
+        return SolidColor(FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value())
     }
 
     @Composable
@@ -45,14 +45,15 @@ open class TextFieldTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun dividerColor(textFieldInfo: TextFieldInfo): Color {
-        return if (textFieldInfo.isStatusError)
-            FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerForeground1].value()
-        else if (textFieldInfo.isFocused)
-            FluentTheme.aliasTokens.brandStroke[FluentAliasTokens.BrandStrokeColorTokens.BrandStroke1].value()
-        else
-            FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value()
-
+    open fun dividerColor(textFieldInfo: TextFieldInfo): Brush {
+        return SolidColor(
+            if (textFieldInfo.isStatusError)
+                FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerForeground1].value()
+            else if (textFieldInfo.isFocused)
+                FluentTheme.aliasTokens.brandStroke[FluentAliasTokens.BrandStrokeColorTokens.BrandStroke1].value()
+            else
+                FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value()
+        )
     }
 
     @Composable

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -231,7 +232,7 @@ fun BottomSheet(
         topEnd = tokens.cornerRadius(bottomSheetInfo)
     )
     val sheetElevation: Dp = tokens.elevation(bottomSheetInfo)
-    val sheetBackgroundColor: Color = tokens.backgroundColor(bottomSheetInfo)
+    val sheetBackgroundColor: Brush = tokens.backgroundColor(bottomSheetInfo)
     val sheetContentColor: Color = Color.Transparent
     val sheetHandleColor: Color = tokens.handleColor(bottomSheetInfo)
     val scrimOpacity: Float = tokens.scrimOpacity(bottomSheetInfo)
@@ -318,6 +319,7 @@ fun BottomSheet(
                     peekHeight,
                     sheetState
                 )
+                .background(sheetBackgroundColor)
                 .semantics(mergeDescendants = true) {
                     if (sheetState.isVisible) {
                         dismiss {
@@ -345,7 +347,6 @@ fun BottomSheet(
                 },
             shape = sheetShape,
             elevation = sheetElevation,
-            color = sheetBackgroundColor,
             contentColor = sheetContentColor
         ) {
             Column {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusTarget
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -351,7 +352,7 @@ private fun HorizontalDrawer(
     drawerState: DrawerState,
     drawerShape: Shape,
     drawerElevation: Dp,
-    drawerBackgroundColor: Color,
+    drawerBackground: Brush,
     drawerContentColor: Color,
     scrimColor: Color,
     scrimVisible: Boolean,
@@ -425,6 +426,7 @@ private fun HorizontalDrawer(
                             }
                         }
                     }
+                    .background(drawerBackground)
                     .swipeable(
                         state = drawerState,
                         anchors = anchors,
@@ -436,7 +438,6 @@ private fun HorizontalDrawer(
                         resistance = null
                     ),
                 shape = drawerShape,
-                color = drawerBackgroundColor,
                 contentColor = drawerContentColor,
                 elevation = drawerElevation
             ) {
@@ -470,7 +471,7 @@ private fun TopDrawer(
     drawerState: DrawerState,
     drawerShape: Shape,
     drawerElevation: Dp,
-    drawerBackgroundColor: Color,
+    drawerBackground: Brush,
     drawerContentColor: Color,
     drawerHandleColor: Color,
     scrimColor: Color,
@@ -543,6 +544,7 @@ private fun TopDrawer(
                     .height(
                         pxToDp(drawerState.offset.value)
                     )
+                    .background(drawerBackground)
                     .swipeable(
                         state = drawerState,
                         anchors = anchors,
@@ -552,7 +554,6 @@ private fun TopDrawer(
                     )
                     .focusable(false),
                 shape = drawerShape,
-                color = drawerBackgroundColor,
                 contentColor = drawerContentColor,
                 elevation = drawerElevation
             ) {
@@ -611,7 +612,7 @@ private fun BottomDrawer(
     drawerState: DrawerState,
     drawerShape: Shape,
     drawerElevation: Dp,
-    drawerBackgroundColor: Color,
+    drawerBackground: Brush,
     drawerContentColor: Color,
     drawerHandleColor: Color,
     scrimColor: Color,
@@ -694,6 +695,7 @@ private fun BottomDrawer(
                     }
                 }
                 .drawerHeight(expandable, slideOver, maxOpenHeight, fullHeight, drawerState)
+                .background(drawerBackground)
                 .semantics {
                     if (drawerState.isOpen) {
                         dismiss {
@@ -719,7 +721,6 @@ private fun BottomDrawer(
                 }
                 .focusable(false),
             shape = drawerShape,
-            color = drawerBackgroundColor,
             contentColor = drawerContentColor,
             elevation = drawerElevation
         ) {
@@ -841,7 +842,7 @@ fun Drawer(
                     else -> RoundedCornerShape(tokens.borderRadius(drawerInfo))
                 }
             val drawerElevation: Dp = tokens.elevation(drawerInfo)
-            val drawerBackgroundColor: Color =
+            val drawerBackgroundColor: Brush =
                 tokens.backgroundColor(drawerInfo)
             val drawerContentColor: Color = Color.Transparent
             val drawerHandleColor: Color = tokens.handleColor(drawerInfo)
@@ -855,7 +856,7 @@ fun Drawer(
                     drawerState = drawerState,
                     drawerShape = drawerShape,
                     drawerElevation = drawerElevation,
-                    drawerBackgroundColor = drawerBackgroundColor,
+                    drawerBackground = drawerBackgroundColor,
                     drawerContentColor = drawerContentColor,
                     drawerHandleColor = drawerHandleColor,
                     scrimColor = scrimColor,
@@ -870,7 +871,7 @@ fun Drawer(
                     drawerState = drawerState,
                     drawerShape = drawerShape,
                     drawerElevation = drawerElevation,
-                    drawerBackgroundColor = drawerBackgroundColor,
+                    drawerBackground = drawerBackgroundColor,
                     drawerContentColor = drawerContentColor,
                     drawerHandleColor = drawerHandleColor,
                     scrimColor = scrimColor,
@@ -885,7 +886,7 @@ fun Drawer(
                     drawerState = drawerState,
                     drawerShape = drawerShape,
                     drawerElevation = drawerElevation,
-                    drawerBackgroundColor = drawerBackgroundColor,
+                    drawerBackground = drawerBackgroundColor,
                     drawerContentColor = drawerContentColor,
                     scrimColor = scrimColor,
                     scrimVisible = scrimVisible,

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -133,7 +134,7 @@ object ListItem {
         actionTextColor: Color,
         descriptionTextTypography: TextStyle,
         actionTextTypography: TextStyle,
-        backgroundColor: Color
+        backgroundColor: Brush
     ) {
         PlaceholderForActionText(actionTextComposable = {
             BasicText(
@@ -168,7 +169,7 @@ object ListItem {
                     )
                 ) {
                     Surface(
-                        onClick = onClick, color = backgroundColor
+                        onClick = onClick, Modifier.background(backgroundColor)
                     ) {
                         BasicText(
                             text = actionText,
@@ -254,7 +255,7 @@ object ListItem {
             unreadDot = unreadDot
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getColorByState(
+            token.backgroundColor(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)
@@ -464,7 +465,7 @@ object ListItem {
             style = style
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getColorByState(
+            token.backgroundColor(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)
@@ -628,7 +629,7 @@ object ListItem {
             placement = descriptionPlacement
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getColorByState(
+            token.backgroundColor(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)
@@ -756,7 +757,7 @@ object ListItem {
             borderInset = borderInset
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getColorByState(
+            token.backgroundColor(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -103,7 +103,7 @@ fun Menu(
                 content = content,
                 elevation = token.elevation(menuInfo),
                 cornerRadius = token.cornerRadius(menuInfo),
-                color = token.backgroundColor(menuInfo)
+                background = token.backgroundColor(menuInfo)
             )
         }
 
@@ -123,7 +123,7 @@ internal fun MenuContent(
     transformOriginState: MutableState<TransformOrigin>,
     modifier: Modifier = Modifier,
     elevation: Dp,
-    color: Color,
+    background: Brush,
     cornerRadius: Dp,
     content: @Composable () -> Unit
 ) {
@@ -185,7 +185,7 @@ internal fun MenuContent(
                 transformOrigin = transformOriginState.value
             }
             .shadow(elevation, shape, clip = false)
-            .background(color = color, shape = shape)
+            .background(background, shape)
             .clip(shape)
             .semantics(mergeDescendants = false) {}
             .pointerInput(Unit) {}

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -60,7 +60,7 @@ fun Badge(
                     radius = dpToPx(borderStroke.width + 4.dp)
                 )
                 drawCircle(
-                    color = background,
+                    brush = background,
                     style = Fill,
                     radius = dpToPx(4.dp)
                 )

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
@@ -220,11 +221,11 @@ fun CardNudge(
                     modifier = Modifier.testTag(ACTION_BUTTON),
                     pillButtonTokens = object : PillButtonTokens() {
                         @Composable
-                        override fun backgroundColor(pillButtonInfo: PillButtonInfo): StateColor {
-                            return StateColor(
-                                rest = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(),
-                                pressed = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value(),
-                                focused = aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()
+                        override fun backgroundColor(pillButtonInfo: PillButtonInfo): StateBrush {
+                            return StateBrush(
+                                rest = SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()),
+                                pressed = SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()),
+                                focused = SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value())
                             )
                         }
 

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
@@ -93,7 +93,7 @@ fun AvatarCarousel(
         itemsIndexed(avatarList) { index, item ->
             val backgroundColor =
                 token.backgroundColor(avatarCarouselInfo)
-                    .getColorByState(
+                    .getBrushByState(
                         enabled = item.enabled,
                         selected = false,
                         interactionSource = remember { MutableInteractionSource() }

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
@@ -64,7 +64,7 @@ fun PersonaChip(
     )
     val backgroundColor =
         token.backgroundColor(personaChipInfo = personaChipInfo)
-            .getColorByState(
+            .getBrushByState(
                 enabled = enabled, selected = selected, interactionSource = interactionSource
             )
     val textColor = token.textColor(personaChipInfo = personaChipInfo)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
@@ -62,12 +62,12 @@ fun SearchBarPersonaChip(
         size = size
     )
     val backgroundColor =
-        token.backgroundColor(searchBarPersonaChipInfo = searchBarPersonaChipInfo)
-            .getColorByState(
+        token.backgroundColor(personaChipInfo = searchBarPersonaChipInfo)
+            .getBrushByState(
                 enabled = enabled, selected = selected, interactionSource = interactionSource
             )
     val textColor =
-        token.textColor(searchBarPersonaChipInfo = searchBarPersonaChipInfo)
+        token.textColor(personaChipInfo = searchBarPersonaChipInfo)
             .getColorByState(
                 enabled = enabled, selected = selected, interactionSource = interactionSource
             )

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -1,6 +1,5 @@
 package com.microsoft.fluentui.tokenized.segmentedcontrols
 
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -14,15 +13,18 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
-import com.microsoft.fluentui.theme.token.Icon
 import androidx.compose.material.ripple.rememberRipple
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -38,6 +40,7 @@ import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.PillBarInfo
 import com.microsoft.fluentui.theme.token.controlTokens.PillBarTokens
 import com.microsoft.fluentui.theme.token.controlTokens.PillButtonInfo
@@ -102,15 +105,12 @@ fun PillButton(
         }
     }
 
-    val backgroundColor by animateColorAsState(
-        targetValue = token.backgroundColor(pillButtonInfo = pillButtonInfo)
-            .getColorByState(
-                enabled = pillMetaData.enabled,
-                selected = pillMetaData.selected,
-                interactionSource = interactionSource
-            ),
-        animationSpec = tween(200)
-    )
+    val backgroundColor = token.backgroundColor(pillButtonInfo = pillButtonInfo)
+        .getBrushByState(
+            enabled = pillMetaData.enabled,
+            selected = pillMetaData.selected,
+            interactionSource = interactionSource
+        )
     val iconColor =
         token.iconColor(pillButtonInfo = pillButtonInfo).getColorByState(
             enabled = pillMetaData.enabled,
@@ -255,7 +255,7 @@ fun PillBar(
     LazyRow(
         modifier = modifier
             .fillMaxWidth()
-            .background(if (showBackground) token.background(pillBarInfo) else Color.Unspecified)
+            .background(if (showBackground) token.background(pillBarInfo) else SolidColor(Color.Unspecified))
             .focusable(enabled = false),
         contentPadding = PaddingValues(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),


### PR DESCRIPTION
### Problem
Our Background Tokens were returning a Color Object which is mono colored. This would not have let partners use gradients as background of controls. 

### Root cause 
Color object is single coloured and doesn't support Gradient and designs.

### Fix
Update relevant tokens to return Brush object which allows developers to create gradient as well as Mono Color Solid backgrounds.

### Validations
Created a new Theme with control tokens where the FAB and appbar have gradients. Verified Visually.

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_20230509_120632_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/237056786-af13eabe-254a-446b-83b6-bf79bcea2d73.jpg) | ![Screenshot_20230509_120700_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/237056909-32aff1c3-51c7-4d4e-9c57-ae72dd2db45a.jpg) |
| ![Screenshot_20230509_121110_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/237057040-a2614bf1-8e5b-4d06-bcac-d14cc6916ba0.jpg) | ![Screenshot_20230509_120722_Fluent UI Demo DEV](https://user-images.githubusercontent.com/12729351/237057134-7ffeefe6-d03d-4a41-8948-0379d53c96ff.jpg) |



### Pull request checklist
This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
