### PR TITLE
Trailing Accessory View will be shown when bottom view is used in listitem

### DIFF
--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -438,7 +438,7 @@ object ListItem {
      * @param secondarySubTextTrailingContent Optional secondary text trailing Content.
      * @param border [BorderType] Optional border for the list item.
      * @param borderInset [BorderInset]Optional borderInset for list item.
-     * @param bottomContent Optional bottom Content under Text field. If used, trailing Content will not be displayed
+     * @param bottomContent Optional bottom Content under Text field.
      * @param leadingAccessoryContent Optional composable leading accessory Content.
      * @param trailingAccessoryContent Optional composable trailing accessory Content.
      * @param leadingAccessoryContentAlignment Alignment for leading accessory Content to align Top, Bottom or Center
@@ -525,7 +525,7 @@ object ListItem {
      * @param secondarySubTextTrailingContent Optional secondary text trailing Content.
      * @param border [BorderType] Optional border for the list item.
      * @param borderInset [BorderInset]Optional borderInset for list item.
-     * @param bottomContent Optional bottom Content under Text field. If used, trailing Content will not be displayed
+     * @param bottomContent Optional bottom Content under Text field.
      * @param leadingAccessoryContent Optional composable leading accessory Content.
      * @param trailingAccessoryContent Optional composable trailing accessory Content.
      * @param leadingAccessoryContentAlignment Alignment for leading accessory Content to align Top, Bottom or Center

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -401,7 +401,7 @@ object ListItem {
                     }
                 }
             }
-            if (bottomContent == null && trailingAccessoryContent != null && textAlignment == ListItemTextAlignment.Regular) {
+            if (trailingAccessoryContent != null && textAlignment == ListItemTextAlignment.Regular) {
                 Box(
                     Modifier
                         .padding(


### PR DESCRIPTION
### Problem 
T.A.View is not shown when bottomView param is used in ListItem.Item
### Root cause 
if condition is added to remove T.A.View when bottomContent is used
### Fix
Removed the condition

### Validations
Manual test and peer review
(how the change was tested, including both manual and automated tests)

### Screenshots

Before
![image](https://github.com/microsoft/fluentui-android/assets/5608292/be9e6bc4-afac-4d59-bc04-2878584a652a) 
After
![image](https://github.com/microsoft/fluentui-android/assets/5608292/0e83fece-eafb-4dec-868f-9489fd93f481)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
