### PR TITLE
Accessibility Bug Fix for Snackbar

### DIFF
--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -15,7 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
@@ -136,6 +139,9 @@ fun Snackbar(
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .background(token.backgroundBrush(snackBarInfo))
+                .semantics {
+                    liveRegion = LiveRegionMode.Polite
+                }
                 .testTag(SNACKBAR),
             verticalAlignment = Alignment.CenterVertically
         ) {


### PR DESCRIPTION
### Problem 
When Snackbar is displayed in talkback mode, it wasn't being announced.

### Root cause 
Semantics wasn't properly configured.

### Fix
Set LiveRegion setting on semantics. This allows elements to be announced as they show up.

### Validations
Manual Validation with talkback.

### Screenshots
No Visual Changes

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
