### PR TITLE
Bottom Drawer PopUp Update

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
@@ -3,7 +3,6 @@ package com.microsoft.fluentuidemo.demos
 import android.content.res.Resources
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -15,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_CONTENT_TAG
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_HANDLE_TAG
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_SCRIM_TAG
-import com.microsoft.fluentui.tokenized.notification.SNACK_BAR_ICON
 import com.microsoft.fluentuidemo.BaseTest
 import com.microsoft.fluentuidemo.R
 import org.junit.Before

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
@@ -31,12 +31,14 @@ class V2BottomDrawerUITest : BaseTest() {
     private val drawerScrim = composeTestRule.onNodeWithTag(DRAWER_SCRIM_TAG)
 
     private fun openCheckForVerticalDrawer() {
+        composeTestRule.waitForIdle()
         drawerHandle.assertExists("Drawer Handle not shown")
         drawerContent.assertExists("Drawer Content not shown")
         drawerScrim.assertExists("Drawer Scrim not shown")
     }
 
     private fun closeCheckForVerticalDrawer() {
+        composeTestRule.waitForIdle()
         drawerHandle.assertDoesNotExist()
         drawerScrim.assertDoesNotExist()
         drawerContent.assertDoesNotExist()
@@ -57,13 +59,13 @@ class V2BottomDrawerUITest : BaseTest() {
 
         val scrimEnd = drawerHandle.fetchSemanticsNode().positionInRoot.y.toInt()
 
-        //Click on drawer should not close it.
+        //Click on scrim covered by drawer should not close it.
         drawerScrim.performTouchInput {
             click(Offset((0..width).random().toFloat(), (scrimEnd..height).random().toFloat()))
         }
         openCheckForVerticalDrawer()
 
-        //Click on scrim should close it.
+        //Click on scrim not covered by drawer should close it.
         drawerScrim.performTouchInput {
             click(Offset((0..width).random().toFloat(), (0..scrimEnd).random().toFloat()))
         }
@@ -82,7 +84,6 @@ class V2BottomDrawerUITest : BaseTest() {
         //SwipeDown on drawerHandle should close it.
         drawerHandle.performTouchInput {
             swipeDown(
-                startY = drawerHandle.fetchSemanticsNode().positionInRoot.y,
                 endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
             )
         }
@@ -100,7 +101,7 @@ class V2BottomDrawerUITest : BaseTest() {
 
         val drawerStart = drawerHandle.fetchSemanticsNode().positionInRoot.y.toInt()
 
-        //SwipeDown on drawerContent should close it.
+        //SwipeDown on scrollable drawerContent should close it.
 
         val swipeEnd = drawerScrim.fetchSemanticsNode().size.height
         val swipeStart = (drawerStart..((swipeEnd + drawerStart) / 2)).random()
@@ -131,7 +132,6 @@ class V2BottomDrawerUITest : BaseTest() {
         //SwipeDown of drawerHandle to bottom should close it.
         drawerHandle.performTouchInput {
             swipeDown(
-                startY = drawerHandle.fetchSemanticsNode().positionInRoot.y,
                 endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
             )
         }
@@ -150,11 +150,9 @@ class V2BottomDrawerUITest : BaseTest() {
         //SwipeDown a little should not close the drawer
         drawerHandle.performTouchInput {
             swipeDown(
-                startY = drawerHandle.fetchSemanticsNode().positionInRoot.y,
-                endY = drawerHandle.fetchSemanticsNode().positionInRoot.y + (0..dpToPx(26.dp).toInt()).random()
+                endY = top + (0..dpToPx(26.dp).toInt()).random()
             )
         }
-        composeTestRule.waitForIdle()
         openCheckForVerticalDrawer()
 
     }
@@ -171,7 +169,6 @@ class V2BottomDrawerUITest : BaseTest() {
         //SwipeDown on drawerHandle should close it.
         drawerHandle.performTouchInput {
             swipeDown(
-                startY = drawerHandle.fetchSemanticsNode().positionInRoot.y,
                 endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
             )
         }
@@ -193,10 +190,7 @@ class V2BottomDrawerUITest : BaseTest() {
 
         //SwipeDown on drawerContent should close it.
         drawerContent.performTouchInput {
-            swipeDown(
-                startY = drawerContent.fetchSemanticsNode().positionInRoot.y,
-                endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
-            )
+            swipeDown()
         }
         closeCheckForVerticalDrawer()
     }
@@ -213,11 +207,10 @@ class V2BottomDrawerUITest : BaseTest() {
         //SwipeDown on drawerHandle should close it.
         drawerHandle.performTouchInput {
             swipeDown(
-                startY = drawerHandle.fetchSemanticsNode().positionInRoot.y,
                 endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
             )
         }
-
+        closeCheckForVerticalDrawer()
     }
 
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
@@ -3,6 +3,7 @@ package com.microsoft.fluentuidemo.demos
 import android.content.res.Resources
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -14,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_CONTENT_TAG
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_HANDLE_TAG
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_SCRIM_TAG
+import com.microsoft.fluentui.tokenized.notification.SNACK_BAR_ICON
 import com.microsoft.fluentuidemo.BaseTest
 import com.microsoft.fluentuidemo.R
 import org.junit.Before
@@ -205,6 +207,11 @@ class V2BottomDrawerUITest : BaseTest() {
         composeTestRule.onNodeWithText(getString(R.string.drawer_open)).performClick()
         composeTestRule.onNodeWithText(getString(R.string.drawer_open)).performClick()
         //SwipeDown on drawerHandle should close it.
+        drawerHandle.performTouchInput {
+            swipeDown(
+                endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
+            )
+        }
         drawerHandle.performTouchInput {
             swipeDown(
                 endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
@@ -1,0 +1,213 @@
+package com.microsoft.fluentui.compose
+
+import android.content.Context
+import android.graphics.PixelFormat
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.WindowManager
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewRootForInspector
+import androidx.compose.ui.semantics.popup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.ViewTreeViewModelStoreOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import java.util.UUID
+import kotlin.math.roundToInt
+
+/**
+ * Popup specific for modal bottom drawer.
+ */
+@Composable
+fun ModalPopup(
+    onDismissRequest: () -> Unit,
+    windowInsets: WindowInsets,
+    content: @Composable () -> Unit,
+) {
+    val view = LocalView.current
+    val id = rememberSaveable { UUID.randomUUID() }
+    val parentComposition = rememberCompositionContext()
+    val currentContent by rememberUpdatedState(content)
+    val layoutDirection = LocalLayoutDirection.current
+    val modalWindow = remember {
+        ModalWindow(
+            onDismissRequest = onDismissRequest,
+            composeView = view,
+            saveId = id
+        ).apply {
+            setCustomContent(
+                parent = parentComposition,
+                content = {
+                    Box(
+                        Modifier
+                            .semantics { this.popup() }
+                            .windowInsetsPadding(windowInsets)
+                            .imePadding()
+                    ) {
+                        currentContent()
+                    }
+                }
+            )
+        }
+    }
+
+    DisposableEffect(modalWindow) {
+        modalWindow.show()
+        modalWindow.superSetLayoutDirection(layoutDirection)
+        onDispose {
+            modalWindow.disposeComposition()
+            modalWindow.dismiss()
+        }
+    }
+}
+
+/** Custom compose view for [BottomDrawer] */
+private class ModalWindow(
+    private var onDismissRequest: () -> Unit,
+    private val composeView: View,
+    saveId: UUID,
+) :
+    AbstractComposeView(composeView.context),
+    ViewTreeObserver.OnGlobalLayoutListener,
+    ViewRootForInspector {
+    init {
+        id = android.R.id.content
+        // Set up view owners
+        ViewTreeLifecycleOwner.set(this, ViewTreeLifecycleOwner.get(composeView))
+        ViewTreeViewModelStoreOwner.set(this, ViewTreeViewModelStoreOwner.get(composeView))
+        setViewTreeSavedStateRegistryOwner(composeView.findViewTreeSavedStateRegistryOwner())
+        setTag(androidx.compose.ui.R.id.compose_view_saveable_id_tag, "Popup:$saveId")
+        // Enable children to draw their shadow by not clipping them
+        clipChildren = false
+    }
+
+    private val windowManager =
+        composeView.context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+    private val displayWidth: Int
+        get() {
+            val density = context.resources.displayMetrics.density
+            return (context.resources.configuration.screenWidthDp * density).roundToInt()
+        }
+
+    private val params: WindowManager.LayoutParams =
+        WindowManager.LayoutParams().apply {
+            // Position bottom sheet from the bottom of the screen
+            gravity = Gravity.BOTTOM or Gravity.START
+            // Application panel window
+            type = WindowManager.LayoutParams.TYPE_APPLICATION_PANEL
+            // Fill up the entire app view
+            width = displayWidth
+            height = WindowManager.LayoutParams.MATCH_PARENT
+
+            // Format of screen pixels
+            format = PixelFormat.TRANSLUCENT
+            // Title used as fallback for a11y services
+            // TODO: Provide bottom sheet window resource
+            title = composeView.context.resources.getString(
+                androidx.compose.ui.R.string.default_popup_window_title
+            )
+            // Get the Window token from the parent view
+            token = composeView.applicationWindowToken
+
+            // Flags specific to modal bottom sheet.
+            flags = flags and (
+                    WindowManager.LayoutParams.FLAG_IGNORE_CHEEK_PRESSES or
+                            WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
+                    ).inv()
+
+            flags = flags or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+        }
+
+    private var content: @Composable () -> Unit by mutableStateOf({})
+
+    override var shouldCreateCompositionOnAttachedToWindow: Boolean = false
+        private set
+
+    @Composable
+    override fun Content() {
+        content()
+    }
+
+    fun setCustomContent(
+        parent: CompositionContext? = null,
+        content: @Composable () -> Unit
+    ) {
+        parent?.let { setParentCompositionContext(it) }
+        this.content = content
+        shouldCreateCompositionOnAttachedToWindow = true
+    }
+
+    fun show() {
+        windowManager.addView(this, params)
+    }
+
+    fun dismiss() {
+        ViewTreeLifecycleOwner.set(this, null)
+        setViewTreeSavedStateRegistryOwner(null)
+        composeView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+        windowManager.removeViewImmediate(this)
+    }
+
+    /**
+     * Taken from PopupWindow. Calls [onDismissRequest] when back button is pressed.
+     */
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (event.keyCode == KeyEvent.KEYCODE_BACK) {
+            if (keyDispatcherState == null) {
+                return super.dispatchKeyEvent(event)
+            }
+            if (event.action == KeyEvent.ACTION_DOWN && event.repeatCount == 0) {
+                val state = keyDispatcherState
+                state?.startTracking(event, this)
+                return true
+            } else if (event.action == KeyEvent.ACTION_UP) {
+                val state = keyDispatcherState
+                if (state != null && state.isTracking(event) && !event.isCanceled) {
+                    onDismissRequest()
+                    return true
+                }
+            }
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    override fun onGlobalLayout() {
+        // No-op
+    }
+
+    override fun setLayoutDirection(layoutDirection: Int) {
+        // Do nothing. ViewRootImpl will call this method attempting to set the layout direction
+        // from the context's locale, but we have one already from the parent composition.
+    }
+
+    // Sets the "real" layout direction for our content that we obtain from the parent composition.
+    fun superSetLayoutDirection(layoutDirection: LayoutDirection) {
+        val direction = when (layoutDirection) {
+            LayoutDirection.Ltr -> android.util.LayoutDirection.LTR
+            LayoutDirection.Rtl -> android.util.LayoutDirection.RTL
+        }
+        super.setLayoutDirection(direction)
+    }
+}

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -910,6 +910,7 @@ fun Drawer(
  * The default value is true
  * @param scrimVisible create obscures background when scrim visible set to true when the drawer is open. The default value is true
  * @param showHandle if true drawer handle would be visible. The default value is true
+ * @param windowInsets window insets to be passed to the bottom drawer window via PaddingValues params.
  * @param drawerTokens tokens to provide appearance values. If not provided then drawer tokens will be picked from [FluentTheme]
  * @param drawerContent composable that represents content inside the drawer
  *
@@ -924,6 +925,7 @@ fun BottomDrawer(
     expandable: Boolean = true,
     scrimVisible: Boolean = true,
     showHandle: Boolean = true,
+    windowInsets: WindowInsets = WindowInsets.systemBars,
     drawerTokens: DrawerTokens? = null,
     drawerContent: @Composable () -> Unit
 ) {
@@ -933,7 +935,6 @@ fun BottomDrawer(
         val tokens = drawerTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.DrawerControlType] as DrawerTokens
 
-        val popupPositionProvider = DrawerPositionProvider()
         val scope = rememberCoroutineScope()
         val close: () -> Unit = {
             if (drawerState.confirmStateChange(DrawerValue.Closed)) {
@@ -943,10 +944,9 @@ fun BottomDrawer(
         val behaviorType =
             if (slideOver) BehaviorType.BOTTOM_SLIDE_OVER else BehaviorType.BOTTOM
         val drawerInfo = DrawerInfo(type = behaviorType)
-        Popup(
+        ModalPopup(
             onDismissRequest = close,
-            popupPositionProvider = popupPositionProvider,
-            properties = PopupProperties(focusable = true)
+            windowInsets = windowInsets
         )
         {
             val drawerShape: Shape =


### PR DESCRIPTION
### Problem 
Popup Layer for BottomDrawer is not compatible with IME
### Root cause 
Popup Layer contains window flag which is not suitable with IME
### Fix
Use ModalPopUp in BottomDrawer which has window flag set to work with IME.

### Validations

both manual and automated tests

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
