### PR TITLE
listItems will be unclickable if onClick = null, or no onClick is passed

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ListItemUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ListItemUITest.kt
@@ -72,7 +72,7 @@ class V2ListItemUITest {
         listItem.assertHeightIsAtLeast(43.dp)
         listItem.assertExists()
         listItem.assertIsDisplayed()
-        listItem.assertIsNotEnabled()
+        listItem.assertHasNoClickAction()
     }
 
     @Test
@@ -105,7 +105,7 @@ class V2ListItemUITest {
         listItem.assertHeightIsAtLeast(63.dp)
         listItem.assertExists()
         listItem.assertIsDisplayed()
-        listItem.assertIsNotEnabled()
+        listItem.assertHasNoClickAction()
     }
 
     @Test
@@ -140,7 +140,7 @@ class V2ListItemUITest {
         listItem.assertHeightIsAtLeast(80.dp)
         listItem.assertExists()
         listItem.assertIsDisplayed()
-        listItem.assertIsNotEnabled()
+        listItem.assertHasNoClickAction()
     }
 
     @Test

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ListItemUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ListItemUITest.kt
@@ -1,6 +1,7 @@
 package com.microsoft.fluentuidemo.demos
 
 import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.*
@@ -8,10 +9,16 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
+import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
+import com.microsoft.fluentui.theme.token.controlTokens.BorderInset
+import com.microsoft.fluentui.theme.token.controlTokens.BorderType
 import com.microsoft.fluentui.theme.token.controlTokens.SectionHeaderStyle
 import com.microsoft.fluentui.theme.token.controlTokens.TextPlacement
 import com.microsoft.fluentui.tokenized.controls.Button
 import com.microsoft.fluentui.tokenized.listitem.ListItem
+import com.microsoft.fluentui.tokenized.persona.Avatar
+import com.microsoft.fluentui.tokenized.persona.Person
+import com.microsoft.fluentuidemo.R
 import org.junit.Rule
 import org.junit.Test
 
@@ -315,6 +322,24 @@ class V2ListItemUITest {
         listItem.assertIsDisplayed()
         listItem.assertHeightIsEqualTo(48.dp)
         listItem.assertIsEnabled()
+        listItem.assertHasNoClickAction()
+    }
+
+    @Test
+    fun testUnclickableOneLineListAccessoryContentContent(){
+        composeTestRule.setContent {
+            ListItem.Item(text = PRIMARY_TEXT,
+            leadingAccessoryContent = {
+                Avatar(
+                    person = Person(firstName = "", lastName = "", image = R.drawable.avatar_amanda_brady),
+                    size = AvatarSize.Size24, enablePresence = false
+                )
+             },
+            border = BorderType.Bottom,
+            borderInset = BorderInset.XXLarge
+            )
+        }
+        val listItem = composeTestRule.onNodeWithText(PRIMARY_TEXT)
         listItem.assertHasNoClickAction()
     }
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -103,7 +103,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Header(title = "Text Only")
             ListItem.Item(
                 text = primaryText,
-                onClick = {},
+                onClick = {}, 
                 border = BorderType.Bottom,
                 borderInset = XXLarge,
                 primaryTextTrailingContent = { Icon20() }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -84,6 +84,7 @@ const val sampleText =
 const val primaryText = "Title, primary text"
 const val secondaryText = "Subtitle, secondary text"
 const val tertiaryText = "Footer, tertiary text"
+const val unclickableText = " (Unclickable) "
 
 
 @Composable
@@ -131,8 +132,8 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Header(title = "Wrapped Text list")
             ListItem.Item(
                 text = sampleText,
-                textMaxLines = 4,
                 onClick = {},
+                textMaxLines = 4,
                 leadingAccessoryContent = { LeftContentFolderIcon40() },
                 border = BorderType.Bottom,
                 borderInset = XXLarge
@@ -215,7 +216,7 @@ private fun CreateListActivityUI(context: Context) {
                     border = BorderType.Bottom
                 )
                 ListItem.SectionHeader(
-                    title = "Two-Line list",
+                    title = "Three-Line list",
                     enableChevron = false,
                     enableContentOpenCloseTransition = true,
                     trailingAccessoryContent = { RightContentToggle() },
@@ -261,21 +262,22 @@ private fun OneLineSimpleList() {
     return Column {
         ListItem.Item(
             text = primaryText,
-            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size24, drawable.avatar_amanda_brady) },
+            onClick={},
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
             text = primaryText,
-            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size24, drawable.avatar_allan_munger) },
+            onClick={},
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
-            text = primaryText+" (unclickable)",
+            text = primaryText,
             leadingAccessoryContent = { GetAvatar(size = Size24, drawable.avatar_ashley_mccarthy) },
+            onClick={},
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
@@ -288,7 +290,7 @@ private fun TwoLineSimpleList() {
         ListItem.Item(
             text = primaryText,
             subText = "Subtitle",
-            onClick = {},
+            onClick={},
             leadingAccessoryContent = { GetAvatar(size = Size40, drawable.avatar_daisy_phillips) },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -296,14 +298,15 @@ private fun TwoLineSimpleList() {
         ListItem.Item(
             text = primaryText,
             subText = "Subtitle",
-            onClick = {},
+            onClick={},
             leadingAccessoryContent = { GetAvatar(size = Size40, drawable.avatar_elliot_woodward) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
             text = primaryText,
-            subText = "Subtitle (Unclickable)",
+            subText = "Subtitle",
+            onClick={},
             leadingAccessoryContent = {
                 GetAvatar(
                     size = Size40,
@@ -323,7 +326,7 @@ private fun ThreeLineSimpleList() {
             text = primaryText,
             subText = "Subtitle",
             secondarySubText = tertiaryText,
-            onClick = {},
+            onClick={},
             leadingAccessoryContent = { GetAvatar(size = Size56, drawable.avatar_daisy_phillips) },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -332,15 +335,16 @@ private fun ThreeLineSimpleList() {
             text = primaryText,
             subText = "Subtitle",
             secondarySubText = tertiaryText,
-            onClick = {},
+            onClick={},
             leadingAccessoryContent = { GetAvatar(size = Size56, drawable.avatar_elliot_woodward) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
-            text = primaryText+"(Unclickable)",
+            text = primaryText,
             subText = "Subtitle",
             secondarySubText = tertiaryText,
+            onClick={},
             leadingAccessoryContent = {
                 GetAvatar(
                     size = Size56,
@@ -396,7 +400,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
             borderInset = XXLarge
         )
         ListItem.Item(
-            text = "(UnClickable) $primaryText",
+            text = primaryText + unclickableText,
             leadingAccessoryContent = { LeftContentAvatar(size = Size24) },
             border = BorderType.Bottom,
             borderInset = XXLarge

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -102,12 +102,14 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Header(title = "Text Only")
             ListItem.Item(
                 text = primaryText,
+                onClick = {},
                 border = BorderType.Bottom,
                 borderInset = XXLarge,
                 primaryTextTrailingContent = { Icon20() }
             )
             ListItem.Item(
                 text = primaryText,
+                onClick = {},
                 subText = secondaryText,
                 border = BorderType.Bottom,
                 borderInset = XXLarge,
@@ -115,6 +117,7 @@ private fun CreateListActivityUI(context: Context) {
             )
             ListItem.Item(
                 text = primaryText,
+                onClick = {},
                 subText = secondaryText,
                 secondarySubText = tertiaryText,
                 border = BorderType.Bottom,
@@ -129,6 +132,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Item(
                 text = sampleText,
                 textMaxLines = 4,
+                onClick = {},
                 leadingAccessoryContent = { LeftContentFolderIcon40() },
                 border = BorderType.Bottom,
                 borderInset = XXLarge
@@ -136,6 +140,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Item(
                 text = sampleText,
                 subText = sampleText,
+                onClick = {},
                 textMaxLines = 4,
                 subTextMaxLines = 4,
                 leadingAccessoryContent = { LeftContentFolderIcon40() },
@@ -152,6 +157,7 @@ private fun CreateListActivityUI(context: Context) {
                 text = sampleText,
                 subText = sampleText,
                 secondarySubText = sampleText,
+                onClick = {},
                 textMaxLines = 4,
                 subTextMaxLines = 4,
                 secondarySubTextMaxLines = 4,
@@ -234,11 +240,13 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Header(title = "Centered Action Text")
             ListItem.Item(
                 text = "Action",
+                onClick = {},
                 textAlignment = ListItemTextAlignment.Centered,
                 border = BorderType.Bottom
             )
             ListItem.Item(
                 text = "Disabled",
+                onClick = {},
                 enabled = false,
                 textAlignment = ListItemTextAlignment.Centered,
                 border = BorderType.Bottom
@@ -253,18 +261,20 @@ private fun OneLineSimpleList() {
     return Column {
         ListItem.Item(
             text = primaryText,
+            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size24, drawable.avatar_amanda_brady) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
             text = primaryText,
+            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size24, drawable.avatar_allan_munger) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
-            text = primaryText,
+            text = primaryText+" (unclickable)",
             leadingAccessoryContent = { GetAvatar(size = Size24, drawable.avatar_ashley_mccarthy) },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -278,6 +288,7 @@ private fun TwoLineSimpleList() {
         ListItem.Item(
             text = primaryText,
             subText = "Subtitle",
+            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size40, drawable.avatar_daisy_phillips) },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -285,13 +296,14 @@ private fun TwoLineSimpleList() {
         ListItem.Item(
             text = primaryText,
             subText = "Subtitle",
+            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size40, drawable.avatar_elliot_woodward) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
             text = primaryText,
-            subText = "Subtitle",
+            subText = "Subtitle (Unclickable)",
             leadingAccessoryContent = {
                 GetAvatar(
                     size = Size40,
@@ -311,6 +323,7 @@ private fun ThreeLineSimpleList() {
             text = primaryText,
             subText = "Subtitle",
             secondarySubText = tertiaryText,
+            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size56, drawable.avatar_daisy_phillips) },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -319,12 +332,13 @@ private fun ThreeLineSimpleList() {
             text = primaryText,
             subText = "Subtitle",
             secondarySubText = tertiaryText,
+            onClick = {},
             leadingAccessoryContent = { GetAvatar(size = Size56, drawable.avatar_elliot_woodward) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
-            text = primaryText,
+            text = primaryText+"(Unclickable)",
             subText = "Subtitle",
             secondarySubText = tertiaryText,
             leadingAccessoryContent = {
@@ -357,6 +371,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         )
         ListItem.Item(
             text = primaryText,
+            onClick = {},
             leadingAccessoryContent = {
                 RightContentButton(
                     size = ButtonSize.Small,
@@ -375,18 +390,27 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         )
         ListItem.Item(
             text = primaryText,
+            onClick = {},
+            leadingAccessoryContent = { LeftContentAvatar(size = Size24) },
+            border = BorderType.Bottom,
+            borderInset = XXLarge
+        )
+        ListItem.Item(
+            text = "(UnClickable) $primaryText",
             leadingAccessoryContent = { LeftContentAvatar(size = Size24) },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
             text = "",
+            onClick = {},
             leadingAccessoryContent = { LeftContentThreeIcon() },
             border = BorderType.Bottom,
             borderInset = XXLarge
         )
         ListItem.Item(
             text = primaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentRadioButton() },
             trailingAccessoryContent = { RightContentAvatarStack(Size24) },
             border = BorderType.Bottom,
@@ -394,6 +418,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         )
         ListItem.Item(
             text = primaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentThreeButton() },
             trailingAccessoryContent = { RightContentToggle() },
             border = BorderType.Bottom,
@@ -410,6 +435,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             secondarySubText = tertiaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentAvatar(size = Size40) },
             trailingAccessoryContent = { LeftContentAvatar(size = Size40) },
             border = BorderType.Bottom,
@@ -442,6 +468,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             secondarySubText = tertiaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             primaryTextLeadingContent = {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -462,6 +489,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             subText = secondaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             trailingAccessoryContent = { RightContentAvatarStack(Size40) },
             border = BorderType.Bottom,
@@ -471,6 +499,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             text = primaryText,
             secondarySubText = tertiaryText,
             leadingAccessoryContent = { LeftContentFolderIcon40() },
+            onClick = {},
             secondarySubTextLeadingContent = {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Icon16()
@@ -495,6 +524,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             secondarySubText = tertiaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             secondarySubTextTrailingContent = { Icon16() },
             trailingAccessoryContent = { RightContentToggle() },
@@ -504,6 +534,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             subText = secondaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentThreeButton() },
             trailingAccessoryContent = { RightContentText("Value") },
             border = BorderType.Bottom,
@@ -529,6 +560,7 @@ private fun ThreeLineListAccessoryContentContent(
             text = "Amanda Brady replied to your comment",
             subText = "Wanda can you please update the file with comments",
             secondarySubTextAnnotated = footer,
+            onClick = {},
             leadingAccessoryContent = { LeftContentAvatar(size = Size56) },
             trailingAccessoryContent = { rightContentIconButton() },
             primaryTextTrailingContent = { Badge(text = "2") },
@@ -543,6 +575,7 @@ private fun ThreeLineListAccessoryContentContent(
             text = primaryText,
             subText = secondaryText,
             secondarySubText = tertiaryText,
+            onClick = {},
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             primaryTextTrailingContent = { Badge(text = "Suggested") },
             trailingAccessoryContent = {
@@ -558,6 +591,7 @@ private fun ThreeLineListAccessoryContentContent(
             text = primaryText,
             subText = secondaryText,
             bottomContent = { LinearProgressIndicator() },
+            onClick = {},
             primaryTextLeadingContent = { Icon20() },
             secondarySubTextTrailingContent = {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -285,17 +285,23 @@ object ListItem {
             Alignment.Bottom -> Alignment.BottomEnd
             else -> Alignment.CenterEnd
         }
-        val isClickable = onClick != null
-
         Row(
             modifier
                 .background(backgroundColor)
                 .fillMaxWidth()
                 .height(IntrinsicSize.Max)
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
-                .clickAndSemanticsModifier(
-                    interactionSource, onClick = onClick ?: {}, enabled=isClickable, rippleColor
-                ), verticalAlignment = Alignment.CenterVertically
+                .then(
+                    if(onClick != null){
+                        Modifier.clickAndSemanticsModifier(
+                            interactionSource,
+                            onClick = onClick,
+                            enabled,
+                            rippleColor
+                        )
+                    }
+                    else Modifier
+                )
         ) {
             if (leadingAccessoryContent != null && textAlignment == ListItemTextAlignment.Regular) {
                 Box(

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -285,6 +285,8 @@ object ListItem {
             Alignment.Bottom -> Alignment.BottomEnd
             else -> Alignment.CenterEnd
         }
+        val isClickable = onClick != null
+
         Row(
             modifier
                 .background(backgroundColor)
@@ -292,7 +294,7 @@ object ListItem {
                 .height(IntrinsicSize.Max)
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
                 .clickAndSemanticsModifier(
-                    interactionSource, onClick = onClick ?: {}, enabled, rippleColor
+                    interactionSource, onClick = onClick ?: {}, enabled=isClickable, rippleColor
                 ), verticalAlignment = Alignment.CenterVertically
         ) {
             if (leadingAccessoryContent != null && textAlignment == ListItemTextAlignment.Regular) {


### PR DESCRIPTION
### Problem 
ListItems were clickable even when onCLick = null was passed.
### Root cause 
In ListItem.kt ,  clickAndSemanticsModifier on the modifier is being applied even when onClick is null
### Fix
if onClick is not null then only apply clickAndSemanticsModifier on the modifier

### Validations
tested this on demoUI, and added some list items which are unclickable
(how the change was tested, including both manual and automated tests)

### Screenshots
After:
(Added a listItem which is unclickable)
![image](https://github.com/microsoft/fluentui-android/assets/68989156/7455adf4-45c5-4b9f-b343-d659c12f88bf)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
