### PR TITLE
Change width to match parent to cover whole screen.

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
@@ -3,6 +3,7 @@ package com.microsoft.fluentuidemo.demos
 import android.content.res.Resources
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -14,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_CONTENT_TAG
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_HANDLE_TAG
 import com.microsoft.fluentui.tokenized.drawer.DRAWER_SCRIM_TAG
+import com.microsoft.fluentui.tokenized.notification.SNACK_BAR_ICON
 import com.microsoft.fluentuidemo.BaseTest
 import com.microsoft.fluentuidemo.R
 import org.junit.Before
@@ -210,12 +212,16 @@ class V2BottomDrawerUITest : BaseTest() {
                 endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
             )
         }
-        drawerHandle.performTouchInput {
-            swipeDown(
-                endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
-            )
+        composeTestRule.waitForIdle()
+        if (composeTestRule.onAllNodesWithTag(DRAWER_HANDLE_TAG).fetchSemanticsNodes()
+                .isNotEmpty()
+        ) {
+            drawerHandle.performTouchInput {
+                swipeDown(
+                    endY = drawerScrim.fetchSemanticsNode().size.height.toFloat()
+                )
+            }
         }
         closeCheckForVerticalDrawer()
     }
-
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
@@ -105,11 +105,6 @@ private class ModalWindow(
     private val windowManager =
         composeView.context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 
-    private val displayWidth: Int
-        get() {
-            val density = context.resources.displayMetrics.density
-            return (context.resources.configuration.screenWidthDp * density).roundToInt()
-        }
 
     private val params: WindowManager.LayoutParams =
         WindowManager.LayoutParams().apply {
@@ -118,7 +113,7 @@ private class ModalWindow(
             // Application panel window
             type = WindowManager.LayoutParams.TYPE_APPLICATION_PANEL
             // Fill up the entire app view
-            width = displayWidth
+            width = WindowManager.LayoutParams.MATCH_PARENT
             height = WindowManager.LayoutParams.MATCH_PARENT
 
             // Format of screen pixels

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -286,7 +286,7 @@ private fun Modifier.bottomDrawerSwipeable(
             val minHeight = 0f
             val bottomOpenStateY = max(maxOpenHeight, fullHeight - drawerHeight)
             val bottomExpandedStateY = max(minHeight, fullHeight - drawerHeight)
-            val anchors = if (drawerHeight < bottomOpenStateY || !expandable) {
+            val anchors = if (drawerHeight <= maxOpenHeight || !expandable) {
                 mapOf(
                     fullHeight to DrawerValue.Closed,
                     bottomOpenStateY to DrawerValue.Open


### PR DESCRIPTION
### Problem 
When activity did not recreate on orientation change then on orientation change drawer width did change on rotation. Hence did not cover the screen end-to-end when screen goes from portrait to landscape
### Root cause 
ModalPopUp width was not using width as match parent

### Fix

Update width to match parent for ModalPopUp

### Validations

 manual

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
