### PR TITLE
accessibility bugs

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_bottom_sheet.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_bottom_sheet.xml
@@ -18,6 +18,7 @@
 
     <TextView
         style="@style/TextAppearance.FluentUI.Headline"
+        android:accessibilityHeading="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/demo_headline_padding_bottom"
@@ -56,6 +57,7 @@
 
     <TextView
         style="@style/TextAppearance.FluentUI.Headline"
+        android:accessibilityHeading="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/default_layout_margin"

--- a/FluentUI.Demo/src/main/res/layout/activity_persona_view.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_persona_view.xml
@@ -17,7 +17,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/default_layout_margin"
         android:layout_marginEnd="@dimen/default_layout_margin"
-        android:text="@string/persona_view_description_xxlarge" />
+        android:text="@string/persona_view_description_xxlarge"
+        android:contentDescription="Double Extra large Avatar with three lines of text"/>
 
     <com.microsoft.fluentui.persona.PersonaView
         android:id="@+id/persona_example_xxlarge"

--- a/fluentui_core/src/main/res/values/strings.xml
+++ b/fluentui_core/src/main/res/values/strings.xml
@@ -65,6 +65,10 @@
     <string name="fluentui_radio_button">Radio Button</string>
     <string name="fluentui_label">Label</string>
 
+    <!-- Describes the expand/collapsed state of control -->
+    <string name="fluentui_expanded">Expanded</string>
+    <string name="fluentui_collapsed">Collapsed</string>
+
     <!--types of control -->
     <string name="fluentui_large">Large</string>
     <string name="fluentui_medium">Medium</string>

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -699,8 +699,13 @@ object ListItem {
                 )
                 .semantics(mergeDescendants = true) {
                     contentDescription =
-                        "{$title}." + "${if (!enableContentOpenCloseTransition || expandedState) "Expanded" else "Collapsed"}"
-                    role = Role.Button
+                        "{$title}." + if (enableContentOpenCloseTransition) {
+                            if (expandedState) {
+                                "Expanded"
+                            } else {
+                                "Collapsed"
+                            }
+                        } else {""}
                 }
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
         ) {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -26,12 +26,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.*
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.*
+import com.microsoft.fluentui.listitem.R
 import com.microsoft.fluentui.icons.ListItemIcons
 import com.microsoft.fluentui.icons.listitemicons.Chevron
 import com.microsoft.fluentui.theme.FluentTheme
@@ -686,6 +688,8 @@ object ListItem {
         val rotationState by animateFloatAsState(
             targetValue = if (!enableContentOpenCloseTransition || expandedState) chevronOrientation.enterTransition else chevronOrientation.exitTransition
         )
+        val expandedString = LocalContext.current.resources.getString(R.string.fluentui_expanded)
+        val collapsedString = LocalContext.current.resources.getString(R.string.fluentui_collapsed)
         Box(
             modifier = modifier
                 .fillMaxWidth()
@@ -701,9 +705,9 @@ object ListItem {
                     contentDescription =
                         "{$title}." + if (enableContentOpenCloseTransition) {
                             if (expandedState) {
-                                "Expanded"
+                                expandedString
                             } else {
-                                "Collapsed"
+                                collapsedString
                             }
                         } else {""}
                 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -728,10 +728,9 @@ object ListItem {
                             if (enableChevron) {
                                 Icon(
                                     painter = rememberVectorPainter(image = ListItemIcons.Chevron),
-                                    contentDescription = "Chevron",
+                                    contentDescription = null,
                                     Modifier
-                                        .rotate(rotationState)
-                                        .clearAndSetSemantics { },
+                                        .rotate(rotationState),
                                     tint = chevronTint
                                 )
                             }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -77,12 +77,14 @@ object ListItem {
             BorderType.Top -> drawLine(
                 borderColor, Offset(0f, 0f), Offset(size.width, 0f), borderSize * density
             )
+
             BorderType.Bottom -> drawLine(
                 borderColor,
                 Offset(borderInset, size.height),
                 Offset(size.width, size.height),
                 borderSize * density
             )
+
             BorderType.TopBottom -> {
                 drawLine(
                     borderColor, Offset(0f, 0f), Offset(size.width, 0f), borderSize * density
@@ -94,6 +96,7 @@ object ListItem {
                     borderSize * density
                 )
             }
+
             NoBorder -> {
 
             }
@@ -187,6 +190,7 @@ object ListItem {
         }
 
     }
+
     @Composable
     internal fun InternalItem(
         text: String,
@@ -693,6 +697,11 @@ object ListItem {
                     enabled,
                     rippleColor
                 )
+                .semantics(mergeDescendants = true) {
+                    contentDescription =
+                        "{$title}." + "${if (!enableContentOpenCloseTransition || expandedState) "Expanded" else "Collapsed"}"
+                    role = Role.Button
+                }
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
         ) {
             Column {
@@ -717,14 +726,17 @@ object ListItem {
 
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             if (enableChevron) {
-                                Icon(painter = rememberVectorPainter(image = ListItemIcons.Chevron),
+                                Icon(
+                                    painter = rememberVectorPainter(image = ListItemIcons.Chevron),
                                     contentDescription = "Chevron",
                                     Modifier
-                                        .clickable { expandedState = !expandedState }
-                                        .rotate(rotationState),
-                                    tint = chevronTint)
+                                        .rotate(rotationState)
+                                        .clearAndSetSemantics { },
+                                    tint = chevronTint
+                                )
                             }
                             BasicText(
+                                modifier = Modifier.clearAndSetSemantics { },
                                 text = title,
                                 style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                                 maxLines = titleMaxLines,


### PR DESCRIPTION
### Problem 
Talkback issues in Multiple activities.
1. V1 Bottom Sheet heading talkback issue
2. V1 Persona View, XXLarge talkback
3. Talkback is not announcing the expanded/collapsed state for modified parameters.
### Root cause 
talkback semantics not set properly
### Fix
Talkback set to the heading
Talkback set to XXLarge as Double extra large
Modified API to set semantics based on the state of the header (Expanded, Collapsed)

### Validations
Manual testing, peer review
(how the change was tested, including both manual and automated tests)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
