### PR TITLE
Added cornerRadius token in BadgeToken

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BadgeTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BadgeTokens.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -52,6 +53,7 @@ open class BadgeTokens : IControlToken, Parcelable {
                     badgeInfo
                 ).width
             )
+
             BadgeType.List -> PaddingValues(
                 start = FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size80) + borderStroke(
                     badgeInfo
@@ -72,4 +74,7 @@ open class BadgeTokens : IControlToken, Parcelable {
             FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.StrokeFocus1].value()
         )
     }
+
+    @Composable
+    open fun cornerRadius(badgeInfo: BadgeInfo): Dp = 100.dp
 }

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -72,15 +71,15 @@ fun Badge(
         val textColor = token.textColor(badgeInfo = badgeInfo)
         val typography = token.typography(badgeInfo = badgeInfo)
         val paddingValues = token.padding(badgeInfo = badgeInfo)
+        val shape = RoundedCornerShape(token.cornerRadius(badgeInfo = badgeInfo))
 
         Row(
             modifier
                 .requiredHeight(if (badgeType == BadgeType.Character) 20.dp else 27.dp)
-                .border(borderStroke.width, borderStroke.brush, CircleShape)
+                .border(borderStroke.width, borderStroke.brush, shape)
                 .padding(0.5.dp) //TODO to check fix for https://issuetracker.google.com/issues/228985905
-                .background(background, CircleShape)
-                .clip(RoundedCornerShape(100.dp)),
-
+                .background(background, shape)
+                .clip(shape),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
         ) {


### PR DESCRIPTION
### Problem 
Corner radius could not configure via token.
### Root cause 
Corner radius was hardcoded & hence token was not available in BadgeToken.
### Fix
Added cornerRadius in controlToken for badge to configure corner radius for badge.

### Validations
manual validation

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
