### PR TITLE
Fix: App Refactor when Control tokens updates

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
@@ -111,7 +111,7 @@ class V2ButtonsActivity : DemoActivity() {
                                 size = ButtonSize.Medium,
                                 onClick = {
                                     FluentTheme.updateControlTokens(
-                                        ControlTokens().updateToken(
+                                        controlTokens.updateToken(
                                             ControlTokens.ControlType.AppBar,
                                             MyAppBarToken()
                                         ).updateToken(

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -83,7 +83,8 @@ fun ContextualCommandBar(
     contextualCommandBarToken: ContextualCommandBarTokens? = null
 ) {
 
-    val token = contextualCommandBarToken
+    val themeID = FluentTheme.themeID
+	val token = contextualCommandBarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ContextualCommandBar] as ContextualCommandBarTokens
 
     val contextualCommandBarInfo = ContextualCommandBarInfo()

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -84,7 +84,7 @@ fun ContextualCommandBar(
 ) {
 
     val themeID = FluentTheme.themeID
-	val token = contextualCommandBarToken
+    val token = contextualCommandBarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ContextualCommandBar] as ContextualCommandBarTokens
 
     val contextualCommandBarInfo = ContextualCommandBarInfo()

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -83,7 +83,8 @@ fun ContextualCommandBar(
     contextualCommandBarToken: ContextualCommandBarTokens? = null
 ) {
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = contextualCommandBarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ContextualCommandBar] as ContextualCommandBarTokens
 

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
@@ -47,7 +47,8 @@ fun AnnouncementCard(
     @DrawableRes previewImageDrawable: Int? = null,
     announcementCardTokens: AnnouncementCardTokens? = null
 ) {
-    val token = announcementCardTokens
+    val themeID = FluentTheme.themeID
+	val token = announcementCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AnnouncementCard] as AnnouncementCardTokens
     val announcementCardInfo = AnnouncementCardInfo()
     val textColor = token.textColor(announcementCardInfo = announcementCardInfo)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
@@ -48,7 +48,7 @@ fun AnnouncementCard(
     announcementCardTokens: AnnouncementCardTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = announcementCardTokens
+    val token = announcementCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AnnouncementCard] as AnnouncementCardTokens
     val announcementCardInfo = AnnouncementCardInfo()
     val textColor = token.textColor(announcementCardInfo = announcementCardInfo)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
@@ -47,7 +47,8 @@ fun AnnouncementCard(
     @DrawableRes previewImageDrawable: Int? = null,
     announcementCardTokens: AnnouncementCardTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = announcementCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AnnouncementCard] as AnnouncementCardTokens
     val announcementCardInfo = AnnouncementCardInfo()

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
@@ -28,7 +28,8 @@ fun BasicCard(
     basicCardTokens: BasicCardTokens? = null,
     content: @Composable () -> Unit
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = basicCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BasicCard] as BasicCardTokens
     val basicCardInfo = BasicCardInfo(CardType.Elevated)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
@@ -29,7 +29,7 @@ fun BasicCard(
     content: @Composable () -> Unit
 ) {
     val themeID = FluentTheme.themeID
-	val token = basicCardTokens
+    val token = basicCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BasicCard] as BasicCardTokens
     val basicCardInfo = BasicCardInfo(CardType.Elevated)
     val cornerRadius = token.cornerRadius(basicCardInfo = basicCardInfo)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
@@ -28,7 +28,8 @@ fun BasicCard(
     basicCardTokens: BasicCardTokens? = null,
     content: @Composable () -> Unit
 ) {
-    val token = basicCardTokens
+    val themeID = FluentTheme.themeID
+	val token = basicCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BasicCard] as BasicCardTokens
     val basicCardInfo = BasicCardInfo(CardType.Elevated)
     val cornerRadius = token.cornerRadius(basicCardInfo = basicCardInfo)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -59,7 +59,7 @@ fun Button(
     buttonTokens: ButtonTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = buttonTokens ?: FluentTheme.controlTokens.tokens[ControlType.Button] as ButtonTokens
+    val token = buttonTokens ?: FluentTheme.controlTokens.tokens[ControlType.Button] as ButtonTokens
     val buttonInfo = ButtonInfo(style, size)
     val clickAndSemanticsModifier = Modifier.clickable(
         interactionSource = interactionSource,

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -58,7 +58,8 @@ fun Button(
     contentDescription: String? = null,
     buttonTokens: ButtonTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = buttonTokens ?: FluentTheme.controlTokens.tokens[ControlType.Button] as ButtonTokens
     val buttonInfo = ButtonInfo(style, size)
     val clickAndSemanticsModifier = Modifier.clickable(

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -58,7 +58,8 @@ fun Button(
     contentDescription: String? = null,
     buttonTokens: ButtonTokens? = null
 ) {
-    val token = buttonTokens ?: FluentTheme.controlTokens.tokens[ControlType.Button] as ButtonTokens
+    val themeID = FluentTheme.themeID
+	val token = buttonTokens ?: FluentTheme.controlTokens.tokens[ControlType.Button] as ButtonTokens
     val buttonInfo = ButtonInfo(style, size)
     val clickAndSemanticsModifier = Modifier.clickable(
         interactionSource = interactionSource,

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
@@ -53,7 +53,8 @@ fun CheckBox(
     checkBoxToken: CheckBoxTokens? = null
 ) {
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = checkBoxToken
         ?: FluentTheme.controlTokens.tokens[ControlType.CheckBox] as CheckBoxTokens
     val checkBoxInfo = CheckBoxInfo(checked)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
@@ -53,7 +53,8 @@ fun CheckBox(
     checkBoxToken: CheckBoxTokens? = null
 ) {
 
-    val token = checkBoxToken
+    val themeID = FluentTheme.themeID
+	val token = checkBoxToken
         ?: FluentTheme.controlTokens.tokens[ControlType.CheckBox] as CheckBoxTokens
     val checkBoxInfo = CheckBoxInfo(checked)
     val toggleModifier =

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
@@ -54,7 +54,7 @@ fun CheckBox(
 ) {
 
     val themeID = FluentTheme.themeID
-	val token = checkBoxToken
+    val token = checkBoxToken
         ?: FluentTheme.controlTokens.tokens[ControlType.CheckBox] as CheckBoxTokens
     val checkBoxInfo = CheckBoxInfo(checked)
     val toggleModifier =

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Citation.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Citation.kt
@@ -38,6 +38,8 @@ fun Citation(
     modifier: Modifier = Modifier,
     citationTokens: CitationTokens? = null
 ) {
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = citationTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Citation] as CitationTokens
     val citationInfo = CitationInfo()

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
@@ -59,7 +59,8 @@ fun FileCard(
     actionOverflowIcon: FluentIcon? = null,
     fileCardTokens: FileCardTokens? = null
 ) {
-    val token = fileCardTokens
+    val themeID = FluentTheme.themeID
+	val token = fileCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.FileCard] as FileCardTokens
     val isPreviewAvailable = !(previewImageDrawable == null && previewImageVector == null)
     val fileCardInfo = FileCardInfo(isPreviewAvailable)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
@@ -59,7 +59,8 @@ fun FileCard(
     actionOverflowIcon: FluentIcon? = null,
     fileCardTokens: FileCardTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = fileCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.FileCard] as FileCardTokens
     val isPreviewAvailable = !(previewImageDrawable == null && previewImageVector == null)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
@@ -60,7 +60,7 @@ fun FileCard(
     fileCardTokens: FileCardTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = fileCardTokens
+    val token = fileCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.FileCard] as FileCardTokens
     val isPreviewAvailable = !(previewImageDrawable == null && previewImageVector == null)
     val fileCardInfo = FileCardInfo(isPreviewAvailable)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
@@ -57,7 +57,8 @@ fun FloatingActionButton(
     if (icon == null && (text == null || text == ""))
         return
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = fabTokens
         ?: FluentTheme.controlTokens.tokens[ControlType.FloatingActionButton] as FABTokens
 

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
@@ -57,7 +57,8 @@ fun FloatingActionButton(
     if (icon == null && (text == null || text == ""))
         return
 
-    val token = fabTokens
+    val themeID = FluentTheme.themeID
+	val token = fabTokens
         ?: FluentTheme.controlTokens.tokens[ControlType.FloatingActionButton] as FABTokens
 
     val fabInfo = FABInfo(state, size)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FloatingActionButton.kt
@@ -58,7 +58,7 @@ fun FloatingActionButton(
         return
 
     val themeID = FluentTheme.themeID
-	val token = fabTokens
+    val token = fabTokens
         ?: FluentTheme.controlTokens.tokens[ControlType.FloatingActionButton] as FABTokens
 
     val fabInfo = FABInfo(state, size)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Label.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Label.kt
@@ -27,6 +27,7 @@ fun Label(
     modifier: Modifier = Modifier,
     labelTokens: LabelTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = labelTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Label] as LabelTokens
     val labelInfo = LabelInfo(textStyle, colorStyle)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Label.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Label.kt
@@ -27,7 +27,8 @@ fun Label(
     modifier: Modifier = Modifier,
     labelTokens: LabelTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = labelTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Label] as LabelTokens
     val labelInfo = LabelInfo(textStyle, colorStyle)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
@@ -45,7 +45,8 @@ fun RadioButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     radioButtonToken: RadioButtonTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = radioButtonToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.RadioButton] as RadioButtonTokens
     val radioButtonInfo = RadioButtonInfo(selected)

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
@@ -45,7 +45,8 @@ fun RadioButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     radioButtonToken: RadioButtonTokens? = null
 ) {
-    val token = radioButtonToken
+    val themeID = FluentTheme.themeID
+	val token = radioButtonToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.RadioButton] as RadioButtonTokens
     val radioButtonInfo = RadioButtonInfo(selected)
     val dotRadius = animateDpAsState(

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/RadioButton.kt
@@ -46,7 +46,7 @@ fun RadioButton(
     radioButtonToken: RadioButtonTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = radioButtonToken
+    val token = radioButtonToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.RadioButton] as RadioButtonTokens
     val radioButtonInfo = RadioButtonInfo(selected)
     val dotRadius = animateDpAsState(

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -95,7 +95,8 @@ fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textFieldTokens: TextFieldTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = textFieldTokens
         ?: (FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TextField] as TextFieldTokens)
 

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -96,7 +96,7 @@ fun TextField(
     textFieldTokens: TextFieldTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = textFieldTokens
+    val token = textFieldTokens
         ?: (FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TextField] as TextFieldTokens)
 
     var isFocused: Boolean by rememberSaveable { mutableStateOf(false) }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -95,7 +95,8 @@ fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textFieldTokens: TextFieldTokens? = null
 ) {
-    val token = textFieldTokens
+    val themeID = FluentTheme.themeID
+	val token = textFieldTokens
         ?: (FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TextField] as TextFieldTokens)
 
     var isFocused: Boolean by rememberSaveable { mutableStateOf(false) }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/ToggleSwitch.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/ToggleSwitch.kt
@@ -62,7 +62,7 @@ fun ToggleSwitch(
 ) {
 
     val themeID = FluentTheme.themeID
-	val token = switchTokens
+    val token = switchTokens
         ?: FluentTheme.controlTokens.tokens[ControlType.ToggleSwitch] as ToggleSwitchTokens
     val toggleSwitchInfo = ToggleSwitchInfo(checkedState)
     val backgroundColor: Color = animateColorAsState(

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/ToggleSwitch.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/ToggleSwitch.kt
@@ -61,7 +61,8 @@ fun ToggleSwitch(
     switchTokens: ToggleSwitchTokens? = null
 ) {
 
-    val token = switchTokens
+    val themeID = FluentTheme.themeID
+	val token = switchTokens
         ?: FluentTheme.controlTokens.tokens[ControlType.ToggleSwitch] as ToggleSwitchTokens
     val toggleSwitchInfo = ToggleSwitchInfo(checkedState)
     val backgroundColor: Color = animateColorAsState(

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/ToggleSwitch.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/ToggleSwitch.kt
@@ -61,7 +61,8 @@ fun ToggleSwitch(
     switchTokens: ToggleSwitchTokens? = null
 ) {
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = switchTokens
         ?: FluentTheme.controlTokens.tokens[ControlType.ToggleSwitch] as ToggleSwitchTokens
     val toggleSwitchInfo = ToggleSwitchInfo(checkedState)

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/FluentTheme.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/FluentTheme.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.microsoft.fluentui.theme.token.*
-import kotlin.random.Random
 
 enum class ThemeMode {
     Light,
@@ -121,11 +120,11 @@ object FluentTheme : ViewModel() {
         updateThemeID()
     }
 
+    /*
+     * Update ThemeID for a new combination of AliasTokens, ControlTokens and ThemeMode.
+     */
     private fun updateThemeID() {
-        var temp = Random.nextInt()
-        while (temp == themeID_.value)
-            temp = Random.nextInt()
-        themeID_.value = temp
+        themeID_.value = themeID_.value?.plus(1)
     }
 
     @Composable

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/FluentTheme.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/FluentTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.microsoft.fluentui.theme.token.*
+import kotlin.random.Random
 
 enum class ThemeMode {
     Light,
@@ -13,6 +14,7 @@ enum class ThemeMode {
 }
 
 internal val LocalThemeMode = compositionLocalOf { ThemeMode.Auto }
+internal val LocalThemeID = compositionLocalOf { 1 }
 
 /**
  * FluentTheme function is a entry point for UI created using Fluent Control. Provide your UI Logic
@@ -44,11 +46,13 @@ fun FluentTheme(
     val appAliasTokens by FluentTheme.observeAliasToken(initial = AliasTokens())
     val appControlTokens by FluentTheme.observeControlToken(initial = ControlTokens())
     val appThemeMode by FluentTheme.observeThemeMode(initial = ThemeMode.Auto)
+    val appThemeID by FluentTheme.observeThemeID(initial = 1)
 
     CompositionLocalProvider(
         LocalAliasTokens provides (aliasTokens ?: appAliasTokens),
         LocalControlTokens provides (controlTokens ?: appControlTokens),
-        LocalThemeMode provides (themeMode ?: appThemeMode)
+        LocalThemeMode provides (themeMode ?: appThemeMode),
+        LocalThemeID provides appThemeID
     ) {
         content()
     }
@@ -82,15 +86,23 @@ object FluentTheme : ViewModel() {
         @ReadOnlyComposable
         get() = LocalThemeMode.current
 
+
+    val themeID: Int
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalThemeID.current
+
     private var aliasTokens_: MutableLiveData<IAliasTokens> = MutableLiveData(AliasTokens())
     private var controlTokens_: MutableLiveData<IControlTokens> = MutableLiveData(ControlTokens())
     private var themeMode_: MutableLiveData<ThemeMode> = MutableLiveData(ThemeMode.Auto)
+    private var themeID_: MutableLiveData<Int> = MutableLiveData(1)
 
     /**
      * Update aliasTokens across all FluentTheme scope where explicit values is not provided to it.
      */
     fun updateAliasTokens(overrideAliasTokens: IAliasTokens) {
         aliasTokens_.value = overrideAliasTokens
+        updateThemeID()
     }
 
     /**
@@ -98,6 +110,7 @@ object FluentTheme : ViewModel() {
      */
     fun updateControlTokens(overrideControlTokens: IControlTokens) {
         controlTokens_.value = overrideControlTokens
+        updateThemeID()
     }
 
     /**
@@ -105,16 +118,19 @@ object FluentTheme : ViewModel() {
      */
     fun updateThemeMode(overrideThemeMode: ThemeMode) {
         themeMode_.value = overrideThemeMode
+        updateThemeID()
+    }
+
+    private fun updateThemeID() {
+        var temp = Random.nextInt()
+        while (temp == themeID_.value)
+            temp = Random.nextInt()
+        themeID_.value = temp
     }
 
     @Composable
     internal fun observeAliasToken(initial: IAliasTokens): State<IAliasTokens> {
         return this.aliasTokens_.observeAsState(initial)
-    }
-
-    @Composable
-    internal fun observeAliasToken(): State<IAliasTokens?> {
-        return this.aliasTokens_.observeAsState()
     }
 
     @Composable
@@ -125,5 +141,10 @@ object FluentTheme : ViewModel() {
     @Composable
     internal fun observeThemeMode(initial: ThemeMode): State<ThemeMode> {
         return this.themeMode_.observeAsState(initial = initial)
+    }
+
+    @Composable
+    internal fun observeThemeID(initial: Int): State<Int> {
+        return this.themeID_.observeAsState(initial = initial)
     }
 }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -225,6 +225,7 @@ fun BottomSheet(
     bottomSheetTokens: BottomSheetTokens? = null,
     content: @Composable () -> Unit
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = bottomSheetTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BottomSheet] as BottomSheetTokens
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -225,7 +225,8 @@ fun BottomSheet(
     bottomSheetTokens: BottomSheetTokens? = null,
     content: @Composable () -> Unit
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = bottomSheetTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BottomSheet] as BottomSheetTokens
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -808,6 +808,7 @@ fun Drawer(
     drawerContent: @Composable () -> Unit
 ) {
     if (drawerState.enable) {
+        val themeID = FluentTheme.themeID
         val tokens = drawerTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Drawer] as DrawerTokens
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -808,7 +808,8 @@ fun Drawer(
     drawerContent: @Composable () -> Unit
 ) {
     if (drawerState.enable) {
-        val themeID = FluentTheme.themeID
+        val themeID =
+            FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
         val tokens = drawerTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Drawer] as DrawerTokens
 

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -300,7 +300,7 @@ class ListContentBuilder {
 
             items(itemDataList) { item ->
                 val themeID = FluentTheme.themeID
-	            val token = listItemTokens
+                val token = listItemTokens
                     ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ListItem] as ListItemTokens
                 ListItem.Item(
                     text = item.title,

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -299,7 +299,8 @@ class ListContentBuilder {
             }
 
             items(itemDataList) { item ->
-                val token = listItemTokens
+                val themeID = FluentTheme.themeID
+	            val token = listItemTokens
                     ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ListItem] as ListItemTokens
                 ListItem.Item(
                     text = item.title,

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -299,7 +299,8 @@ class ListContentBuilder {
             }
 
             items(itemDataList) { item ->
-                val themeID = FluentTheme.themeID
+                val themeID =
+                    FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
                 val token = listItemTokens
                     ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ListItem] as ListItemTokens
                 ListItem.Item(

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
@@ -17,6 +17,7 @@ fun Divider(
     height: Dp = 1.dp,
     dividerToken: DividerTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token =
         dividerToken
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Divider] as DividerTokens

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/divider/Divider.kt
@@ -17,7 +17,8 @@ fun Divider(
     height: Dp = 1.dp,
     dividerToken: DividerTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token =
         dividerToken
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Divider] as DividerTokens

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -249,7 +249,8 @@ object ListItem {
         } else {
             ThreeLine
         }
-        val themeID = FluentTheme.themeID
+        val themeID =
+            FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
         val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
@@ -459,7 +460,8 @@ object ListItem {
         listItemTokens: ListItemTokens? = null,
         content: (@Composable () -> Unit)? = null
     ) {
-        val themeID = FluentTheme.themeID
+        val themeID =
+            FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
         val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
@@ -624,7 +626,8 @@ object ListItem {
         trailingAccessoryView: (@Composable () -> Unit)? = null,
         listItemTokens: ListItemTokens? = null
     ) {
-        val themeID = FluentTheme.themeID
+        val themeID =
+            FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
         val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
@@ -753,7 +756,8 @@ object ListItem {
         trailingAccessoryView: (@Composable () -> Unit)? = null,
         listItemTokens: ListItemTokens? = null
     ) {
-        val themeID = FluentTheme.themeID
+        val themeID =
+            FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
         val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -249,7 +249,8 @@ object ListItem {
         } else {
             ThreeLine
         }
-        val token = listItemTokens
+        val themeID = FluentTheme.themeID
+	    val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
             listItemType = listItemType,
@@ -458,7 +459,7 @@ object ListItem {
         listItemTokens: ListItemTokens? = null,
         content: (@Composable () -> Unit)? = null
     ) {
-
+        val themeID = FluentTheme.themeID
         val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
@@ -623,6 +624,7 @@ object ListItem {
         trailingAccessoryView: (@Composable () -> Unit)? = null,
         listItemTokens: ListItemTokens? = null
     ) {
+        val themeID = FluentTheme.themeID
         val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
@@ -751,7 +753,8 @@ object ListItem {
         trailingAccessoryView: (@Composable () -> Unit)? = null,
         listItemTokens: ListItemTokens? = null
     ) {
-        val token = listItemTokens
+        val themeID = FluentTheme.themeID
+	    val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
             listItemType = OneLine,

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -250,7 +250,7 @@ object ListItem {
             ThreeLine
         }
         val themeID = FluentTheme.themeID
-	    val token = listItemTokens
+        val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
             listItemType = listItemType,
@@ -754,7 +754,7 @@ object ListItem {
         listItemTokens: ListItemTokens? = null
     ) {
         val themeID = FluentTheme.themeID
-	    val token = listItemTokens
+        val token = listItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlType.ListItem] as ListItemTokens
         val listItemInfo = ListItemInfo(
             listItemType = OneLine,

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -44,6 +44,7 @@ fun TabItem(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     tabItemTokens: TabItemTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token =
         tabItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabItem] as TabItemTokens

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -44,7 +44,8 @@ fun TabItem(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     tabItemTokens: TabItemTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token =
         tabItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabItem] as TabItemTokens

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Dialog.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Dialog.kt
@@ -37,6 +37,8 @@ fun Dialog(
     dialogTokens: DialogTokens? = null,
     content: @Composable () -> Unit
 ) {
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = dialogTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Dialog] as DialogTokens
     val dialogInfo = DialogInfo()

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
@@ -66,6 +66,7 @@ fun Menu(
     openedStates.targetState = opened
 
     if (openedStates.currentState || openedStates.targetState) {
+        val themeID = FluentTheme.themeID
         val token =
             menuTokens
                 ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Menu] as MenuTokens

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/tokenized/menu/Menu.kt
@@ -66,7 +66,8 @@ fun Menu(
     openedStates.targetState = opened
 
     if (openedStates.currentState || openedStates.targetState) {
-        val themeID = FluentTheme.themeID
+        val themeID =
+            FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
         val token =
             menuTokens
                 ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Menu] as MenuTokens

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -40,7 +40,8 @@ fun Badge(
     badgeType: BadgeType = BadgeType.List,
     badgeTokens: BadgeTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = badgeTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Badge] as BadgeTokens
     val badgeInfo = BadgeInfo(badgeType)

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -40,6 +40,7 @@ fun Badge(
     badgeType: BadgeType = BadgeType.List,
     badgeTokens: BadgeTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = badgeTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Badge] as BadgeTokens
     val badgeInfo = BadgeInfo(badgeType)

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -83,7 +83,8 @@ fun CardNudge(
     outlineMode: Boolean = false,
     cardNudgeTokens: CardNudgeTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = cardNudgeTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.CardNudge] as CardNudgeTokens
 

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -83,6 +83,7 @@ fun CardNudge(
     outlineMode: Boolean = false,
     cardNudgeTokens: CardNudgeTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = cardNudgeTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.CardNudge] as CardNudgeTokens
 

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -116,7 +116,8 @@ fun Snackbar(
 ) {
     val metadata: SnackbarMetadata = snackbarState.currentSnackbar ?: return
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = snackbarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Snackbar] as SnackBarTokens
 

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -116,6 +116,7 @@ fun Snackbar(
 ) {
     val metadata: SnackbarMetadata = snackbarState.currentSnackbar ?: return
 
+    val themeID = FluentTheme.themeID
     val token = snackbarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Snackbar] as SnackBarTokens
 

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
@@ -63,7 +63,7 @@ fun Avatar(
 ) {
 
     val themeID = FluentTheme.themeID
-	val token = avatarToken
+    val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
     val personInitials = person.getInitials()
@@ -317,7 +317,7 @@ fun Avatar(
     avatarToken: AvatarTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = avatarToken
+    val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
     val avatarInfo = AvatarInfo(size, AvatarType.Overflow)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
@@ -62,7 +62,8 @@ fun Avatar(
     avatarToken: AvatarTokens? = null
 ) {
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
@@ -224,7 +225,8 @@ fun Avatar(
     avatarToken: AvatarTokens? = null,
 ) {
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
@@ -316,7 +318,8 @@ fun Avatar(
     enableActivityRings: Boolean = false,
     avatarToken: AvatarTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
@@ -62,7 +62,8 @@ fun Avatar(
     avatarToken: AvatarTokens? = null
 ) {
 
-    val token = avatarToken
+    val themeID = FluentTheme.themeID
+	val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
     val personInitials = person.getInitials()
@@ -223,6 +224,7 @@ fun Avatar(
     avatarToken: AvatarTokens? = null,
 ) {
 
+    val themeID = FluentTheme.themeID
     val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
@@ -314,7 +316,8 @@ fun Avatar(
     enableActivityRings: Boolean = false,
     avatarToken: AvatarTokens? = null
 ) {
-    val token = avatarToken
+    val themeID = FluentTheme.themeID
+	val token = avatarToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Avatar] as AvatarTokens
 
     val avatarInfo = AvatarInfo(size, AvatarType.Overflow)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
@@ -58,6 +58,7 @@ fun AvatarCarousel(
     avatarTokens: AvatarTokens? = null,
     avatarCarouselTokens: AvatarCarouselTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = avatarCarouselTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AvatarCarousel] as AvatarCarouselTokens
     val avatarCarouselInfo = AvatarCarouselInfo(size)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarCarousel.kt
@@ -58,7 +58,8 @@ fun AvatarCarousel(
     avatarTokens: AvatarTokens? = null,
     avatarCarouselTokens: AvatarCarouselTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = avatarCarouselTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AvatarCarousel] as AvatarCarouselTokens
     val avatarCarouselInfo = AvatarCarouselInfo(size)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarGroup.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarGroup.kt
@@ -40,7 +40,8 @@ fun AvatarGroup(
     avatarToken: AvatarTokens? = null,
     avatarGroupToken: AvatarGroupTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = avatarGroupToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AvatarGroup] as AvatarGroupTokens
 

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarGroup.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarGroup.kt
@@ -41,7 +41,7 @@ fun AvatarGroup(
     avatarGroupToken: AvatarGroupTokens? = null
 ) {
     val themeID = FluentTheme.themeID
-	val token = avatarGroupToken
+    val token = avatarGroupToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AvatarGroup] as AvatarGroupTokens
 
     val visibleAvatar: Int = if (maxVisibleAvatar < 0)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarGroup.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/AvatarGroup.kt
@@ -40,7 +40,8 @@ fun AvatarGroup(
     avatarToken: AvatarTokens? = null,
     avatarGroupToken: AvatarGroupTokens? = null
 ) {
-    val token = avatarGroupToken
+    val themeID = FluentTheme.themeID
+	val token = avatarGroupToken
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AvatarGroup] as AvatarGroupTokens
 
     val visibleAvatar: Int = if (maxVisibleAvatar < 0)

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Persona.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Persona.kt
@@ -2,11 +2,13 @@ package com.microsoft.fluentui.tokenized.persona
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.microsoft.fluentui.theme.token.controlTokens.*
+import com.microsoft.fluentui.theme.token.controlTokens.AvatarTokens
+import com.microsoft.fluentui.theme.token.controlTokens.BorderInset
 import com.microsoft.fluentui.theme.token.controlTokens.BorderInset.None
+import com.microsoft.fluentui.theme.token.controlTokens.BorderType
 import com.microsoft.fluentui.theme.token.controlTokens.BorderType.NoBorder
+import com.microsoft.fluentui.theme.token.controlTokens.ListItemTokens
 import com.microsoft.fluentui.tokenized.listitem.ListItem
-import com.microsoft.fluentui.tokenized.listitem.TextIcons
 
 /**
  * A customized  list item. Can be a Single or multiline Avatar item. Size of the persona is based on the texts provided

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
@@ -55,7 +55,8 @@ fun PersonaChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     personaChipTokens: PersonaChipTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = personaChipTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PersonaChip] as PersonaChipTokens
     val personaChipInfo = PersonaChipInfo(

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
@@ -55,6 +55,7 @@ fun PersonaChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     personaChipTokens: PersonaChipTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = personaChipTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PersonaChip] as PersonaChipTokens
     val personaChipInfo = PersonaChipInfo(

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaList.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaList.kt
@@ -48,14 +48,16 @@ fun PersonaList(
 ) {
     val scope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
-    LazyColumn(state = lazyListState, modifier = modifier.draggable(
-        orientation = Orientation.Vertical,
-        state = rememberDraggableState { delta ->
-            scope.launch {
-                lazyListState.scrollBy(-delta)
-            }
-        },
-    )) {
+    LazyColumn(
+        state = lazyListState, modifier = modifier.draggable(
+            orientation = Orientation.Vertical,
+            state = rememberDraggableState { delta ->
+                scope.launch {
+                    lazyListState.scrollBy(-delta)
+                }
+            },
+        )
+    ) {
         items(personas) { item ->
             ListItem.Item(
                 text = item.title,

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
@@ -54,6 +54,7 @@ fun SearchBarPersonaChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     searchbarPersonaChipTokens: SearchBarPersonaChipTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = searchbarPersonaChipTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.SearchBarPersonaChip] as SearchBarPersonaChipTokens
     val searchBarPersonaChipInfo = SearchBarPersonaChipInfo(

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/SearchBarPersonaChip.kt
@@ -54,7 +54,8 @@ fun SearchBarPersonaChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     searchbarPersonaChipTokens: SearchBarPersonaChipTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = searchbarPersonaChipTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.SearchBarPersonaChip] as SearchBarPersonaChipTokens
     val searchBarPersonaChipInfo = SearchBarPersonaChipInfo(

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
@@ -131,9 +131,9 @@ fun CircularProgressIndicator(
     )
     val indicatorSizeInPx = dpToPx(circularProgressIndicatorSize)
     Canvas(
-            modifier = modifier
-                .requiredSize(circularProgressIndicatorSize)
-                .progressSemantics()
+        modifier = modifier
+            .requiredSize(circularProgressIndicatorSize)
+            .progressSemantics()
     ) {
         drawArc(
             circularProgressIndicatorColor,
@@ -144,6 +144,6 @@ fun CircularProgressIndicator(
                 indicatorSizeInPx, indicatorSizeInPx
             ),
             style = Stroke(dpToPx(circularProgressIndicatorStrokeWidth), cap = StrokeCap.Round)
-       )
+        )
     }
 }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
@@ -36,6 +36,7 @@ fun CircularProgressIndicator(
     style: FluentStyle = FluentStyle.Neutral,
     circularProgressIndicatorTokens: CircularProgressIndicatorTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = circularProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.CircularProgressIndicator] as CircularProgressIndicatorTokens
     val circularProgressIndicatorInfo = CircularProgressIndicatorInfo(
@@ -98,6 +99,7 @@ fun CircularProgressIndicator(
     style: FluentStyle = FluentStyle.Neutral,
     circularProgressIndicatorTokens: CircularProgressIndicatorTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = circularProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.CircularProgressIndicator] as CircularProgressIndicatorTokens
     val circularProgressIndicatorInfo = CircularProgressIndicatorInfo(

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/CircularProgressIndicator.kt
@@ -36,7 +36,8 @@ fun CircularProgressIndicator(
     style: FluentStyle = FluentStyle.Neutral,
     circularProgressIndicatorTokens: CircularProgressIndicatorTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = circularProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.CircularProgressIndicator] as CircularProgressIndicatorTokens
     val circularProgressIndicatorInfo = CircularProgressIndicatorInfo(
@@ -99,7 +100,8 @@ fun CircularProgressIndicator(
     style: FluentStyle = FluentStyle.Neutral,
     circularProgressIndicatorTokens: CircularProgressIndicatorTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = circularProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.CircularProgressIndicator] as CircularProgressIndicatorTokens
     val circularProgressIndicatorInfo = CircularProgressIndicatorInfo(

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/LinearProgressIndicator.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/LinearProgressIndicator.kt
@@ -34,6 +34,7 @@ fun LinearProgressIndicator(
     linearProgressIndicatorHeight: LinearProgressIndicatorHeight = LinearProgressIndicatorHeight.XXXSmall,
     linearProgressIndicatorTokens: LinearProgressIndicatorTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = linearProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.LinearProgressIndicator] as LinearProgressIndicatorTokens
     val linearProgressIndicatorInfo = LinearProgressIndicatorInfo(
@@ -97,6 +98,7 @@ fun LinearProgressIndicator(
     linearProgressIndicatorHeight: LinearProgressIndicatorHeight = LinearProgressIndicatorHeight.XXXSmall,
     linearProgressIndicatorTokens: LinearProgressIndicatorTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = linearProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.LinearProgressIndicator] as LinearProgressIndicatorTokens
     val linearProgressIndicatorInfo = LinearProgressIndicatorInfo(

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/LinearProgressIndicator.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/LinearProgressIndicator.kt
@@ -34,7 +34,8 @@ fun LinearProgressIndicator(
     linearProgressIndicatorHeight: LinearProgressIndicatorHeight = LinearProgressIndicatorHeight.XXXSmall,
     linearProgressIndicatorTokens: LinearProgressIndicatorTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = linearProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.LinearProgressIndicator] as LinearProgressIndicatorTokens
     val linearProgressIndicatorInfo = LinearProgressIndicatorInfo(
@@ -98,7 +99,8 @@ fun LinearProgressIndicator(
     linearProgressIndicatorHeight: LinearProgressIndicatorHeight = LinearProgressIndicatorHeight.XXXSmall,
     linearProgressIndicatorTokens: LinearProgressIndicatorTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = linearProgressIndicatorTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.LinearProgressIndicator] as LinearProgressIndicatorTokens
     val linearProgressIndicatorInfo = LinearProgressIndicatorInfo(

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/ProgressText.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/progress/ProgressText.kt
@@ -42,6 +42,8 @@ fun ProgressText(
     modifier: Modifier = Modifier,
     progressTextTokens: ProgressTextTokens? = null
 ) {
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = progressTextTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.ProgressText] as ProgressTextTokens
     val progressTextInfo = ProgressTextInfo(progress)

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -41,6 +41,7 @@ fun Shimmer(
     shape: ShimmerShape = ShimmerShape.Box,
     shimmerTokens: ShimmerTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val tokens = shimmerTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Shimmer] as ShimmerTokens
     val configuration = LocalConfiguration.current

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -41,7 +41,8 @@ fun Shimmer(
     shape: ShimmerShape = ShimmerShape.Box,
     shimmerTokens: ShimmerTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val tokens = shimmerTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.Shimmer] as ShimmerTokens
     val configuration = LocalConfiguration.current

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
@@ -42,6 +42,7 @@ fun TabBar(
     tabItemTokens: TabItemTokens? = null,
     tabBarTokens: TabBarTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = tabBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabBar] as TabBarTokens
 

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
@@ -45,7 +45,8 @@ fun TabBar(
     tabItemTokens: TabItemTokens? = null,
     tabBarTokens: TabBarTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = tabBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabBar] as TabBarTokens
 

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
@@ -9,7 +9,10 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
-import com.microsoft.fluentui.theme.token.controlTokens.*
+import com.microsoft.fluentui.theme.token.controlTokens.TabBarInfo
+import com.microsoft.fluentui.theme.token.controlTokens.TabBarTokens
+import com.microsoft.fluentui.theme.token.controlTokens.TabItemTokens
+import com.microsoft.fluentui.theme.token.controlTokens.TabTextAlignment
 import com.microsoft.fluentui.tokenized.tabItem.TabItem
 
 

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -75,6 +75,7 @@ fun PillButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     pillButtonTokens: PillButtonTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = pillButtonTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillButton] as PillButtonTokens
     val pillButtonInfo = PillButtonInfo(
@@ -245,7 +246,8 @@ fun PillBar(
     if (metadataList.size == 0)
         return
 
-    val token = pillBarTokens
+    val themeID = FluentTheme.themeID
+	val token = pillBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillBar] as PillBarTokens
 
     val pillBarInfo = PillBarInfo(style)

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -75,7 +75,8 @@ fun PillButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     pillButtonTokens: PillButtonTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = pillButtonTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillButton] as PillButtonTokens
     val pillButtonInfo = PillButtonInfo(
@@ -246,7 +247,8 @@ fun PillBar(
     if (metadataList.size == 0)
         return
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = pillBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillBar] as PillBarTokens
 

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -247,7 +247,7 @@ fun PillBar(
         return
 
     val themeID = FluentTheme.themeID
-	val token = pillBarTokens
+    val token = pillBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillBar] as PillBarTokens
 
     val pillBarInfo = PillBarInfo(style)

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
@@ -47,7 +47,8 @@ fun PillSwitch(
     if (metadataList.size == 0)
         return
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = pillSwitchTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillSwitch] as PillSwitchTokens
 

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
@@ -47,6 +47,7 @@ fun PillSwitch(
     if (metadataList.size == 0)
         return
 
+    val themeID = FluentTheme.themeID
     val token = pillSwitchTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillSwitch] as PillSwitchTokens
 

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillTabs.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillTabs.kt
@@ -43,6 +43,7 @@ fun PillTabs(
     if (metadataList.size == 0)
         return
 
+    val themeID = FluentTheme.themeID
     val token =
         tabsTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillTabs] as PillTabsTokens

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillTabs.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillTabs.kt
@@ -43,7 +43,8 @@ fun PillTabs(
     if (metadataList.size == 0)
         return
 
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token =
         tabsTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.PillTabs] as PillTabsTokens

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -80,7 +80,8 @@ fun AppBar(
     accessoryDelta: Float = 1.0F,
     appBarTokens: AppBarTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = appBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AppBar] as AppBarTokens
 

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -80,6 +80,7 @@ fun AppBar(
     accessoryDelta: Float = 1.0F,
     appBarTokens: AppBarTokens? = null
 ) {
+    val themeID = FluentTheme.themeID
     val token = appBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AppBar] as AppBarTokens
 

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -93,7 +93,8 @@ fun SearchBar(
     rightAccessoryIcon: FluentIcon? = null,
     searchBarTokens: SearchBarTokens? = null
 ) {
-    val themeID = FluentTheme.themeID
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = searchBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.SearchBar] as SearchBarTokens
     val searchBarInfo = SearchBarInfo(style)

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -93,7 +93,7 @@ fun SearchBar(
     rightAccessoryIcon: FluentIcon? = null,
     searchBarTokens: SearchBarTokens? = null
 ) {
-
+    val themeID = FluentTheme.themeID
     val token = searchBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.SearchBar] as SearchBarTokens
     val searchBarInfo = SearchBarInfo(style)


### PR DESCRIPTION
### Problem 
If we update a control token,without creating a new ControlToken object/copy, the app was not recomposing.

### Root cause 
This is  due to no change in the overall object. Only a parameter or object changes.

### Fix
Add another parameter called ThemeID which updates whenever there is a change in aliasToken, controlToken or ThemeMode.
This param has to be used by every app so that it invokes recomposition across the FluentTheme.

### Validations
Manual Validation

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
