### PR TITLE
Add enabled and read only parms in text field controls

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -87,28 +87,4 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
     }
-
-    @Test
-    fun testReadOnlyMode(){
-        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
-        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
-        modifiableParametersButton.performClick()
-        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
-        toggleControlToValue(control, true)
-        component.performTextInput("Test")
-        val componentEditable = composeTestRule.onNodeWithText(TEXT_FIELD, true)
-        componentEditable.assertDoesNotExist()
-    }
-
-    @Test
-    fun testEnabledMode(){
-        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
-        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
-        modifiableParametersButton.performClick()
-        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
-        toggleControlToValue(control, true)
-        component.performClick()
-        component.assertIsNotEnabled()
-    }
-
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -1,8 +1,13 @@
 package com.microsoft.fluentuidemo.demos
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.*
 import com.microsoft.fluentui.tokenized.controls.*
 import com.microsoft.fluentuidemo.BaseTest
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotSame
+import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
 
@@ -86,5 +91,33 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.assertExists("Text field did not render properly")
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
+    }
+    @Test
+    fun testReadOnlyMode() {
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        component.assertExists("Text field did not render properly")
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performClick()
+        component.assertIsFocused()
+        try {
+            component.performTextInput("Test")
+            fail("Text field should not be editable")
+        } catch (e: Exception) {
+            //Test passed as exception was thrown
+        }
+    }
+
+    @Test
+    fun testEnabledMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        component.assertExists("Text field did not render properly")
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, false)
+        component.assertIsNotEnabled()
     }
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -87,4 +87,28 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
     }
+
+    @Test
+    fun testReadOnlyMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performTextInput("Test")
+        val componentEditable = composeTestRule.onNodeWithText(TEXT_FIELD, true)
+        componentEditable.assertDoesNotExist()
+    }
+
+    @Test
+    fun testEnabledMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performClick()
+        component.assertIsNotEnabled()
+    }
+
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -39,6 +39,7 @@ import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.V2DemoActivity
 import com.microsoft.fluentuidemo.util.DemoAppStrings
 import com.microsoft.fluentuidemo.util.getDemoAppString
+import java.io.Console
 
 // Tags used for testing
 const val TEXT_FIELD_MODIFIABLE_PARAMETER_SECTION = "textFieldModifiableParameterSection"
@@ -49,6 +50,8 @@ const val TEXT_FIELD_ASSISTIVE_TEXT_PARAM = "textFieldAssistiveTextParam"
 const val TEXT_FIELD_SECONDARY_TEXT_PARAM = "textFieldSecondaryTextParam"
 const val TEXT_FIELD_ERROR_PARAM = "textFieldErrorTextParam"
 const val TEXT_FIELD_PASSWORD_MODE_PARAM = "textFieldPasswordModeParam"
+const val TEXT_FIELD_READONLY_PARAM = "textFieldReadOnlyParam"
+const val TEXT_FIELD_ENABLED_PARAM = "textFieldEnabledParam"
 
 
 class V2TextFieldActivity : V2DemoActivity() {
@@ -73,6 +76,8 @@ class V2TextFieldActivity : V2DemoActivity() {
             var errorText by rememberSaveable { mutableStateOf(false) }
             var passwordMode by rememberSaveable { mutableStateOf(false) }
             var keyboardType by remember { mutableStateOf(KeyboardType.Text) }
+            var readOnly by rememberSaveable { mutableStateOf(false) }
+            var enabled by rememberSaveable { mutableStateOf(true) }
 
             val resources = LocalContext.current.resources
 
@@ -278,6 +283,42 @@ class V2TextFieldActivity : V2DemoActivity() {
                                     }
                                 )
                             }
+                            item {
+                                ListItem.Item(
+                                    text = "Read Only",
+                                    subText = if (readOnly)
+                                        "Enabled"
+                                    else
+                                        "Disabled",
+                                    trailingAccessoryContent = {
+                                        ToggleSwitch(
+                                            modifier = Modifier.testTag(TEXT_FIELD_READONLY_PARAM),
+                                            onValueChange = {
+                                                readOnly = it
+                                            },
+                                            checkedState = readOnly
+                                        )
+                                    }
+                                )
+                            }
+                            item {
+                                ListItem.Item(
+                                    text = "Enabled",
+                                    subText = if (enabled)
+                                        "Enabled"
+                                    else
+                                        "Disabled",
+                                    trailingAccessoryContent = {
+                                        ToggleSwitch(
+                                            modifier = Modifier.testTag(TEXT_FIELD_ENABLED_PARAM),
+                                            onValueChange = {
+                                                enabled = it
+                                            },
+                                            checkedState = enabled
+                                        )
+                                    }
+                                )
+                            }
                         }
                     }
 
@@ -290,6 +331,8 @@ class V2TextFieldActivity : V2DemoActivity() {
                         TextField(
                             value,
                             { value = it },
+                            readOnly = readOnly,
+                            enabled = enabled,
                             hintText = if (hintText) resources.getString(R.string.fluentui_hint) else null,
                             label = if (label) resources.getString(R.string.fluentui_label) else null,
                             assistiveText = if (assistiveText) resources.getString(R.string.fluentui_assistive_text) else null,
@@ -304,8 +347,6 @@ class V2TextFieldActivity : V2DemoActivity() {
                             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                             keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
                             visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None,
-                            readOnly = false,
-                            enabled = true,
                         )
                     }
                 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -88,7 +88,7 @@ class V2TextFieldActivity : V2DemoActivity() {
                         title = getDemoAppString(DemoAppStrings.ModifiableParameters),
                         enableChevron = true,
                         enableContentOpenCloseTransition = true,
-                        chevronOrientation = ChevronOrientation(90f, 0f),
+                        chevronOrientation = ChevronOrientation(90f, 0f)
                     ) {
                         LazyColumn(Modifier.fillMaxHeight(0.5F)) {
                             item {
@@ -346,7 +346,7 @@ class V2TextFieldActivity : V2DemoActivity() {
                             ),
                             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                             keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
-                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None,
+                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
                         )
                     }
                 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivity.kt
@@ -303,7 +303,9 @@ class V2TextFieldActivity : V2DemoActivity() {
                             ),
                             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                             keyboardActions = KeyboardActions(onAny = { focusManager.clearFocus() }),
-                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None
+                            visualTransformation = if (passwordMode) PasswordVisualTransformation() else VisualTransformation.None,
+                            readOnly = false,
+                            enabled = true,
                         )
                     }
                 }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -106,7 +106,9 @@ fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textFieldContentDescription: String? = null,
     decorationBox: (@Composable (innerTextField: @Composable () -> Unit) -> Unit)? = null,
-    textFieldTokens: TextFieldTokens? = null
+    textFieldTokens: TextFieldTokens? = null,
+    readOnly: Boolean = false,
+    enabled: Boolean = true
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -214,7 +216,9 @@ fun TextField(
                                 textDirection = TextDirection.ContentOrLtr
                             )
                         ),
-                        cursorBrush = token.cursorColor(textFieldInfo)
+                        cursorBrush = token.cursorColor(textFieldInfo),
+                        readOnly = readOnly,
+                        enabled = enabled,
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -89,6 +89,8 @@ fun TextField(
     value: String,
     onValueChange: ((String) -> Unit),
     modifier: Modifier = Modifier,
+    readOnly: Boolean = false,
+    enabled: Boolean = true,
     hintText: String? = null,
     label: String? = null,
     assistiveText: String? = null,
@@ -107,8 +109,6 @@ fun TextField(
     textFieldContentDescription: String? = null,
     decorationBox: (@Composable (innerTextField: @Composable () -> Unit) -> Unit)? = null,
     textFieldTokens: TextFieldTokens? = null,
-    readOnly: Boolean = false,
-    enabled: Boolean = true
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -183,6 +183,8 @@ fun TextField(
                                         isFocused = true
                                 }
                             },
+                        readOnly = readOnly,
+                        enabled = enabled,
                         singleLine = true,
                         keyboardOptions = keyboardOptions,
                         keyboardActions = keyboardActions,
@@ -217,8 +219,6 @@ fun TextField(
                             )
                         ),
                         cursorBrush = token.cursorColor(textFieldInfo),
-                        readOnly = readOnly,
-                        enabled = enabled,
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -108,7 +108,7 @@ fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textFieldContentDescription: String? = null,
     decorationBox: (@Composable (innerTextField: @Composable () -> Unit) -> Unit)? = null,
-    textFieldTokens: TextFieldTokens? = null,
+    textFieldTokens: TextFieldTokens? = null
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -218,7 +218,7 @@ fun TextField(
                                 textDirection = TextDirection.ContentOrLtr
                             )
                         ),
-                        cursorBrush = token.cursorColor(textFieldInfo),
+                        cursorBrush = token.cursorColor(textFieldInfo)
                     )
                     if (!trailingAccessoryText.isNullOrBlank()) {
                         Spacer(Modifier.requiredWidth(8.dp))


### PR DESCRIPTION
### Problem 
Test cases were missing
### Root cause 

### Fix
Added test cases and they are passing the test

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
