### PR TITLE
removed brigintovoewrequester from people picker

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -139,10 +138,6 @@ fun Button(
                     text = text,
                     modifier = Modifier.clearAndSetSemantics { },
                     style = token.typography(buttonInfo).merge(
-                        TextStyle(
-                            platformStyle = PlatformTextStyle(includeFontPadding = false)
-                        )
-                    ).merge(
                         TextStyle(
                             color = token.textColor(buttonInfo = buttonInfo)
                                 .getColorByState(

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.relocation.BringIntoViewRequester
-import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
@@ -25,7 +23,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -36,7 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.key.Key
@@ -61,7 +57,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipStyle
 import com.microsoft.fluentui.tokenized.divider.Divider
 import com.microsoft.fluentui.tokenized.persona.Person
 import com.microsoft.fluentui.tokenized.persona.PersonaChip
-import kotlinx.coroutines.launch
 
 /**
  * API to create a customized PeoplePicker for users to add a list of PersonaChips

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -129,10 +129,8 @@ fun PeoplePicker(
     val textColor = token.textColor(peoplePickerInfo = peoplePickerInfo)
     val cursorBrush = token.cursorBrush(peoplePickerInfo = peoplePickerInfo)
     val focusRequester = remember { FocusRequester() }
-    val bringIntoViewRequester = remember { BringIntoViewRequester() }
     var queryText by rememberSaveable { mutableStateOf("") }
     var selectedPeopleListSize by rememberSaveable { mutableStateOf(0) }
-    val scope = rememberCoroutineScope()
 
     Row(
         modifier = modifier
@@ -225,16 +223,6 @@ fun PeoplePicker(
                         modifier = Modifier
                             .fillMaxWidth()
                             .focusRequester(focusRequester)
-                            .bringIntoViewRequester(bringIntoViewRequester)
-                            .onFocusEvent { focusState ->
-                                when {
-                                    focusState.isFocused -> {
-                                        scope.launch {
-                                            bringIntoViewRequester.bringIntoView()
-                                        }
-                                    }
-                                }
-                            }
                             .semantics { contentDescription = searchHint ?: "" }
                             .testTag("Text field"),
                         textStyle = textTypography.merge(

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.ExperimentalTextApi
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -161,8 +160,7 @@ fun AppBar(
                                 text = title,
                                 style = titleTextStyle.merge(
                                     TextStyle(
-                                        color = token.titleTextColor(appBarInfo),
-                                        platformStyle = PlatformTextStyle(includeFontPadding = true)
+                                        color = token.titleTextColor(appBarInfo)
                                     )
                                 ),
                                 maxLines = 1,
@@ -203,8 +201,7 @@ fun AppBar(
                                     TextStyle(
                                         color = token.subtitleTextColor(
                                             appBarInfo
-                                        ),
-                                        platformStyle = PlatformTextStyle(includeFontPadding = true)
+                                        )
                                     )
                                 ),
                                 maxLines = 1,
@@ -232,10 +229,7 @@ fun AppBar(
                             .weight(1F),
                         style = titleTextStyle.merge(
                             TextStyle(
-                                color = token.titleTextColor(appBarInfo),
-                                platformStyle = PlatformTextStyle(
-                                    includeFontPadding = true
-                                )
+                                color = token.titleTextColor(appBarInfo)
                             )
                         ),
                         maxLines = 1,


### PR DESCRIPTION
### Problem 
Bringintoviewrequester causes exception due to incompatible version in client. 
platform text style usage form appbar and button.
### Root cause 
Incompatible version
### Fix
Removed the usage since it was added temporarily for horizontal scroll and has no significant impact once versions are upgraded
removed platform text style usage form appbar and button.

### Validations
manual testing
(how the change was tested, including both manual and automated tests)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
