### PR TITLE
Pass fractional swipe value to leftSwipeGesture and rightSwipeGesture lambda

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivityUITest.kt
@@ -1,7 +1,6 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.content.Intent
-import android.util.Log
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ActivityScenario

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivityUITest.kt
@@ -1,6 +1,7 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.content.Intent
+import android.util.Log
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ActivityScenario
@@ -154,14 +155,14 @@ class V2CardNudgeActivityUITest {
     fun testLeftSwipe() {
         composeTestRule.onNodeWithTag(CARDNUDGE).performTouchInput { swipeLeft() }
         composeTestRule.onNodeWithTag(CARDNUDGE).performClick()
-        composeTestRule.onNodeWithText("Left Swiped").assertExists()
+        composeTestRule.onNodeWithText("Left Swiped", substring = true).assertExists()
     }
 
     @Test
     fun testRightSwipe() {
         composeTestRule.onNodeWithTag(CARDNUDGE).performTouchInput { swipeRight() }
         composeTestRule.onNodeWithTag(CARDNUDGE).performClick()
-        composeTestRule.onNodeWithText("Right Swiped").assertExists()
+        composeTestRule.onNodeWithText("Right Swiped", substring = true).assertExists()
     }
 
     @After

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
@@ -3,10 +3,15 @@ package com.microsoft.fluentuidemo.demos
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.icons.Icons
@@ -18,10 +23,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentIcon
+import com.microsoft.fluentui.tokenized.controls.Label
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.listitem.ChevronOrientation
 import com.microsoft.fluentui.tokenized.listitem.ListItem
@@ -31,6 +42,7 @@ import com.microsoft.fluentui.tokenized.segmentedcontrols.PillMetaData
 import com.microsoft.fluentuidemo.DemoActivity
 import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.databinding.V2ActivityComposeBinding
+import kotlin.math.abs
 
 class V2CardNudgeActivity : DemoActivity() {
     override val contentNeedsScrollableContainer: Boolean
@@ -57,6 +69,7 @@ class V2CardNudgeActivity : DemoActivity() {
             FluentTheme {
                 var swipeLeft: Boolean by rememberSaveable { mutableStateOf(false) }
                 var swipeRight: Boolean by rememberSaveable { mutableStateOf(false) }
+                var swipeAmount: Float by rememberSaveable { mutableStateOf(0.0F) }
 
                 Column(
                     Modifier.fillMaxSize(),
@@ -234,50 +247,87 @@ class V2CardNudgeActivity : DemoActivity() {
                     val rightSwiped =
                         LocalContext.current.resources.getString(R.string.fluentui_right_swiped)
 
-                    Box(Modifier.fillMaxHeight(), contentAlignment = Alignment.Center) {
-                        CardNudge(
-                            metadata = CardNudgeMetaData(
-                                message = LocalContext.current.resources.getString(R.string.fluentui_title),
-                                icon = if (icon) FluentIcon(Icons.Outlined.Call) else null,
-                                subTitle = subtitle,
-                                accentText = accentText,
-                                accentIcon = if (accentImage) FluentIcon(Icons.Outlined.LocationOn) else null,
-                                actionMetaData = if (actionButton)
-                                    PillMetaData(
-                                        LocalContext.current.resources.getString(R.string.fluentui_action_button),
-                                        onClick = {
+                    Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
+                        Box(
+                            Modifier
+                                .wrapContentHeight()
+                                .fillMaxWidth()
+                                .background(
+                                    if (abs(swipeAmount) > 0.3)
+                                        FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.WarningBackground1].value()
+                                    else
+                                        Color.Unspecified
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            BasicText(
+                                "Hide",
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size160)),
+                                style = FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Body1Strong].merge(
+                                    TextStyle(
+                                        textAlign = if (swipeAmount > 0) TextAlign.Left else TextAlign.Right,
+                                        color = if (abs(swipeAmount) > 0.3)
+                                            FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.WarningForeground1].value()
+                                        else
+                                            Color.Black
+                                    )
+                                )
+                            )
+                            CardNudge(
+                                metadata = CardNudgeMetaData(
+                                    message = LocalContext.current.resources.getString(R.string.fluentui_title),
+                                    icon = if (icon) FluentIcon(Icons.Outlined.Call) else null,
+                                    subTitle = subtitle,
+                                    accentText = accentText,
+                                    accentIcon = if (accentImage) FluentIcon(Icons.Outlined.LocationOn) else null,
+                                    actionMetaData = if (actionButton)
+                                        PillMetaData(
+                                            LocalContext.current.resources.getString(R.string.fluentui_action_button),
+                                            onClick = {
+                                                Toast.makeText(
+                                                    context,
+                                                    buttonPressed,
+                                                    Toast.LENGTH_SHORT
+                                                ).show()
+                                            }
+                                        ) else null,
+                                    dismissOnClick = if (dismissEnabled) {
+                                        {
                                             Toast.makeText(
                                                 context,
-                                                buttonPressed,
+                                                dismissPressed,
                                                 Toast.LENGTH_SHORT
                                             ).show()
                                         }
-                                    ) else null,
-                                dismissOnClick = if (dismissEnabled) {
-                                    {
-                                        Toast.makeText(
-                                            context,
-                                            dismissPressed,
-                                            Toast.LENGTH_SHORT
-                                        ).show()
+                                    } else null,
+                                    leftSwipeGesture = {
+                                        swipeRight = false
+                                        swipeLeft = true
+                                        swipeAmount = it
+                                    },
+                                    rightSwipeGesture = {
+                                        swipeRight = true
+                                        swipeLeft = false
+                                        swipeAmount = it
                                     }
-                                } else null,
-                                leftSwipeGesture = {
-                                    swipeRight = false
-                                    swipeLeft = true
-                                },
-                                rightSwipeGesture = {
-                                    swipeRight = true
-                                    swipeLeft = false
-                                }
 
-                            ),
-                            outlineMode = outlineEnabled
-                        )
+                                ),
+                                outlineMode = outlineEnabled
+                            )
+
+                        }
                         if (swipeLeft)
-                            BasicText(leftSwiped)
+                            Label(
+                                leftSwiped + ": " + abs(swipeAmount).toString(),
+                                textStyle = FluentAliasTokens.TypographyTokens.Caption1Strong
+                            )
                         else if (swipeRight)
-                            BasicText(rightSwiped)
+                            Label(
+                                rightSwiped + ": " + abs(swipeAmount).toString(),
+                                textStyle = FluentAliasTokens.TypographyTokens.Caption1Strong
+                            )
                     }
                 }
             }

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -129,9 +129,9 @@ fun CardNudge(
             verticalAlignment = Alignment.CenterVertically
         ) {
             LaunchedEffect(state.offset.value) {
-                if (state.offset.value > 0F) {
+                if (state.offset.value > 0.1F) {
                     metadata.rightSwipeGesture?.invoke(state.offset.value / maxWidth)
-                } else if (state.offset.value < 0F) {
+                } else if (state.offset.value < -0.1F) {
                     metadata.leftSwipeGesture?.invoke(state.offset.value / maxWidth)
                 }
             }

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -55,8 +55,8 @@ class CardNudgeMetaData(
     val accentText: String? = null,
     val accentIcon: FluentIcon? = null,
     val actionMetaData: PillMetaData? = null,
-    val leftSwipeGesture: (() -> Unit)? = null,
-    val rightSwipeGesture: (() -> Unit)? = null
+    val leftSwipeGesture: ((Float) -> Unit)? = null,
+    val rightSwipeGesture: ((Float) -> Unit)? = null
 )
 
 private enum class SwipeGesture {
@@ -128,14 +128,17 @@ fun CardNudge(
                 .testTag(CARD_NUDGE),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            LaunchedEffect(state.currentValue) {
-                if (state.currentValue == SwipeGesture.RIGHT) {
-                    metadata.rightSwipeGesture?.invoke()
-                    state.animateTo(SwipeGesture.NONE)
-                } else if (state.currentValue == SwipeGesture.LEFT) {
-                    metadata.leftSwipeGesture?.invoke()
-                    state.animateTo(SwipeGesture.NONE)
+            LaunchedEffect(state.offset.value) {
+                if (state.offset.value > 0F) {
+                    metadata.rightSwipeGesture?.invoke(state.offset.value / maxWidth)
+                } else if (state.offset.value < 0F) {
+                    metadata.leftSwipeGesture?.invoke(state.offset.value / maxWidth)
                 }
+            }
+
+            LaunchedEffect(state.currentValue) {
+                if (state.currentValue != SwipeGesture.NONE)
+                    state.animateTo(SwipeGesture.NONE)
             }
 
             if (metadata.icon != null && metadata.icon.isIconAvailable()) {


### PR DESCRIPTION
### Problem 
Currently the leftSwipe and rightSwipe lamda functions were invoked on complete swipe to either end. This restricted developers to use it for intermediate states/offset.

### Root cause 
The current lambda functions didn't accept any parameter. 

### Fix
added a float parameter to the lambda functions depicting the fraction value for the swipe.

### Validations
Manual Checks done.
UI Tests Validated

### Screenshots
https://github.com/microsoft/fluentui-android/assets/12729351/391bc3cf-acce-4344-95a9-94bdfd318b9f


### Pull request checklist
This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
