### PR TITLE
Fix for Rtl enable left side align list item content builder bug [Don't Merge]

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -3,6 +3,7 @@ package com.microsoft.fluentuidemo.demos
 import androidx.compose.ui.test.*
 import com.microsoft.fluentui.tokenized.controls.*
 import com.microsoft.fluentuidemo.BaseTest
+import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
 
@@ -86,5 +87,33 @@ class V2TextFieldActivityUITest : BaseTest() {
         component.assertExists("Text field did not render properly")
         component.performTextInput("Test")
         component.assertExists("Password mode did not render properly")
+    }
+    @Test
+    fun testReadOnlyMode() {
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_READONLY_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        component.assertExists("Text field did not render properly")
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, true)
+        component.performClick()
+        component.assertIsFocused()
+        try {
+            component.performTextInput("Test")
+            fail("Text field should not be editable")
+        } catch (e: Exception) {
+            //Test passed as exception was thrown
+        }
+    }
+
+    @Test
+    fun testEnabledMode(){
+        val control = composeTestRule.onNodeWithTag(TEXT_FIELD_ENABLED_PARAM)
+        val component = composeTestRule.onNodeWithTag(TEXT_FIELD, true)
+        component.assertExists("Text field did not render properly")
+        modifiableParametersButton.performClick()
+        modifiableParametersButton.performTouchInput { swipeUp(durationMillis = 1000) }
+        toggleControlToValue(control, false)
+        component.assertIsNotEnabled()
     }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -1,5 +1,4 @@
 package com.microsoft.fluentui.tokenized.contentBuilder
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,7 +9,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
@@ -117,7 +118,7 @@ class ListContentBuilder {
         //TODO As per the thread https://issuetracker.google.com/issues/184670295#comment34 focus
         // navigation issues should resolve with compose version 1.3.0.
         return {
-            LazyColumn {
+            LazyColumn{
                 for (contentData in listOfContentData) {
                     when (contentData) {
                         is HorizontalListContentData -> createHorizontalList(
@@ -248,7 +249,9 @@ class ListContentBuilder {
                     tabItemTokens
                         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabItemControlType] as TabItemTokens
                 LazyRow(
-                    state = rowLazyListState, modifier = Modifier
+                    reverseLayout = (LocalLayoutDirection.current == LayoutDirection.Rtl),
+                    state = rowLazyListState,
+                    modifier = Modifier
                         .background(
                             token.backgroundBrush(
                                 TabItemInfo(
@@ -262,7 +265,7 @@ class ListContentBuilder {
                 ) {
                     itemsIndexed(itemDataList) { index, item ->
                         TabItem(
-                            title = item.title,
+                            title = "${item.title} $index",
                             enabled = item.enabled,
                             fixedWidth = fixedWidth,
                             onClick = item.onClick,


### PR DESCRIPTION
**[ Don't merge, the Kotlin upgrade fixes the issue without any new changes ]**

### Problem 
Horizontal items were not getting right aligned when RTL enabled
### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  | Screenshot or description with this change |
![Screenshot_2023-08-18-14-10-36-42_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/de0d84e5-f303-452e-b75a-3e904662bce3) |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
