### PR TITLE
Add param to enable Bottom border on AppBar

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -29,7 +29,11 @@ import com.microsoft.fluentui.icons.listitemicons.Chevron
 import com.microsoft.fluentui.icons.searchbaricons.Arrowback
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
-import com.microsoft.fluentui.theme.token.*
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentColor
+import com.microsoft.fluentui.theme.token.FluentIcon
+import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
@@ -74,6 +78,7 @@ class V2AppBarActivity : V2DemoActivity() {
             var subtitle: String? by rememberSaveable { mutableStateOf("Subtitle") }
             var enableSearchBar: Boolean by rememberSaveable { mutableStateOf(false) }
             var enableButtonBar: Boolean by rememberSaveable { mutableStateOf(false) }
+            var enableBottomBorder: Boolean by rememberSaveable { mutableStateOf(true) }
             var yAxisDelta: Float by rememberSaveable { mutableStateOf(1.0F) }
 
             Column(modifier = Modifier.pointerInput(Unit) {
@@ -197,6 +202,23 @@ class V2AppBarActivity : V2DemoActivity() {
                                 )
                             }
                         )
+
+                        ListItem.Item(
+                            text = LocalContext.current.resources.getString(R.string.app_bar_bottom_border),
+                            subText = if (enableBottomBorder)
+                                LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                            else
+                                LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                            trailingAccessoryContent = {
+                                ToggleSwitch(
+                                    onValueChange = {
+                                        enableBottomBorder = !enableBottomBorder
+                                    },
+                                    modifier = Modifier.testTag(APP_BAR_SEARCHBAR_PARAM),
+                                    checkedState = enableBottomBorder,
+                                )
+                            }
+                        )
                     }
                 }
 
@@ -284,6 +306,7 @@ class V2AppBarActivity : V2DemoActivity() {
                     appBarSize = appBarSize,
                     style = style,
                     searchMode = searchMode,
+                    bottomBorder = enableBottomBorder,
                     searchBar = if (enableSearchBar) {
                         {
                             SearchBar(

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -214,7 +214,6 @@ class V2AppBarActivity : V2DemoActivity() {
                                     onValueChange = {
                                         enableBottomBorder = !enableBottomBorder
                                     },
-                                    modifier = Modifier.testTag(APP_BAR_SEARCHBAR_PARAM),
                                     checkedState = enableBottomBorder,
                                 )
                             }

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -36,6 +36,9 @@
     <string name="app_bar_style">AppBar Style</string>
     <string name="app_bar_subtitle">Subtitle</string>
 
+    <!-- Text to show the bottom border property of App bar .-->
+    <string name="app_bar_bottom_border">Bottom Border</string>
+
     <!-- Text that shows the action performed to the user -->
     <string name="app_bar_layout_navigation_icon_clicked">Navigation icon clicked.</string>
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -1,6 +1,8 @@
 package com.microsoft.fluentui.theme.token.controlTokens
 
 import android.os.Parcelable
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
@@ -12,7 +14,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
-import com.microsoft.fluentui.theme.token.*
+import com.microsoft.fluentui.theme.token.ControlInfo
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentColor
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
+import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.IControlToken
 import kotlinx.parcelize.Parcelize
 
 enum class AppBarSize {
@@ -37,6 +44,7 @@ open class AppBarTokens : IControlToken, Parcelable {
                     FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
                         themeMode = FluentTheme.themeMode
                     )
+
                 FluentStyle.Brand ->
                     FluentColor(
                         light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
@@ -57,6 +65,7 @@ open class AppBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground2].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -76,6 +85,7 @@ open class AppBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -95,6 +105,7 @@ open class AppBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground2].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -114,6 +125,7 @@ open class AppBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -133,6 +145,7 @@ open class AppBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground2].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -197,6 +210,29 @@ open class AppBarTokens : IControlToken, Parcelable {
             AppBarSize.Large -> PaddingValues(start = 12.dp)
             AppBarSize.Medium -> PaddingValues()
             AppBarSize.Small -> PaddingValues(start = 8.dp)
+        }
+    }
+
+    @Composable
+    open fun borderStroke(info: AppBarInfo): BorderStroke {
+        return when (info.style) {
+            FluentStyle.Neutral ->
+                if (FluentTheme.themeMode == ThemeMode.Dark || (FluentTheme.themeMode == ThemeMode.Auto && isSystemInDarkTheme())) {
+                    BorderStroke(
+                        FluentGlobalTokens.strokeWidth(FluentGlobalTokens.StrokeWidthTokens.StrokeWidthNone),
+                        Color.Unspecified
+                    )
+                } else {
+                    BorderStroke(
+                        FluentGlobalTokens.strokeWidth(FluentGlobalTokens.StrokeWidthTokens.StrokeWidth05),
+                        FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value()
+                    )
+                }
+
+            else -> BorderStroke(
+                FluentGlobalTokens.strokeWidth(FluentGlobalTokens.StrokeWidthTokens.StrokeWidthNone),
+                Color.Unspecified
+            )
         }
     }
 

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -9,8 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.PlatformTextStyle
@@ -53,6 +56,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
  * @param rightAccessoryView Row Placeholder to be placed at right on AppTitle. Default: [null]
  * @param searchBar Composable to be placed as searchbar below appTitle. Default: [null]
  * @param bottomBar Composable to Be placed below appTitle. Displayed if searchbar is not provided or when in searchmode. Default: [null]
+ * @param bottomBorder Boolean to place a bottom border on AppBar. Applies only when searchBar and bottomBar are empty. Default: [true]
  * @param appTitleDelta Ratio of opening of appTitle. Used for Shychrome and other animations. Default: [1.0F]
  * @param accessoryDelta Ratio of opening of accessory View. Used for Shychrome and other animations. Default: [1.0F]
  * @param appBarTokens Optional Tokens for App Bar to customize it. Default: [null]
@@ -84,6 +88,7 @@ fun AppBar(
     rightAccessoryView: @Composable (RowScope.() -> Unit)? = null,
     searchBar: @Composable (RowScope.() -> Unit)? = null,
     bottomBar: @Composable (RowScope.() -> Unit)? = null,
+    bottomBorder: Boolean = true,
     appTitleDelta: Float = 1.0F,
     accessoryDelta: Float = 1.0F,
     appBarTokens: AppBarTokens? = null
@@ -103,6 +108,24 @@ fun AppBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(token.backgroundBrush(appBarInfo))
+                .then(
+                    if (bottomBorder && searchBar == null && bottomBar == null) {
+                        val strokeWidth =
+                            with(LocalDensity.current) { token.borderStroke(appBarInfo).width.toPx() }
+                        val strokeColor = token.borderStroke(appBarInfo).brush
+                        Modifier.drawBehind {
+                            val y = size.height - strokeWidth / 2
+                            drawLine(
+                                strokeColor,
+                                Offset(0f, y),
+                                Offset(size.width, y),
+                                strokeWidth
+                            )
+                        }
+                    } else {
+                        Modifier
+                    }
+                )
         ) {
             Row(
                 Modifier


### PR DESCRIPTION
### Problem 
Bottom border wasn't enabled on AppBar. This is something which is useful when searchbar or bottom bar are not present.

### Root cause 
-

### Fix
Added the feature using modifier and canvas.


### Validations
Manual validation

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-android/assets/12729351/e838a15f-f21a-4ef3-ae15-f90875fda0eb) | 
![image](https://github.com/microsoft/fluentui-android/assets/12729351/c4d8d870-484f-4ac0-9759-848d2b37a778) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
