### PR TITLE
V2 Filecard Fix: allowing incoming dim to ovveride the filecard width

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
@@ -115,7 +115,7 @@ fun FileCard(
         Box(contentAlignment = Alignment.Center) {
             Column(
                 modifier = Modifier
-                    .requiredWidth(IntrinsicSize.Min)
+                    .width(IntrinsicSize.Min)
                     .testTag("Card")
                     .then(
                         if (onClick != null) Modifier.clickable(


### PR DESCRIPTION
### Problem 
Filecard width cannot be restricted and wraps the content
### Root cause 
width parameter does not take any upcoming measurements
### Fix
replace" requiredWidth" parameter with "width"

### Validations
manual testing, auto testing and peer review
(how the change was tested, including both manual and automated tests)

### Screenshots

Before
![image](https://github.com/microsoft/fluentui-android/assets/5608292/4e38f9c0-f6b8-4327-856d-1551653e74ff)
After
![image](https://github.com/microsoft/fluentui-android/assets/5608292/5e55597d-092b-4a43-a53d-93d6a0974082)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
