### PR TITLE
Remove PlatformStyle from Badge and Citation

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Citation.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Citation.kt
@@ -30,7 +30,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.CitationTokens
  * @param modifier Optional modifier for the citation
  * @param citationTokens Optional tokens to customize appearance
  */
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun Citation(
     text: String,
@@ -76,9 +75,7 @@ fun Citation(
             text = text,
             style = typography.merge(
                 TextStyle(
-                    platformStyle = PlatformTextStyle(
-                        includeFontPadding = false
-                    ), color = textColor
+                    color = textColor
                 )
             )
         )

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Citation.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Citation.kt
@@ -14,8 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.ExperimentalTextApi
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -31,7 +31,6 @@ import com.microsoft.fluentui.util.dpToPx
  *
  */
 
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun Badge(
     modifier: Modifier = Modifier,
@@ -88,10 +87,7 @@ fun Badge(
                 modifier = Modifier.padding(paddingValues),
                 style = typography.merge(
                     TextStyle(
-                        color = textColor,
-                        platformStyle = PlatformTextStyle(
-                            includeFontPadding = false
-                        )
+                        color = textColor
                     )
                 )
             )

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -3,7 +3,13 @@ package com.microsoft.fluentui.tokenized.notification
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -11,8 +17,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.drawscope.Fill
-import androidx.compose.ui.text.ExperimentalTextApi
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme


### PR DESCRIPTION
### Problem 
Runtime Error in OfficeMobile for ShareFlow

### Root cause 
Platform Style is a depracated API for newer Compose Version and Hence causes mismatch for OfficeMobile and Loop.
It's removal was started but was left out for Badge and Citation.

### Fix
Removed Platform Style for Badeg and Citation

### Validations
Manual Validation
(how the change was tested, including both manual and automated tests)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
