### PR TITLE
Adding FluentUI support of enabled and readOnly params for TextField

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -87,28 +87,4 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
     }
-
-    @Test
-    fun testReadOnlyMode(){
-        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
-        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
-        modifiableParametersButton.performClick()
-        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
-        toggleControlToValue(control, true)
-        component.performTextInput("Test")
-        val componentEditable = composeTestRule.onNodeWithText(TEXT_FIELD, true)
-        componentEditable.assertDoesNotExist()
-    }
-
-    @Test
-    fun testEnabledMode(){
-        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
-        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
-        modifiableParametersButton.performClick()
-        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
-        toggleControlToValue(control, true)
-        component.performClick()
-        component.assertIsNotEnabled()
-    }
-
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -87,4 +87,28 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
     }
+
+    @Test
+    fun testReadOnlyMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performTextInput("Test")
+        val componentEditable = composeTestRule.onNodeWithText(TEXT_FIELD, true)
+        componentEditable.assertDoesNotExist()
+    }
+
+    @Test
+    fun testEnabledMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performClick()
+        component.assertIsNotEnabled()
+    }
+
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -39,6 +39,7 @@ import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.V2DemoActivity
 import com.microsoft.fluentuidemo.util.DemoAppStrings
 import com.microsoft.fluentuidemo.util.getDemoAppString
+import java.io.Console
 
 // Tags used for testing
 const val TEXT_FIELD_MODIFIABLE_PARAMETER_SECTION = "textFieldModifiableParameterSection"
@@ -49,6 +50,8 @@ const val TEXT_FIELD_ASSISTIVE_TEXT_PARAM = "textFieldAssistiveTextParam"
 const val TEXT_FIELD_SECONDARY_TEXT_PARAM = "textFieldSecondaryTextParam"
 const val TEXT_FIELD_ERROR_PARAM = "textFieldErrorTextParam"
 const val TEXT_FIELD_PASSWORD_MODE_PARAM = "textFieldPasswordModeParam"
+const val TEXT_FIELD_READONLY_PARAM = "textFieldReadOnlyParam"
+const val TEXT_FIELD_ENABLED_PARAM = "textFieldEnabledParam"
 
 
 class V2TextFieldActivity : V2DemoActivity() {
@@ -73,6 +76,8 @@ class V2TextFieldActivity : V2DemoActivity() {
             var errorText by rememberSaveable { mutableStateOf(false) }
             var passwordMode by rememberSaveable { mutableStateOf(false) }
             var keyboardType by remember { mutableStateOf(KeyboardType.Text) }
+            var readOnly by rememberSaveable { mutableStateOf(false) }
+            var enabled by rememberSaveable { mutableStateOf(true) }
 
             val resources = LocalContext.current.resources
 
@@ -278,6 +283,42 @@ class V2TextFieldActivity : V2DemoActivity() {
                                     }
                                 )
                             }
+                            item {
+                                ListItem.Item(
+                                    text = "Read Only",
+                                    subText = if (readOnly)
+                                        "Enabled"
+                                    else
+                                        "Disabled",
+                                    trailingAccessoryContent = {
+                                        ToggleSwitch(
+                                            modifier = Modifier.testTag(TEXT_FIELD_READONLY_PARAM),
+                                            onValueChange = {
+                                                readOnly = it
+                                            },
+                                            checkedState = readOnly
+                                        )
+                                    }
+                                )
+                            }
+                            item {
+                                ListItem.Item(
+                                    text = "Enabled",
+                                    subText = if (enabled)
+                                        "Enabled"
+                                    else
+                                        "Disabled",
+                                    trailingAccessoryContent = {
+                                        ToggleSwitch(
+                                            modifier = Modifier.testTag(TEXT_FIELD_ENABLED_PARAM),
+                                            onValueChange = {
+                                                enabled = it
+                                            },
+                                            checkedState = enabled
+                                        )
+                                    }
+                                )
+                            }
                         }
                     }
 
@@ -290,6 +331,8 @@ class V2TextFieldActivity : V2DemoActivity() {
                         TextField(
                             value,
                             { value = it },
+                            readOnly = readOnly,
+                            enabled = enabled,
                             hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
                             label = if (label) resources.getString(R.string.fluentui_label) else null,
                             assistiveText = if (assistiveText) resources.getString(R.string.fluentui_assistive_text) else null,
@@ -304,8 +347,6 @@ class V2TextFieldActivity : V2DemoActivity() {
                             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                             keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
                             visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None,
-                            readOnly = false,
-                            enabled = true,
                         )
                     }
                 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -88,7 +88,7 @@ class V2TextFieldActivity : V2DemoActivity() {
                         title = getDemoAppString(DemoAppStrings.ModifiableParameters),
                         enableChevron = true,
                         enableContentOpenCloseTransition = true,
-                        chevronOrientation = ChevronOrientation(90f, 0f),
+                        chevronOrientation = ChevronOrientation(90f, 0f)
                     ) {
                         LazyColumn(Modifier.fillMaxHeight(0.5F)) {
                             item {
@@ -346,7 +346,7 @@ class V2TextFieldActivity : V2DemoActivity() {
                             ),
                             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                             keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
-                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None,
+                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
                         )
                     }
                 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -303,7 +303,9 @@ class V2TextFieldActivity : V2DemoActivity() {
                             ),
                             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                             keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
-                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
+                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None,
+                            readOnly = false,
+                            enabled = true,
                         )
                     }
                 }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -106,7 +106,9 @@ fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textFieldContentDescription: String? = null,
     decorationBox: (@Composable (innerTextField: @Composable () -> Unit) -> Unit)? = null,
-    textFieldTokens: TextFieldTokens? = null
+    textFieldTokens: TextFieldTokens? = null,
+    readOnly: Boolean = false,
+    enabled: Boolean = true
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -214,7 +216,9 @@ fun TextField(
                                 textDirection = TextDirection.ContentOrLtr
                             )
                         ),
-                        cursorBrush = token.cursorColor(textFieldInfo)
+                        cursorBrush = token.cursorColor(textFieldInfo),
+                        readOnly = readOnly,
+                        enabled = enabled,
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -89,6 +89,8 @@ fun TextField(
     value: String,
     onValueChange: ((String) -> Unit),
     modifier: Modifier = Modifier,
+    readOnly: Boolean = false,
+    enabled: Boolean = true,
     hintText: String? = null,
     label: String? = null,
     assistiveText: String? = null,
@@ -107,8 +109,6 @@ fun TextField(
     textFieldContentDescription: String? = null,
     decorationBox: (@Composable (innerTextField: @Composable () -> Unit) -> Unit)? = null,
     textFieldTokens: TextFieldTokens? = null,
-    readOnly: Boolean = false,
-    enabled: Boolean = true
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -183,6 +183,8 @@ fun TextField(
                                         isFocused = true
                                 }
                             },
+                        readOnly = readOnly,
+                        enabled = enabled,
                         singleLine = true,
                         keyboardOptions = keyboardOptions,
                         keyboardActions = keyboardActions,
@@ -217,8 +219,6 @@ fun TextField(
                             )
                         ),
                         cursorBrush = token.cursorColor(textFieldInfo),
-                        readOnly = readOnly,
-                        enabled = enabled,
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -108,7 +108,7 @@ fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textFieldContentDescription: String? = null,
     decorationBox: (@Composable (innerTextField: @Composable () -> Unit) -> Unit)? = null,
-    textFieldTokens: TextFieldTokens? = null,
+    textFieldTokens: TextFieldTokens? = null
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -218,7 +218,7 @@ fun TextField(
                                 textDirection = TextDirection.ContentOrLtr
                             )
                         ),
-                        cursorBrush = token.cursorColor(textFieldInfo),
+                        cursorBrush = token.cursorColor(textFieldInfo)
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))


### PR DESCRIPTION
### Problem 
readOnly and enabled params not working for Fluent TextField
### Root cause 
These params were not passed, and BasicTextField was picking their default values (enabled = true, readOnly = false)
### Fix
TextField accepts these params, and passes them accordingly to its BasicTextField.


### Validations
(Manually tested)
Tested 2 scenarios  on demoUI app by passing 
Scenario 1) readOnly = true
Result BasicTextField was not editable, however the field was coming in focus on click

Scenario 2) enabled = false
Result BasicTextField was not editable as well field was not coming in focus on click.

(how the change was tested, including both manual and automated tests)

### Screenshots
Before: 
![image](https://github.com/microsoft/fluentui-android/assets/68989156/ab94888d-59d3-4fcd-90f1-143350c2497a)

After
Added 2 toggles for readOnly and Enabled:
![image](https://github.com/microsoft/fluentui-android/assets/68989156/768440f2-2279-43b6-8c51-e61c81ec37a1)


Scenario 1) readOnly = true
(not able to write anything in the textField)
![image](https://github.com/microsoft/fluentui-android/assets/68989156/731be99f-738f-448d-906e-bbd810bd9e37)

Scenario 2)  enabled = false
(not coming in focus on click)
![image](https://github.com/microsoft/fluentui-android/assets/68989156/afea3ac8-3efa-4f28-9966-bef6dad98803)

| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
