### PR TITLE
V1 ToolTip Alignment Fix

### DIFF
--- a/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
+++ b/fluentui_transients/src/main/java/com/microsoft/fluentui/tooltip/Tooltip.kt
@@ -256,8 +256,7 @@ class Tooltip {
         if (secondScreen) positionY -= displayHeight + DuoSupportUtils.DUO_HINGE_WIDTH
 
         isAboveAnchor = context.activity?.let {
-            if (DuoSupportUtils.isDeviceSurfaceDuo(it)) positionY + contentHeight + margin > displayHeight
-            else positionY + contentHeight + margin - context.statusBarHeight > displayHeight
+            positionY + contentHeight + margin > displayHeight
         } ?: false
         if (isAboveAnchor) {
             positionY = anchor.top - contentHeight - offsetY


### PR DESCRIPTION
### Problem 
ToolTip preferably comes to side on anchor placed at bottom when it has enough space to its side.

### Root cause 
Position evaluated wrongly for tooltip.
### Fix
Fix the evaluation of ToolTip position

### Validations
Manual validation

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
| ![image](https://github.com/microsoft/fluentui-android/assets/97503451/45b8b7dd-520a-4357-a7b1-be2d61feae96) | 
![image](https://github.com/microsoft/fluentui-android/assets/97503451/ea52b9fe-3df0-4659-922d-876933716a1c) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
