### PR TITLE
Added test cases for readOnly and enabled params for TextField

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -3,6 +3,7 @@ package com.microsoft.fluentuidemo.demos
 import androidx.compose.ui.test.*
 import com.microsoft.fluentui.tokenized.controls.*
 import com.microsoft.fluentuidemo.BaseTest
+import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
 
@@ -86,5 +87,33 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.assertExists("Text field did not render properly")
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
+    }
+    @Test
+    fun testReadOnlyMode() {
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        component.assertExists("Text field did not render properly")
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performClick()
+        component.assertIsFocused()
+        try {
+            component.performTextInput("Test")
+            fail("Text field should not be editable")
+        } catch (e: Exception) {
+            //Test passed as exception was thrown
+        }
+    }
+
+    @Test
+    fun testEnabledMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        component.assertExists("Text field did not render properly")
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, false)
+        component.assertIsNotEnabled()
     }
 }


### PR DESCRIPTION
### Problem 

### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
