### PR TITLE
disable formatting for menu_description string in demo app

### DIFF
--- a/FluentUI.Demo/src/main/res/values-af-rZA/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-af-rZA/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Herhaal inhoudteks</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Kieslys se wydte sal verander ten opsigte van inhoudteks. Die maksimum
+    <string name="menu_description" formatted="false">Kieslys se wydte sal verander ten opsigte van inhoudteks. Die maksimum
         wydte is beperk tot 75% skermgrootte. Die inhoudkantlyn van die kant en onderkant word deur die kenteken beheer. Dieselfde inhoudteks sal herhaal om die hoogte
         te wissel.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ar-rSA/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ar-rSA/strings.xml
@@ -764,7 +764,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">تكرار نص المحتوى</string>
     <!-- UI Label for description -->
-    <string name="menu_description">سيتغير عرض القائمة فيما يتعلق بنص المحتوى. يقتصر الحد الأقصى
+    <string name="menu_description" formatted="false">سيتغير عرض القائمة فيما يتعلق بنص المحتوى. يقتصر الحد الأقصى
         للعرض على 75% من حجم الشاشة. يتم التحكم في هامش المحتوى من جانب وأسفل برمز مميز. سيتكرر نص المحتوى نفسه لتغيير
         الارتفاع.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-b+az+Latn+AZ/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-b+az+Latn+AZ/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Məzmun Mətnini Təkrar Edin</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menyu eni Məzmun Mətni ilə bağlı dəyişəcək. Maksimum
+    <string name="menu_description" formatted="false">Menyu eni Məzmun Mətni ilə bağlı dəyişəcək. Maksimum
         en ekran ölçüsünün 75%-i ilə məhdudlaşdırılır. Yandan və aşağıdan məzmunun kənar boşluğu nişan ilə idarə olunur. Eyni məzmun mətni hündürlüyü dəyişdirmək üçün
         təkrarlanacaq.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-b+bs+Latn+BA/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-b+bs+Latn+BA/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ponovi tekst sadržaja</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Širina menija će se promijeniti u odnosu na tekst sadržaja. Maksimalna
+    <string name="menu_description" formatted="false">Širina menija će se promijeniti u odnosu na tekst sadržaja. Maksimalna
         širina je ograničena na 75% veličine ekrana. Marginom sadržaja s bočne i donje strane upravlja token. Isti tekst sadržaja će se ponoviti da bi se promijenila
         visina.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-b+sr+Cyrl+RS/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-b+sr+Cyrl+RS/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Понови текст садржаја</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Ширина менија ће се променити у односу на текст садржаја. Максимална
+    <string name="menu_description" formatted="false">Ширина менија ће се променити у односу на текст садржаја. Максимална
         ширина је ограничена 75% величине екрана. Маргином садржаја са стране и на дну управља токен. Исти текст садржаја ће се поновити да би се променила
         висина.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-b+sr+Latn+RS/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-b+sr+Latn+RS/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ponovi tekst sadržaja</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Širina menija će se promeniti u odnosu na tekst sadržaja. Maksimalna
+    <string name="menu_description" formatted="false">Širina menija će se promeniti u odnosu na tekst sadržaja. Maksimalna
         širina je ograničena na 75% veličine ekrana. Marginom sadržaja sa strane i na dnu upravlja token. Isti tekst sadržaja će se ponoviti da bi se promenila
         visina.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-b+uz+Latn+UZ/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-b+uz+Latn+UZ/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Kontent matnni takrorlash</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menyu kengligi kontent matniga nisbatan oʻzgaradi. Maksimal
+    <string name="menu_description" formatted="false">Menyu kengligi kontent matniga nisbatan oʻzgaradi. Maksimal
         kenglik ekran oʻlchamining 75% bilan cheklangan. Yon va pastdan kontent chegarasi token bilan boshqariladi. Xuddi shu kontent matni balandlikni oʻzgartirish uchun
         takrorlanadi.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-bg-rBG/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-bg-rBG/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Повтаряне на текста на съдържанието</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Ширината на менюто ще се промени по отношение на текста на съдържанието. Максимумът
+    <string name="menu_description" formatted="false">Ширината на менюто ще се промени по отношение на текста на съдържанието. Максимумът
         ширината е ограничена до 75% на размера на екрана. Полето на съдържанието отстрани и отдолу се управлява от маркер. Един и същ текст на съдържание ще се повтаря, за да варира
         височината.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ca-rES/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ca-rES/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repeteix el text del contingut</string>
     <!-- UI Label for description -->
-    <string name="menu_description">L\'amplària del menú canviarà respecte al text de contingut. L’amplària
+    <string name="menu_description" formatted="false">L\'amplària del menú canviarà respecte al text de contingut. L’amplària
         màxima està restringida al 75% de la mida de la pantalla. El marge de contingut del costat i de la part inferior està governant pel testimoni. El mateix text de contingut es repetirà per variar
         l\'alçària.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-cs-rCZ/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-cs-rCZ/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Opakovat text obsahu</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Šířka nabídky se změní s ohledem na text obsahu. Maximální
+    <string name="menu_description" formatted="false">Šířka nabídky se změní s ohledem na text obsahu. Maximální
         šířka je omezená na 75 % velikosti obrazovky. Okraj obsahu ze strany a zespoda se řídí tokenem. Stejný text obsahu se bude opakovat, aby se měnila
         výška.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-cy-rGB/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-cy-rGB/strings.xml
@@ -764,7 +764,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ailadrodd Testun y Cynnwys</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Bydd lled y ddewislen yn newid o ran Testun y Cynnwys. Y terfyn uchaf
+    <string name="menu_description" formatted="false">Bydd lled y ddewislen yn newid o ran Testun y Cynnwys. Y terfyn uchaf
         mae\'r lled wedi\'i gyfyngu iddo yw 75% maint y sgrin. Mae ymyl y cynnwys o\'r ochr a\'r gwaelod yn cael ei lywodraethu gan docyn. Bydd yr un testun cynnwys yn ailadrodd er mwyn amrywio
         yr uchder.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-da-rDK/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-da-rDK/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Gentag indholdstekst</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menubredden ændres i forhold til indholdstekst. Maks
+    <string name="menu_description" formatted="false">Menubredden ændres i forhold til indholdstekst. Maks
         bredden er begrænset til 75 % af skærmstørrelsen. Indholdsmargenen fra side og bund styres efter token. Den samme indholdstekst gentages for at variere
         højden.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-de-rDE/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-de-rDE/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Inhaltstext wiederholen</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Die Menübreite ändert sich in Bezug auf den Inhaltstext. Der Höchstwert
+    <string name="menu_description" formatted="false">Die Menübreite ändert sich in Bezug auf den Inhaltstext. Der Höchstwert
         Die Breite ist auf 75% der Bildschirmgröße beschränkt. Der Inhaltsrand von der Seite und unten wird durch das Token gesteuert. Der gleiche Inhaltstext wird wiederholt, um zu variieren.
         die Höhe.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-el-rGR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-el-rGR/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Επανάληψη κειμένου περιεχομένου</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Το πλάτος του μενού θα αλλάξει σε σχέση με το κείμενο περιεχομένου. Το μέγιστο
+    <string name="menu_description" formatted="false">Το πλάτος του μενού θα αλλάξει σε σχέση με το κείμενο περιεχομένου. Το μέγιστο
         πλάτος περιορίζεται στο 75% του μεγέθους της οθόνης. Το περιθώριο περιεχομένου από τα πλευρικά σημεία και το κάτω μέρος διέπεται από διακριτικό. Το ίδιο κείμενο περιεχομένου θα επαναλαμβάνεται για να διαφέρει
         το ύψος.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-en-rGB/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-en-rGB/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repeat Content Text</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menu width will change with respect to Content Text. The max
+    <string name="menu_description" formatted="false">Menu width will change with respect to Content Text. The max
         width is restricted to 75% of screen size. The content margin from side and bottom is govern by token. The same content text will repeat to vary
         the height.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-es-rES/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-es-rES/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repetir texto de contenido</string>
     <!-- UI Label for description -->
-    <string name="menu_description">El ancho del menú cambiará con respecto al texto del contenido. El máximo
+    <string name="menu_description" formatted="false">El ancho del menú cambiará con respecto al texto del contenido. El máximo
         el ancho está restringido a 75% de tamaño de pantalla. El margen de contenido del lado e inferior se rige por token. El mismo texto de contenido se repetirá para variar
         el alto.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-es-rMX/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-es-rMX/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repetir texto de contenido</string>
     <!-- UI Label for description -->
-    <string name="menu_description">El ancho del menú cambiará con respecto al texto del contenido. El máximo
+    <string name="menu_description" formatted="false">El ancho del menú cambiará con respecto al texto del contenido. El máximo
         el ancho está restringido a 75% de tamaño de pantalla. El margen de contenido del lado e inferior se rige por token. El mismo texto de contenido se repetirá para variar
         el alto.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-et-rEE/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-et-rEE/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Korda sisuteksti</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menüü laius muutub vastavalt sisutekstile. Maksimaalne
+    <string name="menu_description" formatted="false">Menüü laius muutub vastavalt sisutekstile. Maksimaalne
         laius on piiratud 75% ekraani suurusest. Sisuveerist küljelt ja alt reguleerib tõend. Kõrguse muutmiseks sama sisutekst
         kordub.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-eu-rES/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-eu-rES/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Errepikatu edukiaren testua</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menuaren zabalera aldatu egingo da Edukiaren testuari dagokionez. Gehienezko
+    <string name="menu_description" formatted="false">Menuaren zabalera aldatu egingo da Edukiaren testuari dagokionez. Gehienezko
          zabalera pantailaren tamainaren % 75era mugatzen da. Alboko eta beheko edukiaren marjina token bidez gobernatzen da. Edukiaren testu bera errepikatuko da altuera
          aldatzeko.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-fa-rIR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-fa-rIR/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">تکرار متن محتوا</string>
     <!-- UI Label for description -->
-    <string name="menu_description">عرض منو نسبت به «متن محتوا» تغییر می‌کند. حداکثر
+    <string name="menu_description" formatted="false">عرض منو نسبت به «متن محتوا» تغییر می‌کند. حداکثر
         عرض برای اندازه ۷۵٪ صفحه محدود شده است. حاشیه محتوا از کناره و پایین بر اساس نشانه اعمال می‌شود.همان متن محتوا برای تغییر
 ارتفاع تکرار می‌شود.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-fi-rFI/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-fi-rFI/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Toista sisältöteksti</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Valikon leveys muuttuu sisältötekstin suhteen. Enimmäisarvo
+    <string name="menu_description" formatted="false">Valikon leveys muuttuu sisältötekstin suhteen. Enimmäisarvo
         leveydelle on rajoitettu 75 prosenttiin näytön koosta. Sisällön reunusta sivulta ja alhaalta hallitaan tunnuksen avulla. Sama sisältöteksti toistuu ja vaihtelee
         korkeutta.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-fil-rPH/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-fil-rPH/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ulitin ang Teksto ng Nilalaman</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Ang lapad ng menu ay magbabago nang may paggalang sa Teksto ng Content. Ang max na
+    <string name="menu_description" formatted="false">Ang lapad ng menu ay magbabago nang may paggalang sa Teksto ng Content. Ang max na
         lapad ay limitado sa 75% ng laki ng screen. Ang margin ng content mula sa gilid at ibaba ay pinamamahalaan ng token. Ang parehong teksto ng nilalaman ay uulitin para mag-iba ng
         taas.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-fr-rCA/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-fr-rCA/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Répéter le texte du contenu</string>
     <!-- UI Label for description -->
-    <string name="menu_description">La largeur du menu sera modifiée en fonction du texte du contenu. La largeur maximale
+    <string name="menu_description" formatted="false">La largeur du menu sera modifiée en fonction du texte du contenu. La largeur maximale
         est limitée à 75 % de la taille de l’écran. La marge latérale et inférieure du contenu est régie par un jeton. Le même texte de contenu se répétera pour faire varier
         la hauteur.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-fr-rFR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-fr-rFR/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Répéter le texte du contenu</string>
     <!-- UI Label for description -->
-    <string name="menu_description">La largeur du menu sera modifiée en fonction du texte du contenu. La largeur maximale
+    <string name="menu_description" formatted="false">La largeur du menu sera modifiée en fonction du texte du contenu. La largeur maximale
         est limitée à 75 % de la taille de l’écran. La marge latérale et inférieure du contenu est régie par un jeton. Le même texte de contenu se répétera pour faire varier
         la hauteur.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-gl-rES/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-gl-rES/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repetir texto de contido</string>
     <!-- UI Label for description -->
-    <string name="menu_description">O ancho do menú cambiará con respecto ao texto do contido. O máx.
+    <string name="menu_description" formatted="false">O ancho do menú cambiará con respecto ao texto do contido. O máx.
          ancho está restrinxido ao 75 % do tamaño da pantalla. A marxe de contido desde o lado e abaixo rexerase por token. O mesmo texto de contido repetirase para variar
          a altura.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-gu-rIN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-gu-rIN/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">સામગ્રી ટેક્સ્ટ પુનરાવર્તિત કરો</string>
     <!-- UI Label for description -->
-    <string name="menu_description">સામગ્રી ટેક્સ્ટના સંબંધમાં મેનૂની પહોળાઈ બદલાશે. મહત્તમ પહોળાઈને
+    <string name="menu_description" formatted="false">સામગ્રી ટેક્સ્ટના સંબંધમાં મેનૂની પહોળાઈ બદલાશે. મહત્તમ પહોળાઈને
         સ્ક્રીનની સાઇઝના 75% પર પ્રતિબંધિત કરવામાં આવી છે. સાઇડ અને નીચેથી સામગ્રી હાંસિયો ટોકન દ્વારા સંચાલિત થાય છે. ઊંચાઈ અલગ કરવા માટે સમાન સામગ્રી ટેક્સ્ટ પુનરાવર્તિત
         થશે.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-he-rIL/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-he-rIL/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">טקסט תוכן חוזר</string>
     <!-- UI Label for description -->
-    <string name="menu_description">רוחב התפריט ישתנה בהתאם לטקסט התוכן. הרוחב המרבי
+    <string name="menu_description" formatted="false">רוחב התפריט ישתנה בהתאם לטקסט התוכן. הרוחב המרבי
         מוגבל ל- 75% מגודל המסך. שולי התוכן מהצדדים ומלמטה נקבעים על-ידי אסימון. תהיה חזרה על אותו טקסט תוכן כדי לשנות את
         הגובה.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-hi-rIN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-hi-rIN/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">कंटेंट टेक्स्ट दोहराएँ</string>
     <!-- UI Label for description -->
-    <string name="menu_description">सामग्री पाठ के संदर्भ में मेनू की चौड़ाई परिवर्तित हो जाएगी. अधिकतम
+    <string name="menu_description" formatted="false">सामग्री पाठ के संदर्भ में मेनू की चौड़ाई परिवर्तित हो जाएगी. अधिकतम
         स्क्रीन आकार के 75% तक चौड़ाई प्रतिबंधित है. पार्श्व और नीचे की सामग्री मार्जिन टोकन द्वारा नियंत्रित होती है. समान सामग्री पाठ भिन्न होने के लिए दोहराया जाएगा
         ऊँचाई.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-hr-rHR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-hr-rHR/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ponovi tekst sadržaja</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Širina izbornika promijenit će se u odnosu na tekst sadržaja. Maksimalna
+    <string name="menu_description" formatted="false">Širina izbornika promijenit će se u odnosu na tekst sadržaja. Maksimalna
         širina ograničena je na 75 % veličine zaslona. Margina sadržaja s bočne i donje strane regulirana je tokenom. Isti tekst sadržaja ponavljat će se kako bi se mijenjala
         visina.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-hu-rHU/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-hu-rHU/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Tartalomszöveg ismétlése</string>
     <!-- UI Label for description -->
-    <string name="menu_description">A menü szélessége a tartalom szövegéhez képest változik. A maximális
+    <string name="menu_description" formatted="false">A menü szélessége a tartalom szövegéhez képest változik. A maximális
         szélesség a képernyőméret 75%-ára van korlátozva. Az oldalról és az alulról mért tartalommargót token szabályozza. Ugyanaz a tartalomszöveg ismétlődik, hogy változzon
         a magasság.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-id-rID/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-id-rID/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ulangi Teks Konten</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Lebar menu akan berubah sehubungan dengan Teks Konten. Maks
+    <string name="menu_description" formatted="false">Lebar menu akan berubah sehubungan dengan Teks Konten. Maks
         lebar dibatasi di 75% ukuran layar. Margin konten dari sisi dan bawah diatur berdasarkan token. Teks konten yang sama akan diulangi untuk memvariasikan
         tingginya.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-is-rIS/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-is-rIS/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Endurtaka efnistexta</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Breidd valmyndar mun breytast í samræmi við efnistexta. Hámarkið
+    <string name="menu_description" formatted="false">Breidd valmyndar mun breytast í samræmi við efnistexta. Hámarkið
         breidd er takmörkuð við 75% skjástærð. Efnisspássía frá hlið og neðst stjórnast með lykla. Sami efnistexti verður endurtekinn í breytilegan
         hæðina.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-it-rIT/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-it-rIT/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ripeti testo contenuto</string>
     <!-- UI Label for description -->
-    <string name="menu_description">La larghezza del menu cambierà rispetto al testo del contenuto. Valore massimo
+    <string name="menu_description" formatted="false">La larghezza del menu cambierà rispetto al testo del contenuto. Valore massimo
         la larghezza è limitata a 75% delle dimensioni dello schermo. Il margine del contenuto dal lato e dal basso è regolato dal token. Lo stesso testo del contenuto si ripeterà per variare
         l\'altezza.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ja-rJP/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ja-rJP/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">コンテンツ テキストの繰り返し</string>
     <!-- UI Label for description -->
-    <string name="menu_description">メニューの幅はコンテンツ テキストに対して変更されます。最大値
+    <string name="menu_description" formatted="false">メニューの幅はコンテンツ テキストに対して変更されます。最大値
         幅は画面サイズの75%に制限されています。コンテンツの左右の余白はトークンによって管理されます。同じコンテンツ テキストが繰り返し異なります
         高さ。</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ka-rGE/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ka-rGE/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">შიგთავსის ტექსტის გამეორება</string>
     <!-- UI Label for description -->
-    <string name="menu_description">მენიუს სიგანე შეიცვლება შიგთავსის ტექსტთან მიმართებაში. მაქსიმალური
+    <string name="menu_description" formatted="false">მენიუს სიგანე შეიცვლება შიგთავსის ტექსტთან მიმართებაში. მაქსიმალური
         სიგანე შეზღუდულია ეკრანის ზომის 75%-მდე. შიგთავსის მინდორი გვერდიდან და ქვემოდან რეგულირდება ჟეტონით. იგივე შიგთავსის ტექსტი განმეორდება
         სიმაღლის შესაცვლელად.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-kk-rKZ/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-kk-rKZ/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Мазмұн мәтінін қайталау</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Мәзір ені мазмұн мәтініне қарай өзгереді. Максималды ені экран
+    <string name="menu_description" formatted="false">Мәзір ені мазмұн мәтініне қарай өзгереді. Максималды ені экран
         өлшемінің 75%-ымен шектелген. Шеттен және төменгі жағынан мазмұн шетін таңбалауыш басқарады. Биіктікті өзгертіп тұру үшін бірдей мазмұн
         мәтіні қайталанады.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-km-rKH/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-km-rKH/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">បង្ហាញអត្ថបទបង្ហាញឡើងវិញ</string>
     <!-- UI Label for description -->
-    <string name="menu_description">ទទឹងម៉ឺនុយនឹងផ្លាស់ប្ដូរស្របតាមអត្ថបទខ្លឹមសារ។ ទំហំ
+    <string name="menu_description" formatted="false">ទទឹងម៉ឺនុយនឹងផ្លាស់ប្ដូរស្របតាមអត្ថបទខ្លឹមសារ។ ទំហំ
         ទទឹងអតិបរមាត្រូវបានដាក់កំហិតនៅ 75% នៃទំហំអេក្រង់។ គែមខ្លឹមសារពីចំហៀង និងខាងក្រោមត្រូវបានគ្រប់គ្រងដោយកាក់។ អត្ថបទខ្លឹមសារដូចគ្នានឹងបង្ហាញឡើងវិញ ដើម្បីធ្វើឱ្យ
         កម្ពស់ខុសគ្នា។</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-kn-rIN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-kn-rIN/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">ವಿಷಯ ಪಠ್ಯವನ್ನು ಪುನರಾವರ್ತಿಸಿ</string>
     <!-- UI Label for description -->
-    <string name="menu_description">ಮೆನು ಅಗಲವು ವಿಷಯ ಪಠ್ಯಕ್ಕೆ ಸಂಬಂಧಿಸಿದಂತೆ ಬದಲಾಗುತ್ತದೆ.
+    <string name="menu_description" formatted="false">ಮೆನು ಅಗಲವು ವಿಷಯ ಪಠ್ಯಕ್ಕೆ ಸಂಬಂಧಿಸಿದಂತೆ ಬದಲಾಗುತ್ತದೆ.
 ಗರಿಷ್ಠ
          ಗಾತ್ರವನ್ನು ಪರದೆ ಗಾತ್ರದ 75% ಗೆ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ. ಟೋಕನ್ ಮೂಲಕ ಬದಿಯಿಂದ ಮತ್ತು ಕೆಳಗಿನಿಂದ ವಿಷಯ ಅಂಚು ನಿಯಂತ್ರಿಸಲಾಗುತ್ತದೆ. ಎತ್ತರವನ್ನು ಬದಲಿಸಲು ಒಂದೇ ವಿಷಯ ಪಠ್ಯವು ಪುನರಾವರ್ತಿಸುತ್ತದೆ.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ko-rKR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ko-rKR/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">콘텐츠 텍스트 반복</string>
     <!-- UI Label for description -->
-    <string name="menu_description">콘텐츠 텍스트에 따라 메뉴 너비가 변경됩니다. 최대값
+    <string name="menu_description" formatted="false">콘텐츠 텍스트에 따라 메뉴 너비가 변경됩니다. 최대값
         너비는 화면 크기의 75% 제한됩니다. 측면과 아래쪽의 콘텐츠 여백은 토큰에 의해 제어됩니다. 동일한 콘텐츠 텍스트가 다르게 반복됩니다.
         높이를 지정합니다.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-lo-rLA/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-lo-rLA/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">ເຮັດຊ້ຳຂໍ້ຄວາມເນື້ອຫາ</string>
     <!-- UI Label for description -->
-    <string name="menu_description">ຄວາມກວ້າງຂອງເມນູຈະມີການປ່ຽນແປງກ່ຽວກັບຂໍ້ຄວາມເນື້ອຫາ. ຄວາມກວ້າງ
+    <string name="menu_description" formatted="false">ຄວາມກວ້າງຂອງເມນູຈະມີການປ່ຽນແປງກ່ຽວກັບຂໍ້ຄວາມເນື້ອຫາ. ຄວາມກວ້າງ
         ສູງສຸດຖືກຈຳກັດໄວ້ທີ່ 75% ຂອງຂະໜາດໜ້າຈໍ. ຂອບເນື້ອໃນຈາກດ້ານຂ້າງ ແລະ ດ້ານລຸ່ມແມ່ນຄວບຄຸມໂດຍໂທເຄັນ. ຂໍ້ຄວາມເນື້ອຫາດຽວກັນຈະຊໍ້າຄືນເພື່ອ
         ຄວາມສູງແຕກຕ່າງກັນ.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-lt-rLT/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-lt-rLT/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Kartoti turinio tekstą</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Meniu plotis keisis turinio teksto atžvilgiu. Maks.
+    <string name="menu_description" formatted="false">Meniu plotis keisis turinio teksto atžvilgiu. Maks.
         plotis apribotas iki 75 % ekrano dydžio. Turinio paraštė iš šono ir apačios valdoma atpažinimo ženklu. Tas pats turinio tekstas bus kartojamas, kad keistųsi
         aukštis.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-lv-rLV/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-lv-rLV/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Atkārtot satura tekstu</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Izvēlnes platums tiks mainīts attiecībā pret satura tekstu. Maksimālais platums
+    <string name="menu_description" formatted="false">Izvēlnes platums tiks mainīts attiecībā pret satura tekstu. Maksimālais platums
         ir ierobežots līdz 75% no ekrāna lieluma. Satura piemali no sāniem un apakšas nosaka marķieris. Tas pats satura teksts tiks atkārtots, lai mainītos
         augstums.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-mk-rMK/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-mk-rMK/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Повтори го текстот на содржината</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Ширината на менито ќе се измени во однос на текстот на содржината. Максималната
+    <string name="menu_description" formatted="false">Ширината на менито ќе се измени во однос на текстот на содржината. Максималната
         ширината е ограничена на 75% со големина на екранот. Маргината на содржината од страна и од дното се управува со токен. Истиот текст на содржината ќе се повторува за да варира
         висината.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-mr-rIN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-mr-rIN/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">सामुग्री मजकूराची पुनरावृत्ती करा</string>
     <!-- UI Label for description -->
-    <string name="menu_description">सामुग्री मजकूराच्या संदर्भात मेनूची रूंदी बदलेल. स्क्रीन आकाराच्या 75% कमाल
+    <string name="menu_description" formatted="false">सामुग्री मजकूराच्या संदर्भात मेनूची रूंदी बदलेल. स्क्रीन आकाराच्या 75% कमाल
         रूंदी प्रतिबंधित आहे. बाजूकडून आणि तळाकडील सामुग्री समास टोकननुसार नियंत्रित केले जाते. उंची बदलण्यासाठी समान सामुग्री मजकूराची पुनरावृत्ती
         होईल.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ms-rMY/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ms-rMY/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ulangi Teks Kandungan</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Lebar menu akan berubah berhubung dengan Teks Kandungan. Maks
+    <string name="menu_description" formatted="false">Lebar menu akan berubah berhubung dengan Teks Kandungan. Maks
         lebar dihadkan kepada 75% daripada saiz skrin. Jidar kandungan dari sisi dan bawah dikawal oleh token. Teks kandungan yang sama akan berulang untuk berbeza-beza
         ketinggian.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-nb-rNO/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-nb-rNO/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Gjenta innholdstekst</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menybredden endres når det gjelder innholdstekst. Maksimal
+    <string name="menu_description" formatted="false">Menybredden endres når det gjelder innholdstekst. Maksimal
         bredde er begrenset til 75 % av skjermstørrelsen. Innholdsmargen fra side og bunn styres av token. Den samme innholdsteksten gjentas for å variere
         høyden.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-nl-rNL/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-nl-rNL/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Tekst van inhoud herhalen</string>
     <!-- UI Label for description -->
-    <string name="menu_description">De menubreedte wordt gewijzigd met betrekking tot inhoudstekst. De maximale
+    <string name="menu_description" formatted="false">De menubreedte wordt gewijzigd met betrekking tot inhoudstekst. De maximale
         breedte is beperkt tot 75% van de schermgrootte. De inhoudsmarge van de zijkant en onderkant wordt bepaald door het token. Dezelfde inhoudstekst wordt herhaald om de hoogte te variëren
         .</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-nn-rNO/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-nn-rNO/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Gjenta innhaldstekst</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menybreidda forandrar seg i samsvar med innhaldsteksten. Maksimal
+    <string name="menu_description" formatted="false">Menybreidda forandrar seg i samsvar med innhaldsteksten. Maksimal
         breidde er avgrensa til 75 % av skjermstorleiken. Innhaldsmarginane frå sida og botnen er styrte av token. Den same innhaldsteksten blir gjentatt for å variere
         høgda.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-pl-rPL/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-pl-rPL/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Powtórz tekst zawartości</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Szerokość menu zostanie zmieniona w odniesieniu do tekstu zawartości. Wartość maksymalna
+    <string name="menu_description" formatted="false">Szerokość menu zostanie zmieniona w odniesieniu do tekstu zawartości. Wartość maksymalna
         szerokości jest ograniczona do 75% rozmiaru ekranu. Margines zawartości z boku i u dołu jest regulowany przez token. Ten sam tekst zawartości będzie powtarzany w celu zmiany
         wysokości.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-pt-rBR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-pt-rBR/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repetir Texto do Conteúdo</string>
     <!-- UI Label for description -->
-    <string name="menu_description">A largura do menu será alterada em relação ao Texto do Conteúdo. A largura
+    <string name="menu_description" formatted="false">A largura do menu será alterada em relação ao Texto do Conteúdo. A largura
         máxima é restrita a 75% do tamanho da tela. A margem de conteúdo do lado e da parte inferior é governada por token. O mesmo texto de conteúdo será repetido para variar
         a altura.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-pt-rPT/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-pt-rPT/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repetir Texto de Conteúdo</string>
     <!-- UI Label for description -->
-    <string name="menu_description">A largura do menu será alterada em função do Texto do Conteúdo. A largura
+    <string name="menu_description" formatted="false">A largura do menu será alterada em função do Texto do Conteúdo. A largura
         máxima está restrita a 75% do tamanho do ecrã. A margem de conteúdo dos lados e da parte inferior é regida por token. O mesmo texto de conteúdo será repetido para variar
         a altura.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ro-rRO/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ro-rRO/strings.xml
@@ -761,7 +761,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repetarea textului de conținut</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Lățimea meniului se va modifica în ceea ce privește textul de conținut. Maximul
+    <string name="menu_description" formatted="false">Lățimea meniului se va modifica în ceea ce privește textul de conținut. Maximul
         lățimea este restricționată la 75% dimensiunii ecranului. Marginea de conținut din partea laterală și de jos este guvernată de token. Același text de conținut se va repeta pentru a varia
         înălțimea.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ru-rRU/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ru-rRU/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Повторить текст содержимого</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Ширина меню изменится по отношению к тексту содержимого. Максимальная ширина
+    <string name="menu_description" formatted="false">Ширина меню изменится по отношению к тексту содержимого. Максимальная ширина
         ограничена 75 % от размера экрана. Поля содержимого сбоку и снизу регулируются токеном. Текст содержимого будет повторяться для изменения
         высоты.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-sk-rSK/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-sk-rSK/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Opakovať text obsahu</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Šírka ponuky sa zmení vzhľadom na text obsahu. Maximálna
+    <string name="menu_description" formatted="false">Šírka ponuky sa zmení vzhľadom na text obsahu. Maximálna
         šírka je obmedzená na 75 % veľkosti obrazovky. Okraj obsahu zo strany a zdola sa riadi tokenom. Rovnaký text obsahu sa bude opakovať, aby sa menila
         výška.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-sl-rSI/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-sl-rSI/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Ponovi besedilo vsebine</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Širina menija se bo spremenila glede na besedilo vsebine. Največja vrednost
+    <string name="menu_description" formatted="false">Širina menija se bo spremenila glede na besedilo vsebine. Največja vrednost
         širina je omejena na 75% velikosti zaslona. Rob vsebine od strani in spodaj ureja žeton. Ista vsebina besedila se bo ponavljala s spreminjanjem
         višino.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-sq-rAL/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-sq-rAL/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Përsëritja e tekstit të përmbajtjes</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Gjerësia e menysë do të ndryshojë sipas tekstit të përmbajtjes. Gjerësia maksimale
+    <string name="menu_description" formatted="false">Gjerësia e menysë do të ndryshojë sipas tekstit të përmbajtjes. Gjerësia maksimale
         kufizohet në 75% të madhësisë së ekranit. Kufizat anësore dhe e poshtme e përmbajtjes udhëhiqet nga shenja. I njëjti tekst përmbajtjeje do të përsëritet për të ndryshuar
         lartësinë.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-sv-rSE/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-sv-rSE/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Upprepa innehållstext</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menybredden ändras vad gäller innehållstext. 
+    <string name="menu_description" formatted="false">Menybredden ändras vad gäller innehållstext.
         Maxbredden är begränsad till 75 % av skärmstorleken. Innehållsmarginalen från sidan och nederkanten styrs av token. Samma innehållstext upprepas för att variera
         höjden.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-ta-rIN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-ta-rIN/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">உள்ளடக்க உரையை மீண்டும் செய்யவும்</string>
     <!-- UI Label for description -->
-    <string name="menu_description">உள்ளடக்க உரையைப் பொறுத்தவரை மெனு அகலம் மாறும். அதிகபட்சம்
+    <string name="menu_description" formatted="false">உள்ளடக்க உரையைப் பொறுத்தவரை மெனு அகலம் மாறும். அதிகபட்சம்
         அகலம் திரை அளவு 75% வரையறுக்கப்பட்டுள்ளது. பக்கத்திலிருந்தும் கீழேயும் உள்ள உள்ளடக்க விளிம்பு டோக்கனால் நிர்வகிக்கப்படுகிறது. அதே உள்ளடக்க உரை மீண்டும் மாறுபடும்
         உயரம்.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-te-rIN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-te-rIN/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">కంటెంట్ టెక్స్ట్‌ని రిపీట్ చేయండి</string>
     <!-- UI Label for description -->
-    <string name="menu_description">వచనం టెక్స్ట్‌కి సంబంధించి మెను వెడల్పు మారుతుంది.
+    <string name="menu_description" formatted="false">వచనం టెక్స్ట్‌కి సంబంధించి మెను వెడల్పు మారుతుంది.
         గరిష్ట వెడల్పు స్క్రీన్ పరిమాణంలో 75%కి పరిమితం చేయబడింది.పక్కలలో మరియు దిగువ నుండి కంటెంట్ మార్జిన్ అనేది టోకెన్ ద్వారా నిర్వహించబడుతుంది. అదే కంటెంట్ టెక్స్ట్ అనేది ఎత్తు మారడానికి 
         పునరావృతమవుతుంది.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-th-rTH/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-th-rTH/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">ทําซ้ำข้อความเนื้อหา</string>
     <!-- UI Label for description -->
-    <string name="menu_description">ความกว้างของเมนูจะเปลี่ยนตามข้อความเนื้อหา ค่าสูงสุด
+    <string name="menu_description" formatted="false">ความกว้างของเมนูจะเปลี่ยนตามข้อความเนื้อหา ค่าสูงสุด
         จํากัดความกว้างไว้ที่75% ขนาดหน้าจอ ระยะขอบของเนื้อหาจากด้านข้างและด้านล่างถูกควบคุมโดยโทเค็น ข้อความเนื้อหาเดียวกันจะทําซ้ําให้แตกต่างกัน
         ความสูง</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-tr-rTR/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-tr-rTR/strings.xml
@@ -760,7 +760,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Yinelenen İçerik Metni</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menü genişliği, İçerik Metnine uyacak şekilde değişiklik gösterir. Genişlik,
+    <string name="menu_description" formatted="false">Menü genişliği, İçerik Metnine uyacak şekilde değişiklik gösterir. Genişlik,
         ekran boyutunun en fazla %75\'iyle sınırlıdır. İçeriğin yan ve alt kenar boşluğu belirteç tarafından düzenlenir. Aynı içerik metni, yüksekliği değişiklik gösterecek şekilde
         yinelenir.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-uk-rUA/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-uk-rUA/strings.xml
@@ -762,7 +762,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Повторити текст вмісту</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Ширина меню змінюватиметься відповідно до тексту вмісту. Максимальна
+    <string name="menu_description" formatted="false">Ширина меню змінюватиметься відповідно до тексту вмісту. Максимальна
         ширина обмежена 75 % розміру екрана. Поле вмісту збоку та знизу регулюється маркером. Той самий текст вмісту повторюватиметься, щоб змінювати
         висоту.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-vi-rVN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-vi-rVN/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Văn bản nội dung lặp lại</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Độ rộng menu sẽ thay đổi đối với Văn bản Nội dung. Tối đa
+    <string name="menu_description" formatted="false">Độ rộng menu sẽ thay đổi đối với Văn bản Nội dung. Tối đa
         chiều rộng bị giới hạn 75% kích cỡ màn hình. Lề nội dung từ bên cạnh và dưới cùng được quản lý bởi mã thông báo. Cùng một văn bản nội dung sẽ lặp lại thành khác nhau
         chiều cao.</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-zh-rCN/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-zh-rCN/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">重复内容文本</string>
     <!-- UI Label for description -->
-    <string name="menu_description">菜单宽度将随内容文本而变化。最大
+    <string name="menu_description" formatted="false">菜单宽度将随内容文本而变化。最大
         宽度限制为屏幕大小的 75%。侧面和底部的内容边距由标记控制。相同的内容文本将重复以改变
         高度。</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values-zh-rTW/strings.xml
+++ b/FluentUI.Demo/src/main/res/values-zh-rTW/strings.xml
@@ -759,7 +759,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">重複內容文字</string>
     <!-- UI Label for description -->
-    <string name="menu_description">選單寬度會依循著內容文字而變更。寬度
+    <string name="menu_description" formatted="false">選單寬度會依循著內容文字而變更。寬度
         上限會限制在 75% 的畫面尺寸。在側邊和底部的內容頁面邊界是由權杖所控管。相同的內容文字將會重複以更改
         其高度。</string>
     <!-- UI Label for open menu button -->

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -791,7 +791,7 @@
     <!-- UI Label for repeat content text -->
     <string name="menu_repeat_content_text">Repeat Content Text</string>
     <!-- UI Label for description -->
-    <string name="menu_description">Menu width will change with respect to Content Text. The max
+    <string name="menu_description" formatted="false">Menu width will change with respect to Content Text. The max
         width is restricted to 75% of screen size. The content margin from side and bottom is govern by token. The same content text will repeat to vary
         the height.</string>
     <!-- UI Label for open menu button -->


### PR DESCRIPTION
### Problem 
Build Break will below error:

/home/vsts/work/1/s/FluentUI.Demo/src/main/res/values-da-rDK/strings.xml:763: Error: Incorrect formatting string 
menu_description; missing conversion character in '% a' ? [StringFormatInvalid]
    <string name="menu_description">Menubredden ændres i forhold til indholdstekst. Maks
    ^

### Root cause 
menu_description does not require formatting.
### Fix
Disable formatting in menu description for all language.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
