### PR TITLE
Rename Tokens to Depict Brush instead of Color

### DIFF
--- a/FluentUI.Demo/src/main/java/com/example/theme/token/GradientTokens.kt
+++ b/FluentUI.Demo/src/main/java/com/example/theme/token/GradientTokens.kt
@@ -21,14 +21,14 @@ private var gradient = Brush.linearGradient(
 
 class MyAppBarToken : AppBarTokens() {
     @Composable
-    override fun backgroundColor(info: AppBarInfo): Brush {
-        return if (info.style == FluentStyle.Brand) gradient else super.backgroundColor(info)
+    override fun backgroundBrush(info: AppBarInfo): Brush {
+        return if (info.style == FluentStyle.Brand) gradient else super.backgroundBrush(info)
     }
 }
 
 class MyFABToken : FABTokens() {
     @Composable
-    override fun backgroundColor(info: FABInfo): StateBrush {
+    override fun backgroundBrush(info: FABInfo): StateBrush {
         return StateBrush(
             rest = gradient,
             pressed = gradient,

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -121,7 +121,7 @@ fun ContextualCommandBar(
             .focusable(enabled = false)
             .fillMaxWidth()
             .background(
-                token.contextualCommandBarBackgroundColor(
+                token.contextualCommandBarBackgroundBrush(
                     contextualCommandBarInfo
                 )
             )
@@ -219,7 +219,7 @@ fun ContextualCommandBar(
                                         .clip(shape)
                                         .background(
                                             token
-                                                .buttonBackgroundColor(
+                                                .buttonBackgroundBrush(
                                                     contextualCommandBarInfo
                                                 )
                                                 .getBrushByState(
@@ -346,7 +346,7 @@ fun ContextualCommandBar(
                                     .clip(shape)
                                     .background(
                                         token
-                                            .buttonBackgroundColor(
+                                            .buttonBackgroundBrush(
                                                 contextualCommandBarInfo
                                             )
                                             .getBrushByState(
@@ -446,7 +446,7 @@ fun ContextualCommandBar(
                     modifier = Modifier
                         .then(actionButtonClickable)
                         .background(
-                            token.actionButtonBackgroundColor(
+                            token.actionButtonBackgroundBrush(
                                 contextualCommandBarInfo
                             )
                         )

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -69,7 +69,7 @@ fun Button(
         onClick = onClick
     )
     val backgroundColor =
-        token.backgroundColor(buttonInfo = buttonInfo).getBrushByState(
+        token.backgroundBrush(buttonInfo = buttonInfo).getBrushByState(
             enabled = enabled,
             selected = false,
             interactionSource = interactionSource

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
@@ -70,7 +70,7 @@ fun CheckBox(
         )
 
     val backgroundColor: Brush =
-        token.backgroundColor(checkBoxInfo = checkBoxInfo).getBrushByState(
+        token.backgroundBrush(checkBoxInfo = checkBoxInfo).getBrushByState(
             enabled = enabled,
             selected = checked,
             interactionSource = interactionSource

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
@@ -71,7 +71,7 @@ fun FloatingActionButton(
     )
     val isFabExpanded: Boolean =
         (text != null && text != "" && fabInfo.state == FABState.Expanded)
-    val backgroundColor = token.backgroundColor(fabInfo = fabInfo).getBrushByState(
+    val backgroundColor = token.backgroundBrush(fabInfo = fabInfo).getBrushByState(
         enabled = enabled,
         selected = false,
         interactionSource = interactionSource

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
@@ -66,7 +66,7 @@ fun RadioButton(
     )
 
     val outerStrokeColor =
-        token.backgroundColor(radioButtonInfo = radioButtonInfo)
+        token.backgroundBrush(radioButtonInfo = radioButtonInfo)
             .getBrushByState(
                 enabled = enabled,
                 selected = selected,

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -117,7 +117,7 @@ fun TextField(
                 }
             }
         }
-        .background(token.backgroundColor(textFieldInfo))
+        .background(token.backgroundBrush(textFieldInfo))
         .padding(token.leftRightPadding(textFieldInfo))) {
         if (!label.isNullOrBlank()) {
             Spacer(Modifier.requiredHeight(12.dp))

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -239,7 +239,7 @@ fun TextField(
                         }
 
                         @Composable
-                        override fun dividerColor(dividerInfo: DividerInfo): Brush =
+                        override fun dividerBrush(dividerInfo: DividerInfo): Brush =
                             token.dividerColor(textFieldInfo)
                     }
                 )

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -30,7 +30,7 @@ data class AppBarInfo(
 open class AppBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(info: AppBarInfo): Brush {
+    open fun backgroundBrush(info: AppBarInfo): Brush {
         return SolidColor(
             when (info.style) {
                 FluentStyle.Neutral ->

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarCarouselTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarCarouselTokens.kt
@@ -29,7 +29,7 @@ open class AvatarCarouselTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(avatarCarouselInfo: AvatarCarouselInfo): StateBrush {
+    open fun backgroundBrush(avatarCarouselInfo: AvatarCarouselInfo): StateBrush {
         return StateBrush(
             rest = SolidColor(
                 FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
@@ -326,7 +326,7 @@ open class AvatarTokens(private val activityRingToken: ActivityRingsToken = Acti
     }
 
     @Composable
-    open fun backgroundColor(avatarInfo: AvatarInfo): Brush {
+    open fun backgroundBrush(avatarInfo: AvatarInfo): Brush {
         return SolidColor(
             if (avatarInfo.isImageAvailable || avatarInfo.hasValidInitials) {
                 FluentColor(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BadgeTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BadgeTokens.kt
@@ -27,7 +27,7 @@ class BadgeInfo(val type: BadgeType) : ControlInfo
 open class BadgeTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(badgeInfo: BadgeInfo): Brush {
+    open fun backgroundBrush(badgeInfo: BadgeInfo): Brush {
         return SolidColor(FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.DangerBackground2].value())
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BottomSheetTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BottomSheetTokens.kt
@@ -19,7 +19,7 @@ class BottomSheetInfo : ControlInfo
 open class BottomSheetTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(bottomSheetInfo: BottomSheetInfo): Brush =
+    open fun backgroundBrush(bottomSheetInfo: BottomSheetInfo): Brush =
         SolidColor(
             FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
                 themeMode = FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
@@ -123,7 +123,7 @@ open class ButtonTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(buttonInfo: ButtonInfo): StateBrush {
+    open fun backgroundBrush(buttonInfo: ButtonInfo): StateBrush {
         return when (buttonInfo.style) {
             ButtonStyle.Button ->
                 StateBrush(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CardNudgeTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CardNudgeTokens.kt
@@ -22,7 +22,7 @@ class CardNudgeInfo : ControlInfo
 open class CardNudgeTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(cardNudgeInfo: CardNudgeInfo): Brush {
+    open fun backgroundBrush(cardNudgeInfo: CardNudgeInfo): Brush {
         return SolidColor(aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.CanvasBackground].value())
     }
 
@@ -37,7 +37,7 @@ open class CardNudgeTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun iconBackgroundColor(cardNudgeInfo: CardNudgeInfo): Brush {
+    open fun iconBackgroundBrush(cardNudgeInfo: CardNudgeInfo): Brush {
         return SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value())
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CheckBoxTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CheckBoxTokens.kt
@@ -29,7 +29,7 @@ open class CheckBoxTokens : IControlToken, Parcelable {
     val fixedBorderRadius: Dp = 4.dp
 
     @Composable
-    open fun backgroundColor(checkBoxInfo: CheckBoxInfo): StateBrush {
+    open fun backgroundBrush(checkBoxInfo: CheckBoxInfo): StateBrush {
         return StateBrush(
             selected = SolidColor(
                 aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CircularProgressIndicatorTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CircularProgressIndicatorTokens.kt
@@ -57,7 +57,7 @@ open class CircularProgressIndicatorTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun color(circularProgressIndicatorInfo: CircularProgressIndicatorInfo): Brush {
+    open fun brush(circularProgressIndicatorInfo: CircularProgressIndicatorInfo): Brush {
         return SolidColor(
             if (circularProgressIndicatorInfo.style == FluentStyle.Neutral) {
                 FluentColor(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ContextualCommandBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ContextualCommandBarTokens.kt
@@ -22,7 +22,7 @@ class ContextualCommandBarInfo : ControlInfo
 open class ContextualCommandBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun actionButtonBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): Brush {
+    open fun actionButtonBackgroundBrush(contextualCommandBarInfo: ContextualCommandBarInfo): Brush {
         return SolidColor(
             aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
                 themeMode = themeMode
@@ -62,7 +62,7 @@ open class ContextualCommandBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun contextualCommandBarBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): Brush {
+    open fun contextualCommandBarBackgroundBrush(contextualCommandBarInfo: ContextualCommandBarInfo): Brush {
         return SolidColor(
             aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
                 themeMode = themeMode
@@ -126,7 +126,7 @@ open class ContextualCommandBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun buttonBackgroundColor(contextualCommandBarInfo: ContextualCommandBarInfo): StateBrush {
+    open fun buttonBackgroundBrush(contextualCommandBarInfo: ContextualCommandBarInfo): StateBrush {
         return StateBrush(
             rest = SolidColor(
                 aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
@@ -27,7 +27,7 @@ open class DividerTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun dividerColor(dividerInfo: DividerInfo): Brush {
+    open fun dividerBrush(dividerInfo: DividerInfo): Brush {
         return SolidColor(
             FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value(
                 themeMode = FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DividerTokens.kt
@@ -18,7 +18,7 @@ class DividerInfo : ControlInfo
 @Parcelize
 open class DividerTokens : IControlToken, Parcelable {
     @Composable
-    open fun background(dividerInfo: DividerInfo): Brush {
+    open fun backgroundBrush(dividerInfo: DividerInfo): Brush {
         return SolidColor(
             FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
                 FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
@@ -26,7 +26,7 @@ data class DrawerInfo(val type: BehaviorType = BehaviorType.LEFT_SLIDE_OVER) : C
 open class DrawerTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(drawerInfo: DrawerInfo): Brush =
+    open fun backgroundBrush(drawerInfo: DrawerInfo): Brush =
         SolidColor(
             FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
                 themeMode = FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FABTokens.kt
@@ -73,7 +73,7 @@ open class FABTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(fabInfo: FABInfo): StateBrush {
+    open fun backgroundBrush(fabInfo: FABInfo): StateBrush {
         return StateBrush(
             rest = SolidColor(
                 aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -78,7 +78,7 @@ data class ListItemInfo(
 @Parcelize
 open class ListItemTokens : IControlToken, Parcelable {
     @Composable
-    open fun backgroundColor(listItemInfo: ListItemInfo): StateBrush {
+    open fun backgroundBrush(listItemInfo: ListItemInfo): StateBrush {
         return StateBrush(
             rest = SolidColor(
                 FluentTheme.aliasTokens.neutralBackgroundColor[Background1].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/MenuTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/MenuTokens.kt
@@ -18,7 +18,7 @@ class MenuInfo : ControlInfo
 open class MenuTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(menuInfo: MenuInfo): Brush =
+    open fun backgroundBrush(menuInfo: MenuInfo): Brush =
         SolidColor(
             FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2].value(
                 themeMode = FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PersonaChipTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PersonaChipTokens.kt
@@ -47,7 +47,7 @@ data class PersonaChipInfo(
 open class PersonaChipTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(personaChipInfo: PersonaChipControlInfo): StateBrush {
+    open fun backgroundBrush(personaChipInfo: PersonaChipControlInfo): StateBrush {
         personaChipInfo as PersonaChipInfo
         when (personaChipInfo.style) {
             PersonaChipStyle.Neutral -> return StateBrush(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillBarTokens.kt
@@ -17,7 +17,7 @@ data class PillBarInfo(
 open class PillBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun background(pillBarInfo: PillBarInfo): Brush {
+    open fun backgroundBrush(pillBarInfo: PillBarInfo): Brush {
         return when (pillBarInfo.style) {
             FluentStyle.Neutral -> SolidColor(
                 FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
@@ -33,7 +33,7 @@ open class PillButtonTokens : IControlToken, Parcelable {
         FluentGlobalTokens.iconSize(FluentGlobalTokens.IconSizeTokens.IconSize200)
 
     @Composable
-    open fun backgroundColor(pillButtonInfo: PillButtonInfo): StateBrush {
+    open fun backgroundBrush(pillButtonInfo: PillButtonInfo): StateBrush {
         when (pillButtonInfo.style) {
             FluentStyle.Neutral -> return StateBrush(
                 rest = SolidColor(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillSwitchTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillSwitchTokens.kt
@@ -20,7 +20,7 @@ data class PillSwitchInfo(
 open class PillSwitchTokens : PillBarTokens(), Parcelable {
 
     @Composable
-    open fun background(pillSwitchInfo: PillSwitchInfo): Brush {
+    open fun backgroundBrush(pillSwitchInfo: PillSwitchInfo): Brush {
         return when (pillSwitchInfo.style) {
             FluentStyle.Neutral -> SolidColor(
                 FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillTabsTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillTabsTokens.kt
@@ -21,7 +21,7 @@ data class PillTabsInfo(
 open class PillTabsTokens : PillBarTokens(), Parcelable {
 
     @Composable
-    open fun background(pillTabsInfo: PillTabsInfo): Brush {
+    open fun backgroundBrush(pillTabsInfo: PillTabsInfo): Brush {
         return SolidColor(
             when (pillTabsInfo.style) {
                 FluentStyle.Neutral -> FluentColor(
@@ -41,7 +41,7 @@ open class PillTabsTokens : PillBarTokens(), Parcelable {
     }
 
     @Composable
-    open fun trackBackground(pillTabsInfo: PillTabsInfo): Brush {
+    open fun trackBackgroundBrush(pillTabsInfo: PillTabsInfo): Brush {
         return SolidColor(
             when (pillTabsInfo.style) {
                 FluentStyle.Neutral -> FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/RadioButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/RadioButtonTokens.kt
@@ -27,7 +27,7 @@ open class RadioButtonTokens : IControlToken, Parcelable {
     open var strokeWidthInwards = 1.5.dp
 
     @Composable
-    open fun backgroundColor(radioButtonInfo: RadioButtonInfo): StateBrush {
+    open fun backgroundBrush(radioButtonInfo: RadioButtonInfo): StateBrush {
         return StateBrush(
             rest = SolidColor(
                 aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeAccessible].value(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarPersonaChipTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarPersonaChipTokens.kt
@@ -18,7 +18,7 @@ data class SearchBarPersonaChipInfo(
 @Parcelize
 open class SearchBarPersonaChipTokens : PersonaChipTokens() {
     @Composable
-    override fun backgroundColor(personaChipInfo: PersonaChipControlInfo): StateBrush {
+    override fun backgroundBrush(personaChipInfo: PersonaChipControlInfo): StateBrush {
         personaChipInfo as SearchBarPersonaChipInfo
         when (personaChipInfo.style) {
             FluentStyle.Neutral -> return StateBrush(

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
@@ -22,7 +22,7 @@ data class SearchBarInfo(
 open class SearchBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun inputBackgroundColor(searchBarInfo: SearchBarInfo): Brush {
+    open fun inputBackgroundBrush(searchBarInfo: SearchBarInfo): Brush {
         return SolidColor(
             when (searchBarInfo.style) {
                 FluentStyle.Neutral ->
@@ -43,7 +43,7 @@ open class SearchBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(searchBarInfo: SearchBarInfo): Brush {
+    open fun backgroundBrush(searchBarInfo: SearchBarInfo): Brush {
         return SolidColor(
             when (searchBarInfo.style) {
                 FluentStyle.Neutral ->

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SnackbarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SnackbarTokens.kt
@@ -31,7 +31,7 @@ data class SnackBarInfo(
 open class SnackBarTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(snackBarInfo: SnackBarInfo): Brush {
+    open fun backgroundBrush(snackBarInfo: SnackBarInfo): Brush {
         return SolidColor(
             when (snackBarInfo.style) {
                 SnackbarStyle.Neutral -> aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background4].value()

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -32,7 +32,7 @@ open class TabItemTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun backgroundColor(tabItemInfo: TabItemInfo): Brush {
+    open fun backgroundBrush(tabItemInfo: TabItemInfo): Brush {
         return SolidColor(
             FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value(
                 FluentTheme.themeMode

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
@@ -26,7 +26,7 @@ data class TextFieldInfo(
 open class TextFieldTokens : IControlToken, Parcelable {
 
     @Composable
-    open fun backgroundColor(textFieldInfo: TextFieldInfo): Brush {
+    open fun backgroundBrush(textFieldInfo: TextFieldInfo): Brush {
         return SolidColor(FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value())
     }
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -232,7 +232,7 @@ fun BottomSheet(
         topEnd = tokens.cornerRadius(bottomSheetInfo)
     )
     val sheetElevation: Dp = tokens.elevation(bottomSheetInfo)
-    val sheetBackgroundColor: Brush = tokens.backgroundColor(bottomSheetInfo)
+    val sheetBackgroundColor: Brush = tokens.backgroundBrush(bottomSheetInfo)
     val sheetContentColor: Color = Color.Transparent
     val sheetHandleColor: Color = tokens.handleColor(bottomSheetInfo)
     val scrimOpacity: Float = tokens.scrimOpacity(bottomSheetInfo)

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -843,7 +843,7 @@ fun Drawer(
                 }
             val drawerElevation: Dp = tokens.elevation(drawerInfo)
             val drawerBackgroundColor: Brush =
-                tokens.backgroundColor(drawerInfo)
+                tokens.backgroundBrush(drawerInfo)
             val drawerContentColor: Color = Color.Transparent
             val drawerHandleColor: Color = tokens.handleColor(drawerInfo)
             val scrimOpacity: Float = tokens.scrimOpacity(drawerInfo)

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -174,7 +174,7 @@ class ListContentBuilder {
                 Layout(
                     modifier = Modifier
                         .background(
-                            token.backgroundColor(
+                            token.backgroundBrush(
                                 TabItemInfo(
                                     TabTextAlignment.VERTICAL,
                                     FluentStyle.Brand
@@ -250,7 +250,7 @@ class ListContentBuilder {
                 LazyRow(
                     state = rowLazyListState, modifier = Modifier
                         .background(
-                            token.backgroundColor(
+                            token.backgroundBrush(
                                 TabItemInfo(
                                     TabTextAlignment.VERTICAL,
                                     FluentStyle.Brand

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
@@ -33,7 +33,7 @@ fun Divider(
             Modifier
                 .fillMaxWidth()
                 .requiredHeight(height)
-                .background(token.dividerColor(dividerInfo))
+                .background(token.dividerBrush(dividerInfo))
                 .padding(start = token.startIndent(dividerInfo))
         )
     }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
@@ -25,7 +25,7 @@ fun Divider(
     Column(
         Modifier
             .fillMaxWidth()
-            .background(token.background(dividerInfo))
+            .background(token.backgroundBrush(dividerInfo))
             .focusable(false)
             .padding(token.verticalPadding(dividerInfo))
     ) {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -255,7 +255,7 @@ object ListItem {
             unreadDot = unreadDot
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getBrushByState(
+            token.backgroundBrush(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)
@@ -465,7 +465,7 @@ object ListItem {
             style = style
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getBrushByState(
+            token.backgroundBrush(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)
@@ -629,7 +629,7 @@ object ListItem {
             placement = descriptionPlacement
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getBrushByState(
+            token.backgroundBrush(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)
@@ -757,7 +757,7 @@ object ListItem {
             borderInset = borderInset
         )
         val backgroundColor =
-            token.backgroundColor(listItemInfo).getBrushByState(
+            token.backgroundBrush(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
         val cellHeight = token.cellHeight(listItemInfo)

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -62,7 +62,7 @@ fun TabItem(
             interactionSource = interactionSource
         )
 
-    val backgroundColor = token.backgroundColor(tabItemInfo = tabItemInfo)
+    val backgroundColor = token.backgroundBrush(tabItemInfo = tabItemInfo)
     val rippleColor = token.rippleColor(tabItemInfo = tabItemInfo)
 
     val clickableModifier = Modifier

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
@@ -103,7 +103,7 @@ fun Menu(
                 content = content,
                 elevation = token.elevation(menuInfo),
                 cornerRadius = token.cornerRadius(menuInfo),
-                background = token.backgroundColor(menuInfo)
+                background = token.backgroundBrush(menuInfo)
             )
         }
 

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -43,7 +43,7 @@ fun Badge(
     val token = badgeTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Badge] as BadgeTokens
     val badgeInfo = BadgeInfo(badgeType)
-    val background = token.backgroundColor(badgeInfo = badgeInfo)
+    val background = token.backgroundBrush(badgeInfo = badgeInfo)
     val borderStroke = token.borderStroke(badgeInfo = badgeInfo)
     if (text.isNullOrEmpty()) {
         Box(

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -99,7 +99,7 @@ fun CardNudge(
                 .fillMaxWidth()
                 .offset { IntOffset(state.offset.value.roundToInt(), 0) }
                 .background(
-                    token.backgroundColor(cardNudgeInfo),
+                    token.backgroundBrush(cardNudgeInfo),
                     shape
                 )
                 .then(
@@ -141,7 +141,7 @@ fun CardNudge(
                     modifier = Modifier
                         .size(token.leftIconBackgroundSize(cardNudgeInfo))
                         .background(
-                            token.iconBackgroundColor(cardNudgeInfo),
+                            token.iconBackgroundBrush(cardNudgeInfo),
                             CircleShape
                         )
                         .then(
@@ -221,7 +221,7 @@ fun CardNudge(
                     modifier = Modifier.testTag(ACTION_BUTTON),
                     pillButtonTokens = object : PillButtonTokens() {
                         @Composable
-                        override fun backgroundColor(pillButtonInfo: PillButtonInfo): StateBrush {
+                        override fun backgroundBrush(pillButtonInfo: PillButtonInfo): StateBrush {
                             return StateBrush(
                                 rest = SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()),
                                 pressed = SolidColor(aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackgroundTint].value()),

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -133,7 +133,7 @@ fun Snackbar(
                 .defaultMinSize(minHeight = 52.dp)
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
-                .background(token.backgroundColor(snackBarInfo))
+                .background(token.backgroundBrush(snackBarInfo))
                 .testTag(SNACKBAR),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
@@ -73,7 +73,7 @@ fun Avatar(
         personInitials.isNotEmpty(), person.getName(), cutoutStyle
     )
     val avatarSize = token.avatarSize(avatarInfo)
-    val backgroundColor = token.backgroundColor(avatarInfo)
+    val backgroundColor = token.backgroundBrush(avatarInfo)
     val foregroundColor = token.foregroundColor(avatarInfo)
     val borders = token.borderStroke(avatarInfo)
     val fontTextStyle = token.fontTypography(avatarInfo)
@@ -235,7 +235,7 @@ fun Avatar(
     val avatarSize = token.avatarSize(avatarInfo)
     val cornerRadius = token.cornerRadius(avatarInfo)
     val fontTextStyle = token.fontTypography(avatarInfo)
-    val backgroundColor = token.backgroundColor(avatarInfo)
+    val backgroundColor = token.backgroundBrush(avatarInfo)
     val foregroundColor = token.foregroundColor(avatarInfo)
 
     var membersList = ""
@@ -332,7 +332,7 @@ fun Avatar(
         Box(
             Modifier
                 .clip(CircleShape)
-                .background(token.backgroundColor(avatarInfo))
+                .background(token.backgroundBrush(avatarInfo))
                 .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
@@ -92,7 +92,7 @@ fun AvatarCarousel(
     ) {
         itemsIndexed(avatarList) { index, item ->
             val backgroundColor =
-                token.backgroundColor(avatarCarouselInfo)
+                token.backgroundBrush(avatarCarouselInfo)
                     .getBrushByState(
                         enabled = item.enabled,
                         selected = false,

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
@@ -63,7 +63,7 @@ fun PersonaChip(
         size
     )
     val backgroundColor =
-        token.backgroundColor(personaChipInfo = personaChipInfo)
+        token.backgroundBrush(personaChipInfo = personaChipInfo)
             .getBrushByState(
                 enabled = enabled, selected = selected, interactionSource = interactionSource
             )

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
@@ -62,7 +62,7 @@ fun SearchBarPersonaChip(
         size = size
     )
     val backgroundColor =
-        token.backgroundColor(personaChipInfo = searchBarPersonaChipInfo)
+        token.backgroundBrush(personaChipInfo = searchBarPersonaChipInfo)
             .getBrushByState(
                 enabled = enabled, selected = selected, interactionSource = interactionSource
             )

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
@@ -51,7 +51,7 @@ fun CircularProgressIndicator(
         )
     )
     val circularProgressIndicatorColor =
-        tokens.color(
+        tokens.brush(
             circularProgressIndicatorInfo
         )
     val circularProgressIndicatorSize =
@@ -105,7 +105,7 @@ fun CircularProgressIndicator(
         style = style
     )
     val circularProgressIndicatorColor =
-        tokens.color(
+        tokens.brush(
             circularProgressIndicatorInfo
         )
     val circularProgressIndicatorSize =

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -105,7 +105,7 @@ fun PillButton(
         }
     }
 
-    val backgroundColor = token.backgroundColor(pillButtonInfo = pillButtonInfo)
+    val backgroundColor = token.backgroundBrush(pillButtonInfo = pillButtonInfo)
         .getBrushByState(
             enabled = pillMetaData.enabled,
             selected = pillMetaData.selected,
@@ -255,7 +255,7 @@ fun PillBar(
     LazyRow(
         modifier = modifier
             .fillMaxWidth()
-            .background(if (showBackground) token.background(pillBarInfo) else SolidColor(Color.Unspecified))
+            .background(if (showBackground) token.backgroundBrush(pillBarInfo) else SolidColor(Color.Unspecified))
             .focusable(enabled = false),
         contentPadding = PaddingValues(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
@@ -69,7 +69,7 @@ fun PillSwitch(
                 .padding(horizontal = 16.dp)
                 .focusable(enabled = false)
                 .clip(shape)
-                .background(token.background(pillSwitchInfo), shape),
+                .background(token.backgroundBrush(pillSwitchInfo), shape),
             state = lazyListState
         ) {
             metadataList.forEachIndexed { index, pillMetadata ->

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillTabs.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillTabs.kt
@@ -67,7 +67,7 @@ fun PillTabs(
             modifier = modifier
                 .clip(shape)
                 .padding(horizontal = 16.dp)
-                .background(token.trackBackground(pillTabsInfo), shape)
+                .background(token.trackBackgroundBrush(pillTabsInfo), shape)
         ) {
             metadataList.forEachIndexed { index, pillMetadata ->
                 pillMetadata.selected = (selectedIndex == index)

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -92,7 +92,7 @@ fun AppBar(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(token.backgroundColor(appBarInfo))
+                .background(token.backgroundBrush(appBarInfo))
         ) {
             Row(
                 Modifier

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -110,7 +110,7 @@ fun SearchBar(
 
     Row(
         modifier = modifier
-            .background(token.backgroundColor(searchBarInfo))
+            .background(token.backgroundBrush(searchBarInfo))
             .padding(token.searchBarPadding(searchBarInfo))
     ) {
         Row(
@@ -119,7 +119,7 @@ fun SearchBar(
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .background(
-                    token.inputBackgroundColor(searchBarInfo),
+                    token.inputBackgroundBrush(searchBarInfo),
                     RoundedCornerShape(8.dp)
                 ),
             verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
### Problem 
Token Names depict use of Color Like backgroundColor()

### Fix
Renamed token with Brush appropriately.

### Validations
Manual Visual Verification

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
