### PR TITLE
List Accessory view alignment

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -13,7 +13,11 @@ import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -478,11 +482,18 @@ private fun ThreeLineListAccessoryViewContent(
     context: Context
 ) {
     val separator = " • "
+    val footer = buildAnnotatedString {
+        withStyle(SpanStyle(color = Color.Blue)){
+            append("3 min ago")
+        }
+        append(separator)
+        append("FluentGuide V1.pptx")
+    }
     return Column {
         ListItem.Item(
             text = "Amanda Brady replied to your comment",
             subText = "Wanda can you please update the file with comments",
-            secondarySubText = "3 min ago"+ separator + "FluentGuide V1.pptx",
+            secondarySubTextAnnotated = footer,
             leadingAccessoryView = { LeftViewAvatar(size = Size40) },
             trailingAccessoryView = {rightViewIconButton()},
             textMaxLines = 2,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -7,7 +7,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -21,10 +25,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize.*
 import com.microsoft.fluentui.theme.token.controlTokens.BorderInset.XXLarge
 import com.microsoft.fluentui.theme.token.controlTokens.SectionHeaderStyle.Subtle
 import com.microsoft.fluentui.theme.token.controlTokens.TextPlacement.Bottom
-import com.microsoft.fluentui.tokenized.controls.Button
-import com.microsoft.fluentui.tokenized.controls.CheckBox
-import com.microsoft.fluentui.tokenized.controls.RadioButton
-import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
+import com.microsoft.fluentui.tokenized.controls.*
 import com.microsoft.fluentui.tokenized.listitem.ChevronOrientation
 import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentui.tokenized.listitem.TextIcons
@@ -474,16 +475,15 @@ private fun TwoLineListAccessoryViewContent(context: Context) {
 private fun ThreeLineListAccessoryViewContent(
     context: Context
 ) {
+    val seperator = " • "
     return Column {
         ListItem.Item(
-            text = primaryText,
-            subText = secondaryText,
-            secondarySubText = tertiaryText,
-            primaryTextLeadingIcons = twoTextIcons20(),
-            primaryTextTrailingIcons = oneTextIcon20(),
-            secondarySubTextLeadingIcons = twoTextIcons16(),
-            secondarySubTextTailingIcons = twoTextIcons16(),
-            leadingAccessoryView = { LeftViewFolderIcon40() },
+            text = "Robert replied to your comment",
+            subText = "Wanda can you please update",
+            secondarySubText = "3 min ago"+ seperator + "FluentGuide V1.pptx",
+            leadingAccessoryView = { LeftViewAvatar(size = Size40) },
+            trailingAccessoryView = {rightViewIconButton()},
+            textMaxLines = 2,
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
@@ -669,6 +669,13 @@ private fun Icon20() {
 @Composable
 private fun LeftViewFolderIcon40() {
     return Image(ListItemIcons.Folder40, "Folder")
+}
+
+@Composable
+private fun rightViewIconButton(){
+    Column(verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
+        Icon(Icons.Outlined.MoreVert, contentDescription = "")
+    }
 }
 
 @Composable

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -14,11 +14,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.FluentTheme.aliasTokens
 import com.microsoft.fluentui.theme.FluentTheme.themeMode
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.*
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize.*
@@ -475,15 +477,18 @@ private fun TwoLineListAccessoryViewContent(context: Context) {
 private fun ThreeLineListAccessoryViewContent(
     context: Context
 ) {
-    val seperator = " • "
+    val separator = " • "
     return Column {
         ListItem.Item(
-            text = "Robert replied to your comment",
-            subText = "Wanda can you please update",
-            secondarySubText = "3 min ago"+ seperator + "FluentGuide V1.pptx",
+            text = "Amanda Brady replied to your comment",
+            subText = "Wanda can you please update the file with comments",
+            secondarySubText = "3 min ago"+ separator + "FluentGuide V1.pptx",
             leadingAccessoryView = { LeftViewAvatar(size = Size40) },
             trailingAccessoryView = {rightViewIconButton()},
             textMaxLines = 2,
+            leadingAccessoryViewAlignment = Alignment.Top,
+            trailingAccessoryViewAlignment = Alignment.Top,
+            unreadDot = true,
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
@@ -673,8 +678,16 @@ private fun LeftViewFolderIcon40() {
 
 @Composable
 private fun rightViewIconButton(){
+    class Tokens: BasicCardTokens(){
+        @Composable
+        override fun cornerRadius(basicCardInfo: BasicCardInfo): Dp {
+            return FluentGlobalTokens.cornerRadius(FluentGlobalTokens.CornerRadiusTokens.CornerRadius40)
+        }
+    }
     Column(verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(Icons.Outlined.MoreVert, contentDescription = "")
+        BasicCard(Modifier.padding(all = 4.dp), basicCardTokens = Tokens()) {
+            Icon(Icons.Outlined.MoreVert, contentDescription = "")
+        }
     }
 }
 

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -124,7 +124,6 @@ object ListItem {
         }
     }
 
-    @OptIn(ExperimentalMaterialApi::class)
     @Composable
     private fun InlineText(
         description: String,
@@ -239,6 +238,8 @@ object ListItem {
         bottomView: (@Composable () -> Unit)? = null,
         leadingAccessoryView: (@Composable () -> Unit)? = null,
         trailingAccessoryView: (@Composable () -> Unit)? = null,
+        leadingAccessoryViewAlignment: Alignment.Vertical = Alignment.CenterVertically,
+        trailingAccessoryViewAlignment: Alignment.Vertical = Alignment.CenterVertically,
         textAccessibilityProperties: (SemanticsPropertyReceiver.() -> Unit)? = null,
         listItemTokens: ListItemTokens? = null
     ) {
@@ -255,14 +256,13 @@ object ListItem {
             listItemType = listItemType,
             borderInset = borderInset,
             horizontalSpacing = FluentGlobalTokens.SizeTokens.Size160,
-            verticalSpacing = FluentGlobalTokens.SizeTokens.Size160,
+            verticalSpacing = FluentGlobalTokens.SizeTokens.Size120,
             unreadDot = unreadDot
         )
         val backgroundColor =
             token.backgroundBrush(listItemInfo).getBrushByState(
                 enabled = true, selected = false, interactionSource = interactionSource
             )
-        val cellHeight = token.cellHeight(listItemInfo)
         val primaryTextTypography = token.primaryTextTypography(listItemInfo)
         val subTextTypography = token.subTextTypography(listItemInfo)
         val secondarySubTextTypography =
@@ -292,37 +292,53 @@ object ListItem {
         val borderColor = token.borderColor(listItemInfo).getColorByState(
             enabled = enabled, selected = false, interactionSource = interactionSource
         )
-
+        val leadingAccessoryAlignment = when(leadingAccessoryViewAlignment){
+            Alignment.Top -> Alignment.TopCenter
+            Alignment.Bottom -> Alignment.BottomCenter
+            else -> Alignment.Center
+        }
+        val trailingAccessoryAlignment = when(trailingAccessoryViewAlignment){
+            Alignment.Top -> Alignment.TopEnd
+            Alignment.Bottom -> Alignment.BottomEnd
+            else -> Alignment.CenterEnd
+        }
         Row(
             modifier
                 .background(backgroundColor)
                 .fillMaxWidth()
-                .heightIn(min = cellHeight)
+                .height(IntrinsicSize.Max)
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
                 .clickAndSemanticsModifier(
                     interactionSource, onClick = onClick ?: {}, enabled, rippleColor
                 ), verticalAlignment = Alignment.CenterVertically
         ) {
-            if (unreadDot) {
-                Canvas(
-                    modifier = Modifier
-                        .padding(start = 4.dp)
-                        .sizeIn(minWidth = 8.dp, minHeight = 8.dp)
-                ) {
-                    drawCircle(
-                        color = unreadDotColor, style = Fill, radius = dpToPx(4.dp)
-                    )
-                }
-            }
             if (leadingAccessoryView != null && textAlignment == ListItemTextAlignment.Regular) {
                 Box(
-                    Modifier.padding(
-                        start = if (unreadDot) 4.dp else padding.calculateStartPadding(
-                            LocalLayoutDirection.current
+                    modifier = Modifier
+                        .padding(
+                            start = if (unreadDot) 4.dp else padding.calculateStartPadding(
+                                LocalLayoutDirection.current
+                            ),
+                            top = if(leadingAccessoryViewAlignment == Alignment.Top) padding.calculateTopPadding() else 0.dp,
+                            bottom = if(leadingAccessoryViewAlignment == Alignment.Bottom) padding.calculateBottomPadding() else 0.dp
                         )
-                    ), contentAlignment = Alignment.Center
+                        .fillMaxHeight(), contentAlignment = leadingAccessoryAlignment
                 ) {
-                    leadingAccessoryView()
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (unreadDot) {
+                            Canvas(
+                                modifier = Modifier
+                                    .padding(start = 4.dp)
+                                    .sizeIn(minWidth = 8.dp, minHeight = 8.dp)
+                            ) {
+                                drawCircle(
+                                    color = unreadDotColor, style = Fill, radius = dpToPx(4.dp)
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(4.dp))
+                        }
+                        leadingAccessoryView()
+                    }
                 }
             }
             val contentAlignment =
@@ -406,8 +422,10 @@ object ListItem {
             }
             if (bottomView == null && trailingAccessoryView != null && textAlignment == ListItemTextAlignment.Regular) {
                 Box(
-                    Modifier.padding(end = padding.calculateEndPadding(LocalLayoutDirection.current)),
-                    contentAlignment = Alignment.CenterEnd
+                    Modifier.padding(top = if(trailingAccessoryViewAlignment == Alignment.Top) padding.calculateTopPadding() else 0.dp,
+                        bottom = if(trailingAccessoryViewAlignment == Alignment.Bottom) padding.calculateBottomPadding() else 0.dp,
+                        end = padding.calculateEndPadding(LocalLayoutDirection.current)).fillMaxHeight(),
+                    contentAlignment = trailingAccessoryAlignment
                 ) {
                     trailingAccessoryView()
                 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -187,40 +187,8 @@ object ListItem {
         }
 
     }
-
-    /**
-     * Create a Single line or a multi line List item. A multi line list can be formed by providing either a secondary text or a tertiary text
-     *
-     * @param text Primary text.
-     * @param modifier Optional modifier for List item.
-     * @param subText Optional secondaryText or a subtitle.
-     * @param secondarySubText Optional tertiary text or a footer.
-     * @param secondarySubTextAnnotated Optional tertiary text (Annotated) or a footer. If [secondarySubText] is provided this will be ignored.
-     * @param secondarySubTextInlineContent Map of composables to replace certain ranges of text in [secondarySubTextAnnotated].
-     * @param textAlignment Optional [ListItemTextAlignment] to align text in the center or start at the lead.
-     * @param unreadDot Option boolean value that display a dot on leading edge of the accessory view and makes the primary text bold on true
-     * @param enabled Optional enable/disable List item
-     * @param textMaxLines Optional max visible lines for primary text.
-     * @param subTextMaxLines Optional max visible lines for secondary text.
-     * @param secondarySubTextMaxLines Optional max visible lines for tertiary text.
-     * @param onClick Optional onClick action for list item.
-     * @param primaryTextLeadingIcons Optional primary text leading icons(20X20). Supply text icons using [TextIcons]
-     * @param primaryTextTrailingIcons Optional primary text trailing icons(20X20). Supply text icons using [TextIcons]
-     * @param secondarySubTextLeadingIcons Optional secondary text leading icons(16X16). Supply text icons using [TextIcons]
-     * @param secondarySubTextTailingIcons Optional secondary text trailing icons(16X16). Supply text icons using [TextIcons]
-     * @param border [BorderType] Optional border for the list item.
-     * @param borderInset [BorderInset]Optional borderInset for list item.
-     * @param bottomView Optional bottom view under Text field. If used, trailing view will not be displayed
-     * @param leadingAccessoryView Optional composable leading accessory view.
-     * @param trailingAccessoryView Optional composable trailing accessory view.
-     * @param leadingAccessoryViewAlignment Alignment for leading accessory view to align Top, Bottom or Center
-     * @param trailingAccessoryViewAlignment Alignment for trailing accessory view to align Top, Bottom or Center
-     * @param textAccessibilityProperties Accessibility properties for the text in list item.
-     * @param listItemTokens Optional list item tokens for list item appearance.If not provided then list item tokens will be picked from [AppThemeController]
-     *
-     */
     @Composable
-    fun Item(
+    internal fun InternalItem(
         text: String,
         modifier: Modifier = Modifier,
         subText: String? = null,
@@ -448,6 +416,181 @@ object ListItem {
                 }
             }
         }
+    }
+
+    /**
+     * Create a Single line or a multi line List item. A multi line list can be formed by providing either a secondary text or a tertiary text. Use this if secondarySubText is a String
+     *
+     * @param text Primary text.
+     * @param modifier Optional modifier for List item.
+     * @param subText Optional secondaryText or a subtitle.
+     * @param secondarySubText Optional tertiary text or a footer.
+     * @param textAlignment Optional [ListItemTextAlignment] to align text in the center or start at the lead.
+     * @param unreadDot Option boolean value that display a dot on leading edge of the accessory view and makes the primary text bold on true
+     * @param enabled Optional enable/disable List item
+     * @param textMaxLines Optional max visible lines for primary text.
+     * @param subTextMaxLines Optional max visible lines for secondary text.
+     * @param secondarySubTextMaxLines Optional max visible lines for tertiary text.
+     * @param onClick Optional onClick action for list item.
+     * @param primaryTextLeadingIcons Optional primary text leading icons(20X20). Supply text icons using [TextIcons]
+     * @param primaryTextTrailingIcons Optional primary text trailing icons(20X20). Supply text icons using [TextIcons]
+     * @param secondarySubTextLeadingIcons Optional secondary text leading icons(16X16). Supply text icons using [TextIcons]
+     * @param secondarySubTextTailingIcons Optional secondary text trailing icons(16X16). Supply text icons using [TextIcons]
+     * @param border [BorderType] Optional border for the list item.
+     * @param borderInset [BorderInset]Optional borderInset for list item.
+     * @param bottomView Optional bottom view under Text field. If used, trailing view will not be displayed
+     * @param leadingAccessoryView Optional composable leading accessory view.
+     * @param trailingAccessoryView Optional composable trailing accessory view.
+     * @param leadingAccessoryViewAlignment Alignment for leading accessory view to align Top, Bottom or Center
+     * @param trailingAccessoryViewAlignment Alignment for trailing accessory view to align Top, Bottom or Center
+     * @param textAccessibilityProperties Accessibility properties for the text in list item.
+     * @param listItemTokens Optional list item tokens for list item appearance.If not provided then list item tokens will be picked from [AppThemeController]
+     *
+     */
+    @Composable
+    fun Item(
+        text: String,
+        modifier: Modifier = Modifier,
+        subText: String? = null,
+        secondarySubText: String? = null,
+        textAlignment: ListItemTextAlignment = ListItemTextAlignment.Regular,
+        unreadDot: Boolean = false,
+        enabled: Boolean = true,
+        textMaxLines: Int = 1,
+        subTextMaxLines: Int = 1,
+        secondarySubTextMaxLines: Int = 1,
+        onClick: (() -> Unit)? = null,
+        primaryTextLeadingIcons: TextIcons? = null,
+        primaryTextTrailingIcons: TextIcons? = null,
+        secondarySubTextLeadingIcons: TextIcons? = null,
+        secondarySubTextTailingIcons: TextIcons? = null,
+        border: BorderType = NoBorder,
+        borderInset: BorderInset = None,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        bottomView: (@Composable () -> Unit)? = null,
+        leadingAccessoryView: (@Composable () -> Unit)? = null,
+        trailingAccessoryView: (@Composable () -> Unit)? = null,
+        leadingAccessoryViewAlignment: Alignment.Vertical = Alignment.CenterVertically,
+        trailingAccessoryViewAlignment: Alignment.Vertical = Alignment.CenterVertically,
+        textAccessibilityProperties: (SemanticsPropertyReceiver.() -> Unit)? = null,
+        listItemTokens: ListItemTokens? = null
+    ) {
+        InternalItem(
+            text = text,
+            modifier = modifier,
+            subText = subText,
+            secondarySubText = secondarySubText,
+            textAlignment = textAlignment,
+            unreadDot = unreadDot,
+            enabled = enabled,
+            textMaxLines = textMaxLines,
+            subTextMaxLines = subTextMaxLines,
+            secondarySubTextMaxLines = secondarySubTextMaxLines,
+            onClick = onClick,
+            primaryTextLeadingIcons = primaryTextLeadingIcons,
+            primaryTextTrailingIcons = primaryTextTrailingIcons,
+            secondarySubTextLeadingIcons = secondarySubTextLeadingIcons,
+            secondarySubTextTailingIcons = secondarySubTextTailingIcons,
+            border = border,
+            borderInset = borderInset,
+            interactionSource = interactionSource,
+            bottomView = bottomView,
+            leadingAccessoryView = leadingAccessoryView,
+            trailingAccessoryView = trailingAccessoryView,
+            leadingAccessoryViewAlignment = leadingAccessoryViewAlignment,
+            trailingAccessoryViewAlignment = trailingAccessoryViewAlignment,
+            textAccessibilityProperties = textAccessibilityProperties,
+            listItemTokens = listItemTokens
+        )
+    }
+
+    /**
+     * Create a Single line or a multi line List item. A multi line list can be formed by providing either a secondary text or a tertiary text. Use this if the secondarySubtext is an Annotated String
+     *
+     * @param text Primary text.
+     * @param modifier Optional modifier for List item.
+     * @param subText Optional secondaryText or a subtitle.
+     * @param secondarySubTextAnnotated Optional tertiary text (Annotated) or a footer.
+     * @param secondarySubTextInlineContent Map of composables to replace certain ranges of text in [secondarySubTextAnnotated].
+     * @param textAlignment Optional [ListItemTextAlignment] to align text in the center or start at the lead.
+     * @param unreadDot Option boolean value that display a dot on leading edge of the accessory view and makes the primary text bold on true
+     * @param enabled Optional enable/disable List item
+     * @param textMaxLines Optional max visible lines for primary text.
+     * @param subTextMaxLines Optional max visible lines for secondary text.
+     * @param secondarySubTextMaxLines Optional max visible lines for tertiary text.
+     * @param onClick Optional onClick action for list item.
+     * @param primaryTextLeadingIcons Optional primary text leading icons(20X20). Supply text icons using [TextIcons]
+     * @param primaryTextTrailingIcons Optional primary text trailing icons(20X20). Supply text icons using [TextIcons]
+     * @param secondarySubTextLeadingIcons Optional secondary text leading icons(16X16). Supply text icons using [TextIcons]
+     * @param secondarySubTextTailingIcons Optional secondary text trailing icons(16X16). Supply text icons using [TextIcons]
+     * @param border [BorderType] Optional border for the list item.
+     * @param borderInset [BorderInset]Optional borderInset for list item.
+     * @param bottomView Optional bottom view under Text field. If used, trailing view will not be displayed
+     * @param leadingAccessoryView Optional composable leading accessory view.
+     * @param trailingAccessoryView Optional composable trailing accessory view.
+     * @param leadingAccessoryViewAlignment Alignment for leading accessory view to align Top, Bottom or Center
+     * @param trailingAccessoryViewAlignment Alignment for trailing accessory view to align Top, Bottom or Center
+     * @param textAccessibilityProperties Accessibility properties for the text in list item.
+     * @param listItemTokens Optional list item tokens for list item appearance.If not provided then list item tokens will be picked from [AppThemeController]
+     *
+     */
+    @Composable
+    fun Item(
+        text: String,
+        modifier: Modifier = Modifier,
+        subText: String? = null,
+        secondarySubTextAnnotated: AnnotatedString? = null,
+        secondarySubTextInlineContent: Map<String, InlineTextContent> = mapOf(),
+        textAlignment: ListItemTextAlignment = ListItemTextAlignment.Regular,
+        unreadDot: Boolean = false,
+        enabled: Boolean = true,
+        textMaxLines: Int = 1,
+        subTextMaxLines: Int = 1,
+        secondarySubTextMaxLines: Int = 1,
+        onClick: (() -> Unit)? = null,
+        primaryTextLeadingIcons: TextIcons? = null,
+        primaryTextTrailingIcons: TextIcons? = null,
+        secondarySubTextLeadingIcons: TextIcons? = null,
+        secondarySubTextTailingIcons: TextIcons? = null,
+        border: BorderType = NoBorder,
+        borderInset: BorderInset = None,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        bottomView: (@Composable () -> Unit)? = null,
+        leadingAccessoryView: (@Composable () -> Unit)? = null,
+        trailingAccessoryView: (@Composable () -> Unit)? = null,
+        leadingAccessoryViewAlignment: Alignment.Vertical = Alignment.CenterVertically,
+        trailingAccessoryViewAlignment: Alignment.Vertical = Alignment.CenterVertically,
+        textAccessibilityProperties: (SemanticsPropertyReceiver.() -> Unit)? = null,
+        listItemTokens: ListItemTokens? = null
+    ) {
+        InternalItem(
+            text = text,
+            modifier = modifier,
+            subText = subText,
+            secondarySubTextAnnotated = secondarySubTextAnnotated,
+            secondarySubTextInlineContent = secondarySubTextInlineContent,
+            textAlignment = textAlignment,
+            unreadDot = unreadDot,
+            enabled = enabled,
+            textMaxLines = textMaxLines,
+            subTextMaxLines = subTextMaxLines,
+            secondarySubTextMaxLines = secondarySubTextMaxLines,
+            onClick = onClick,
+            primaryTextLeadingIcons = primaryTextLeadingIcons,
+            primaryTextTrailingIcons = primaryTextTrailingIcons,
+            secondarySubTextLeadingIcons = secondarySubTextLeadingIcons,
+            secondarySubTextTailingIcons = secondarySubTextTailingIcons,
+            border = border,
+            borderInset = borderInset,
+            interactionSource = interactionSource,
+            bottomView = bottomView,
+            leadingAccessoryView = leadingAccessoryView,
+            trailingAccessoryView = trailingAccessoryView,
+            leadingAccessoryViewAlignment = leadingAccessoryViewAlignment,
+            trailingAccessoryViewAlignment = trailingAccessoryViewAlignment,
+            textAccessibilityProperties = textAccessibilityProperties,
+            listItemTokens = listItemTokens
+        )
     }
 
     /**

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -211,6 +211,8 @@ object ListItem {
      * @param bottomView Optional bottom view under Text field. If used, trailing view will not be displayed
      * @param leadingAccessoryView Optional composable leading accessory view.
      * @param trailingAccessoryView Optional composable trailing accessory view.
+     * @param leadingAccessoryViewAlignment Alignment for leading accessory view to align Top, Bottom or Center
+     * @param trailingAccessoryViewAlignment Alignment for trailing accessory view to align Top, Bottom or Center
      * @param textAccessibilityProperties Accessibility properties for the text in list item.
      * @param listItemTokens Optional list item tokens for list item appearance.If not provided then list item tokens will be picked from [AppThemeController]
      *

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -195,6 +195,8 @@ object ListItem {
      * @param modifier Optional modifier for List item.
      * @param subText Optional secondaryText or a subtitle.
      * @param secondarySubText Optional tertiary text or a footer.
+     * @param secondarySubTextAnnotated Optional tertiary text (Annotated) or a footer. If [secondarySubText] is provided this will be ignored.
+     * @param secondarySubTextInlineContent Map of composables to replace certain ranges of text in [secondarySubTextAnnotated].
      * @param textAlignment Optional [ListItemTextAlignment] to align text in the center or start at the lead.
      * @param unreadDot Option boolean value that display a dot on leading edge of the accessory view and makes the primary text bold on true
      * @param enabled Optional enable/disable List item
@@ -223,6 +225,8 @@ object ListItem {
         modifier: Modifier = Modifier,
         subText: String? = null,
         secondarySubText: String? = null,
+        secondarySubTextAnnotated: AnnotatedString? = null,
+        secondarySubTextInlineContent: Map<String, InlineTextContent> = mapOf(),
         textAlignment: ListItemTextAlignment = ListItemTextAlignment.Regular,
         unreadDot: Boolean = false,
         enabled: Boolean = true,
@@ -294,12 +298,12 @@ object ListItem {
         val borderColor = token.borderColor(listItemInfo).getColorByState(
             enabled = enabled, selected = false, interactionSource = interactionSource
         )
-        val leadingAccessoryAlignment = when(leadingAccessoryViewAlignment){
+        val leadingAccessoryAlignment = when (leadingAccessoryViewAlignment) {
             Alignment.Top -> Alignment.TopCenter
             Alignment.Bottom -> Alignment.BottomCenter
             else -> Alignment.Center
         }
-        val trailingAccessoryAlignment = when(trailingAccessoryViewAlignment){
+        val trailingAccessoryAlignment = when (trailingAccessoryViewAlignment) {
             Alignment.Top -> Alignment.TopEnd
             Alignment.Bottom -> Alignment.BottomEnd
             else -> Alignment.CenterEnd
@@ -321,8 +325,8 @@ object ListItem {
                             start = if (unreadDot) 4.dp else padding.calculateStartPadding(
                                 LocalLayoutDirection.current
                             ),
-                            top = if(leadingAccessoryViewAlignment == Alignment.Top) padding.calculateTopPadding() else 0.dp,
-                            bottom = if(leadingAccessoryViewAlignment == Alignment.Bottom) padding.calculateBottomPadding() else 0.dp
+                            top = if (leadingAccessoryViewAlignment == Alignment.Top) padding.calculateTopPadding() else 0.dp,
+                            bottom = if (leadingAccessoryViewAlignment == Alignment.Bottom) padding.calculateBottomPadding() else 0.dp
                         )
                         .fillMaxHeight(), contentAlignment = leadingAccessoryAlignment
                 ) {
@@ -410,6 +414,13 @@ object ListItem {
                                         maxLines = secondarySubTextMaxLines,
                                         overflow = TextOverflow.Ellipsis
                                     )
+                                } else if (secondarySubTextAnnotated != null) {
+                                    BasicText(
+                                        text = secondarySubTextAnnotated,
+                                        inlineContent = secondarySubTextInlineContent,
+                                        maxLines = secondarySubTextMaxLines,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
                                 }
                                 if (secondarySubTextTailingIcons != null) {
                                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -424,9 +435,13 @@ object ListItem {
             }
             if (bottomView == null && trailingAccessoryView != null && textAlignment == ListItemTextAlignment.Regular) {
                 Box(
-                    Modifier.padding(top = if(trailingAccessoryViewAlignment == Alignment.Top) padding.calculateTopPadding() else 0.dp,
-                        bottom = if(trailingAccessoryViewAlignment == Alignment.Bottom) padding.calculateBottomPadding() else 0.dp,
-                        end = padding.calculateEndPadding(LocalLayoutDirection.current)).fillMaxHeight(),
+                    Modifier
+                        .padding(
+                            top = if (trailingAccessoryViewAlignment == Alignment.Top) padding.calculateTopPadding() else 0.dp,
+                            bottom = if (trailingAccessoryViewAlignment == Alignment.Bottom) padding.calculateBottomPadding() else 0.dp,
+                            end = padding.calculateEndPadding(LocalLayoutDirection.current)
+                        )
+                        .fillMaxHeight(),
                     contentAlignment = trailingAccessoryAlignment
                 ) {
                     trailingAccessoryView()


### PR DESCRIPTION
### Problem 
The trailing and leading accessory views alignment couldn't be handled in List item API.
### Root cause 
Alignment is passed as parameter and is fixed
### Fix
Provided "trailingAccessoryViewAlignment" and "leadingAccessoryViewAlignment" parameters to set the alignment for views

### Validations
Manual, Revied by peers

### Screenshots
![image](https://github.com/microsoft/fluentui-android/assets/5608292/a15364ef-dc46-4b5c-aab7-f548a9b58b50)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
