### PR TITLE
adding content support on V2shimmer

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ShimmerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ShimmerUITest.kt
@@ -1,17 +1,22 @@
 package com.microsoft.fluentuidemo.demos
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
-import com.microsoft.fluentui.theme.token.controlTokens.ShimmerShape
+import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
+import com.microsoft.fluentui.tokenized.persona.Avatar
+import com.microsoft.fluentui.tokenized.persona.Person
 import com.microsoft.fluentui.tokenized.shimmer.Shimmer
 import org.junit.Rule
 import org.junit.Test
@@ -29,13 +34,12 @@ class V2ShimmerUITest {
         composeTestRule.setContent {
             FluentTheme {
                 Shimmer(
-                    shape = ShimmerShape.Box, modifier = Modifier
+                    modifier = Modifier
                         .height(50.dp)
                         .width(50.dp)
                         .testTag(SHIMMER)
                 )
                 Shimmer(
-                    shape = ShimmerShape.Circle,
                     modifier = Modifier
                         .size(50.dp)
                         .testTag(SHIMMER_CIRCLE)
@@ -46,5 +50,26 @@ class V2ShimmerUITest {
             .assertWidthIsEqualTo(50.dp)
         composeTestRule.onNodeWithTag(SHIMMER_CIRCLE).assertHeightIsEqualTo(50.dp)
             .assertWidthIsEqualTo(50.dp)
+    }
+
+    @Test
+    fun testShimmerContent() {
+        composeTestRule.setContent {
+            FluentTheme {
+                Shimmer(
+                    modifier = Modifier
+                        .testTag(SHIMMER),
+                    content = {
+                        Avatar(modifier = Modifier.testTag("Avatar").clickable {  }, person = Person("TestName"), size = AvatarSize.Size40)
+                    }
+                )
+            }
+        }
+        val shimmer = composeTestRule.onNodeWithTag(SHIMMER)
+        shimmer.assertHeightIsEqualTo(40.dp).assertWidthIsEqualTo(40.dp)
+        val content = composeTestRule.onNodeWithTag("Avatar")
+        content.assertExists()
+        content.assertIsDisplayed()
+        content.assertHasClickAction()
     }
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ShimmerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ShimmerUITest.kt
@@ -61,7 +61,7 @@ class V2ShimmerUITest {
                         .testTag(SHIMMER),
                     content = {
                         Avatar(modifier = Modifier.testTag("Avatar").clickable {  }, person = Person("TestName"), size = AvatarSize.Size40)
-                    }
+                    }, cornerRadius = 50.dp
                 )
             }
         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -1,21 +1,45 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
+import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
+import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
+import com.microsoft.fluentui.theme.token.controlTokens.BadgeInfo
+import com.microsoft.fluentui.theme.token.controlTokens.BadgeTokens
 import com.microsoft.fluentui.theme.token.controlTokens.ColorStyle
+import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipSize
+import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipStyle
+import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipTokens
+import com.microsoft.fluentui.theme.token.controlTokens.ShimmerInfo
 import com.microsoft.fluentui.theme.token.controlTokens.ShimmerShape
+import com.microsoft.fluentui.theme.token.controlTokens.ShimmerTokens
 import com.microsoft.fluentui.tokenized.controls.Label
+import com.microsoft.fluentui.tokenized.notification.Badge
+import com.microsoft.fluentui.tokenized.persona.Avatar
+import com.microsoft.fluentui.tokenized.persona.Person
+import com.microsoft.fluentui.tokenized.persona.PersonaChip
 import com.microsoft.fluentui.tokenized.shimmer.Shimmer
+import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.V2DemoActivity
 
 class V2ShimmerActivity : V2DemoActivity() {
@@ -122,6 +146,86 @@ class V2ShimmerActivity : V2DemoActivity() {
                     Shimmer(modifier = Modifier.size(180.dp, 12.dp))
                 }
             }
+            class TransparentToken: ShimmerTokens(){
+                @Composable
+                override fun color(shimmerInfo: ShimmerInfo): Color {
+                    return Color.Transparent
+                }
+                @Composable
+                override fun knockoutEffectColor(shimmerInfo: ShimmerInfo): Color {
+                    return Color(0XFFE1BA27)
+                }
+                @Composable
+                override fun cornerRadius(shimmerInfo: ShimmerInfo): Dp {
+                    return 100.dp
+                }
+            }
+            class BadgeColorToken: BadgeTokens(){
+                @Composable
+                override fun backgroundBrush(badgeInfo: BadgeInfo): Brush {
+                    return SolidColor(Color(0xFFD59328))
+                }
+                @Composable
+                override fun borderStroke(badgeInfo: BadgeInfo): BorderStroke {
+                    return BorderStroke(
+                        width = 0.dp,
+                        brush = SolidColor(Color(0xFFD59328))
+                    )
+                }
+            }
+            Label(
+                text = "Shimmer with Content",
+                textStyle = FluentAliasTokens.TypographyTokens.Title2,
+                colorStyle = ColorStyle.Brand
+            )
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp, bottom = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Label(text = "Badge", textStyle = FluentAliasTokens.TypographyTokens.Body1)
+                Shimmer( content = {
+                    Badge(text = "Badge", badgeTokens = BadgeColorToken())
+                }, shimmerTokens = TransparentToken())
+            }
+            class TransparentChipToken: ShimmerTokens(){
+                @Composable
+                override fun color(shimmerInfo: ShimmerInfo): Color {
+                    return Color.Transparent
+                }
+                @Composable
+                override fun cornerRadius(shimmerInfo: ShimmerInfo): Dp {
+                    return 2.dp
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp, bottom = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Label(text = "PersonaChip", textStyle = FluentAliasTokens.TypographyTokens.Body1)
+                Shimmer( content = {
+                    PersonaChip(person = Person("PersonaChip"), selected = true, size = PersonaChipSize.Small, style = PersonaChipStyle.Brand)
+                }, shimmerTokens = TransparentChipToken())
+            }
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp, bottom = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Label(text = "Avatar", textStyle = FluentAliasTokens.TypographyTokens.Body1)
+                Shimmer( content = {
+                    Avatar(person = Person(
+                        "Allan", "Munger",
+                        image = R.drawable.avatar_allan_munger,
+                        status = AvatarStatus.Available,
+                    ), size = AvatarSize.Size72, enableActivityRings = false)
+                }, shimmerTokens = TransparentChipToken())
+            }
+
         }
 
     }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -68,7 +70,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(height = 80.dp, width = 120.dp, cornerRadius = 4.dp)
+                Shimmer(modifier = Modifier.size(120.dp, 80.dp))
                 Column(
                     Modifier
                         .height(80.dp)
@@ -76,7 +78,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Shimmer(modifier = Modifier.size(140.dp, 12.dp))
-                    Shimmer(height = 12.dp, width = 180.dp)
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp))
                     Shimmer(modifier = Modifier.size(200.dp, 12.dp))
                 }
             }
@@ -92,14 +94,14 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp), cornerRadius = 50.dp)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)))
                 Column(
                     Modifier
                         .height(80.dp)
                         .padding(top = 10.dp, bottom = 10.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Shimmer(width = 140.dp, height = 12.dp)
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp))
                     Shimmer(modifier = Modifier.size(180.dp, 12.dp))
                 }
             }
@@ -110,7 +112,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp), cornerRadius = 50.dp)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)))
                 Column(
                     Modifier
                         .height(80.dp)
@@ -128,7 +130,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(height = 60.dp, width = 60.dp, cornerRadius = 50.dp)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)))
                 Column(
                     Modifier
                         .height(80.dp)

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -2,26 +2,20 @@ package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
-import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.BadgeInfo
@@ -29,9 +23,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.BadgeTokens
 import com.microsoft.fluentui.theme.token.controlTokens.ColorStyle
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipSize
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipStyle
-import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipTokens
 import com.microsoft.fluentui.theme.token.controlTokens.ShimmerInfo
-import com.microsoft.fluentui.theme.token.controlTokens.ShimmerShape
 import com.microsoft.fluentui.theme.token.controlTokens.ShimmerTokens
 import com.microsoft.fluentui.tokenized.controls.Label
 import com.microsoft.fluentui.tokenized.notification.Badge
@@ -48,7 +40,8 @@ class V2ShimmerActivity : V2DemoActivity() {
     }
 
     override val paramsUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#params-31"
-    override val controlTokensUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-31"
+    override val controlTokensUrl =
+        "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-31"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -75,7 +68,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(120.dp, 80.dp))
+                Shimmer(height = 80.dp, width = 120.dp, cornerRadius = 4.dp)
                 Column(
                     Modifier
                         .height(80.dp)
@@ -83,7 +76,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Shimmer(modifier = Modifier.size(140.dp, 12.dp))
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp))
+                    Shimmer(height = 12.dp, width = 180.dp)
                     Shimmer(modifier = Modifier.size(200.dp, 12.dp))
                 }
             }
@@ -99,7 +92,25 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp), shape = ShimmerShape.Circle)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp), cornerRadius = 50.dp)
+                Column(
+                    Modifier
+                        .height(80.dp)
+                        .padding(top = 10.dp, bottom = 10.dp),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Shimmer(width = 140.dp, height = 12.dp)
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp))
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp, bottom = 16.dp)
+                    .height(60.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp), cornerRadius = 50.dp)
                 Column(
                     Modifier
                         .height(80.dp)
@@ -117,7 +128,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp), shape = ShimmerShape.Circle)
+                Shimmer(height = 60.dp, width = 60.dp, cornerRadius = 50.dp)
                 Column(
                     Modifier
                         .height(80.dp)
@@ -128,43 +139,19 @@ class V2ShimmerActivity : V2DemoActivity() {
                     Shimmer(modifier = Modifier.size(180.dp, 12.dp))
                 }
             }
-            Row(
-                modifier = Modifier
-                    .padding(top = 8.dp, bottom = 16.dp)
-                    .height(60.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Shimmer(modifier = Modifier.size(60.dp), shape = ShimmerShape.Circle)
-                Column(
-                    Modifier
-                        .height(80.dp)
-                        .padding(top = 10.dp, bottom = 10.dp),
-                    verticalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Shimmer(modifier = Modifier.size(140.dp, 12.dp))
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp))
-                }
-            }
-            class TransparentToken: ShimmerTokens(){
-                @Composable
-                override fun color(shimmerInfo: ShimmerInfo): Color {
-                    return Color.Transparent
-                }
+            class ShimmerGoldEffectToken : ShimmerTokens() {
                 @Composable
                 override fun knockoutEffectColor(shimmerInfo: ShimmerInfo): Color {
                     return Color(0XFFE1BA27)
                 }
-                @Composable
-                override fun cornerRadius(shimmerInfo: ShimmerInfo): Dp {
-                    return 100.dp
-                }
             }
-            class BadgeColorToken: BadgeTokens(){
+
+            class BadgeColorToken : BadgeTokens() {
                 @Composable
                 override fun backgroundBrush(badgeInfo: BadgeInfo): Brush {
                     return SolidColor(Color(0xFFD59328))
                 }
+
                 @Composable
                 override fun borderStroke(badgeInfo: BadgeInfo): BorderStroke {
                     return BorderStroke(
@@ -185,19 +172,9 @@ class V2ShimmerActivity : V2DemoActivity() {
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Label(text = "Badge", textStyle = FluentAliasTokens.TypographyTokens.Body1)
-                Shimmer( content = {
+                Shimmer(content = {
                     Badge(text = "Badge", badgeTokens = BadgeColorToken())
-                }, shimmerTokens = TransparentToken())
-            }
-            class TransparentChipToken: ShimmerTokens(){
-                @Composable
-                override fun color(shimmerInfo: ShimmerInfo): Color {
-                    return Color.Transparent
-                }
-                @Composable
-                override fun cornerRadius(shimmerInfo: ShimmerInfo): Dp {
-                    return 2.dp
-                }
+                }, shimmerTokens = ShimmerGoldEffectToken(), cornerRadius = 100.dp)
             }
             Row(
                 modifier = Modifier
@@ -206,9 +183,14 @@ class V2ShimmerActivity : V2DemoActivity() {
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Label(text = "PersonaChip", textStyle = FluentAliasTokens.TypographyTokens.Body1)
-                Shimmer( content = {
-                    PersonaChip(person = Person("PersonaChip"), selected = true, size = PersonaChipSize.Small, style = PersonaChipStyle.Brand)
-                }, shimmerTokens = TransparentChipToken())
+                Shimmer(cornerRadius = 2.dp, content = {
+                    PersonaChip(
+                        person = Person("PersonaChip"),
+                        selected = true,
+                        size = PersonaChipSize.Small,
+                        style = PersonaChipStyle.Brand
+                    )
+                })
             }
             Row(
                 modifier = Modifier
@@ -217,13 +199,15 @@ class V2ShimmerActivity : V2DemoActivity() {
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Label(text = "Avatar", textStyle = FluentAliasTokens.TypographyTokens.Body1)
-                Shimmer( content = {
-                    Avatar(person = Person(
-                        "Allan", "Munger",
-                        image = R.drawable.avatar_allan_munger,
-                        status = AvatarStatus.Available,
-                    ), size = AvatarSize.Size72, enableActivityRings = false)
-                }, shimmerTokens = TransparentChipToken())
+                Shimmer(cornerRadius = 50.dp, content = {
+                    Avatar(
+                        person = Person(
+                            "Allan", "Munger",
+                            image = R.drawable.avatar_allan_munger,
+                            status = AvatarStatus.Available,
+                        ), size = AvatarSize.Size72, enableActivityRings = false
+                    )
+                })
             }
 
         }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
@@ -40,4 +40,9 @@ open class ShimmerTokens : IControlToken, Parcelable {
             themeMode = FluentTheme.themeMode
         )
     }
+
+    @Composable
+    open fun delay(shimmerInfo: ShimmerInfo): Int {
+        return 1000
+    }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
@@ -3,30 +3,16 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlInfo
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
-import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.IControlToken
 import kotlinx.parcelize.Parcelize
 
-enum class ShimmerShape {
-    Box,
-    Circle
-}
-
-data class ShimmerInfo(
-    val shape: ShimmerShape = ShimmerShape.Box
-) : ControlInfo
+open class ShimmerInfo : ControlInfo
 
 @Parcelize
 open class ShimmerTokens : IControlToken, Parcelable {
-    @Composable
-    open fun cornerRadius(shimmerInfo: ShimmerInfo): Dp {
-        return FluentGlobalTokens.cornerRadius(FluentGlobalTokens.CornerRadiusTokens.CornerRadius40)
-    }
-
     @Composable
     open fun knockoutEffectColor(shimmerInfo: ShimmerInfo): Color {
         return FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Stencil2].value(

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -19,35 +19,84 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.controlTokens.ShimmerInfo
-import com.microsoft.fluentui.theme.token.controlTokens.ShimmerShape
 import com.microsoft.fluentui.theme.token.controlTokens.ShimmerTokens
 import com.microsoft.fluentui.util.dpToPx
 import kotlin.math.absoluteValue
 import kotlin.math.sqrt
 
+const val DEFAULT_WIDTH = 120
+const val DEFAULT_HEIGHT = 80
+const val DEFAULT_CORNER_RADIUS = 4
+
 /**
  * Create a Shimmer effect
  *
- * @param shape Shape of the shimmer. See [ShimmerShape] for shapes
+ * @param height Height of the shimmer
+ * @param width Width of the shimmer
+ * @param cornerRadius Corner radius of the shimmer
  * @param modifier Modifier for shimmer
- * @param content Composable content to be displayed. Note: This will be displayed only when shimmer color(Not knockOutEffect Color) is transparent.
  * @param shimmerTokens Token values for shimmer
  *
  */
-
 @Composable
 fun Shimmer(
+    height: Dp = DEFAULT_HEIGHT.dp,
+    width: Dp = DEFAULT_WIDTH.dp,
+    cornerRadius: Dp = DEFAULT_CORNER_RADIUS.dp,
     modifier: Modifier = Modifier,
-    shape: ShimmerShape = ShimmerShape.Box,
-    content: (@Composable () -> Unit)? = null,
     shimmerTokens: ShimmerTokens? = null
+) {
+    InternalShimmer(
+        height = height,
+        width = width,
+        cornerRadius = cornerRadius,
+        modifier = modifier,
+        shimmerTokens = shimmerTokens
+    )
+}
+
+/**
+ * Create a Shimmer effect
+ *
+ * @param content Content to be shimmered
+ * @param cornerRadius Corner radius of the shimmer
+ * @param modifier Modifier for shimmer
+ * @param shimmerTokens Token values for shimmer
+ *
+ */
+@Composable
+fun Shimmer(
+    cornerRadius: Dp = DEFAULT_CORNER_RADIUS.dp,
+    modifier: Modifier = Modifier,
+    shimmerTokens: ShimmerTokens? = null,
+    content: @Composable () -> Unit,
+) {
+    InternalShimmer(
+        cornerRadius = cornerRadius,
+        modifier = modifier,
+        shimmerTokens = shimmerTokens
+    ) {
+        content()
+    }
+}
+
+@Composable
+internal fun InternalShimmer(
+    height: Dp? = null,
+    width: Dp? = null,
+    cornerRadius: Dp,
+    modifier: Modifier = Modifier,
+    shimmerTokens: ShimmerTokens? = null,
+    content: (@Composable () -> Unit)? = null,
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -58,12 +107,15 @@ fun Shimmer(
     val screenWidth = dpToPx(configuration.screenWidthDp.dp)
     val diagonal =
         sqrt((screenHeight * screenHeight + screenWidth * screenWidth).toDouble()).toFloat()
-    val shimmerInfo = ShimmerInfo(shape = shape)
-    val shimmerBackgroundColor =
+    val shimmerInfo = ShimmerInfo()
+    val shimmerBackgroundColor = if (content != null) {
+        Color.Transparent
+    } else {
         tokens.color(shimmerInfo)
+    }
     val shimmerKnockoutEffectColor = tokens.knockoutEffectColor(shimmerInfo)
     val cornerRadius =
-        dpToPx(tokens.cornerRadius(shimmerInfo))
+        dpToPx(cornerRadius)
     val shimmerDelay = tokens.delay(shimmerInfo)
     val infiniteTransition = rememberInfiniteTransition()
     val isLtr = LocalLayoutDirection.current == LayoutDirection.Ltr
@@ -103,6 +155,8 @@ fun Shimmer(
     } else {
         Spacer(
             modifier = modifier
+                .width(width ?: DEFAULT_WIDTH.dp)
+                .height(height ?: DEFAULT_HEIGHT.dp)
                 .clip(RoundedCornerShape(cornerRadius))
                 .background(gradientColor)
         )

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -57,15 +57,15 @@ fun Shimmer(
 /**
  * Create Shimmer effect on some content
  *
- * @param content Content to be shimmered
  * @param cornerRadius Corner radius of the shimmer
  * @param modifier Modifier for shimmer
  * @param shimmerTokens Token values for shimmer
+ * @param content Content to be shimmered
  *
  */
 @Composable
 fun Shimmer(
-    cornerRadius: Dp = DEFAULT_CORNER_RADIUS.dp,
+    cornerRadius: Dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null,
     content: @Composable () -> Unit,
@@ -143,6 +143,7 @@ internal fun InternalShimmer(
     } else {
         Spacer(
             modifier = modifier
+                .clip(RoundedCornerShape(cornerRadius))
                 .background(gradientColor)
         )
     }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -33,32 +33,22 @@ import com.microsoft.fluentui.util.dpToPx
 import kotlin.math.absoluteValue
 import kotlin.math.sqrt
 
-private const val DEFAULT_WIDTH = 120
-private const val DEFAULT_HEIGHT = 80
 private const val DEFAULT_CORNER_RADIUS = 4
 
 /**
  * Create an empty Shimmer effect
  *
- * @param height Height of the shimmer
- * @param width Width of the shimmer
- * @param cornerRadius Corner radius of the shimmer
  * @param modifier Modifier for shimmer
  * @param shimmerTokens Token values for shimmer
  *
  */
 @Composable
 fun Shimmer(
-    height: Dp = DEFAULT_HEIGHT.dp,
-    width: Dp = DEFAULT_WIDTH.dp,
-    cornerRadius: Dp = DEFAULT_CORNER_RADIUS.dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null
 ) {
     InternalShimmer(
-        height = height,
-        width = width,
-        cornerRadius = cornerRadius,
+        cornerRadius = DEFAULT_CORNER_RADIUS.dp,
         modifier = modifier,
         shimmerTokens = shimmerTokens
     )
@@ -91,8 +81,6 @@ fun Shimmer(
 
 @Composable
 internal fun InternalShimmer(
-    height: Dp? = null,
-    width: Dp? = null,
     cornerRadius: Dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null,
@@ -140,7 +128,7 @@ internal fun InternalShimmer(
     )
     if (content != null) {
         Box(
-            Modifier
+            modifier
                 .width(IntrinsicSize.Max)
                 .height(IntrinsicSize.Max)
         ) {
@@ -155,11 +143,7 @@ internal fun InternalShimmer(
     } else {
         Spacer(
             modifier = modifier
-                .width(width ?: DEFAULT_WIDTH.dp)
-                .height(height ?: DEFAULT_HEIGHT.dp)
-                .clip(RoundedCornerShape(cornerRadius))
                 .background(gradientColor)
         )
     }
-
 }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -37,6 +37,7 @@ import kotlin.math.sqrt
  *
  * @param shape Shape of the shimmer. See [ShimmerShape] for shapes
  * @param modifier Modifier for shimmer
+ * @param content Composable content to be displayed. Note: This will be displayed only when shimmer color(Not knockOutEffect Color) is transparent.
  * @param shimmerTokens Token values for shimmer
  *
  */

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -33,12 +33,12 @@ import com.microsoft.fluentui.util.dpToPx
 import kotlin.math.absoluteValue
 import kotlin.math.sqrt
 
-const val DEFAULT_WIDTH = 120
-const val DEFAULT_HEIGHT = 80
-const val DEFAULT_CORNER_RADIUS = 4
+private const val DEFAULT_WIDTH = 120
+private const val DEFAULT_HEIGHT = 80
+private const val DEFAULT_CORNER_RADIUS = 4
 
 /**
- * Create a Shimmer effect
+ * Create an empty Shimmer effect
  *
  * @param height Height of the shimmer
  * @param width Width of the shimmer
@@ -65,7 +65,7 @@ fun Shimmer(
 }
 
 /**
- * Create a Shimmer effect
+ * Create Shimmer effect on some content
  *
  * @param content Content to be shimmered
  * @param cornerRadius Corner radius of the shimmer

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -1,12 +1,17 @@
 package com.microsoft.fluentui.tokenized.shimmer
 
-import androidx.compose.animation.core.*
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,10 +40,12 @@ import kotlin.math.sqrt
  * @param shimmerTokens Token values for shimmer
  *
  */
+
 @Composable
 fun Shimmer(
     modifier: Modifier = Modifier,
     shape: ShimmerShape = ShimmerShape.Box,
+    content: (@Composable () -> Unit)? = null,
     shimmerTokens: ShimmerTokens? = null
 ) {
     val themeID =
@@ -56,6 +63,7 @@ fun Shimmer(
     val shimmerKnockoutEffectColor = tokens.knockoutEffectColor(shimmerInfo)
     val cornerRadius =
         dpToPx(tokens.cornerRadius(shimmerInfo))
+    val shimmerDelay = tokens.delay(shimmerInfo)
     val infiniteTransition = rememberInfiniteTransition()
     val isLtr = LocalLayoutDirection.current == LayoutDirection.Ltr
     val initialValue = if (isLtr) 0f else screenWidth
@@ -65,7 +73,7 @@ fun Shimmer(
         targetValue,
         infiniteRepeatable(
             animation = tween(
-                durationMillis = 1000,
+                durationMillis = shimmerDelay,
                 easing = LinearEasing
             )
         )
@@ -77,20 +85,26 @@ fun Shimmer(
         start = Offset.Zero,
         end = Offset(shimmerEffect.absoluteValue, shimmerEffect.absoluteValue)
     )
-    if (shape == ShimmerShape.Box) {
-        Spacer(
-            modifier = modifier
-                .width(240.dp)
-                .height(12.dp)
-                .clip(RoundedCornerShape(cornerRadius))
-                .background(gradientColor)
-        )
+    if (content != null) {
+        Box(
+            Modifier
+                .width(IntrinsicSize.Max)
+                .height(IntrinsicSize.Max)
+        ) {
+            content()
+            Spacer(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(cornerRadius))
+                    .background(gradientColor)
+            )
+        }
     } else {
         Spacer(
             modifier = modifier
-                .size(60.dp)
-                .clip(CircleShape)
+                .clip(RoundedCornerShape(cornerRadius))
                 .background(gradientColor)
         )
     }
+
 }


### PR DESCRIPTION
Support adding shimmer effect on composables


### Validations
manual testing and peer review
(how the change was tested, including both manual and automated tests)

### Screenshots
![ezgif com-video-to-gif (1)](https://github.com/microsoft/fluentui-android/assets/5608292/b4ab3853-9ce4-4e4c-a97a-3796400f0644)



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
