### PR TITLE
Use alpha to hide the ModalPopUp Layer till position is not calculated

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,12 +23,15 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.ViewRootForInspector
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.ViewTreeViewModelStoreOwner
@@ -62,6 +66,12 @@ fun ModalPopup(
                     Box(
                         Modifier
                             .semantics { this.popup() }
+                            // Get the size of the content
+                            .onSizeChanged {
+                                popupContentSize = it
+                            }
+                            // Hide the popup while we can't position it correctly
+                            .alpha(if (canCalculatePosition) 1f else 0f)
                             .windowInsetsPadding(windowInsets)
                             .imePadding()
                     ) {
@@ -91,6 +101,10 @@ private class ModalWindow(
     AbstractComposeView(composeView.context),
     ViewTreeObserver.OnGlobalLayoutListener,
     ViewRootForInspector {
+    var popupContentSize: IntSize? by mutableStateOf(null)
+    val canCalculatePosition by derivedStateOf {
+        popupContentSize != null
+    }
     init {
         id = android.R.id.content
         // Set up view owners


### PR DESCRIPTION
### Problem 
ModalPopUp layer used in BottomDrawer API. When BottomDrawer launched first time. The BottomDrawer content show up at top briefly which create a flicker effect.

### Root cause
ModalPopUp layer content repositioned on later re-composition. Hence creating a flicker effect. 

### Fix
Set alpha to 0f till position is not calculated.


### Validations

manual

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  https://github.com/microsoft/fluentui-android/assets/97503451/314f5c25-263c-4c48-af82-f842f28a5b99 | https://github.com/microsoft/fluentui-android/assets/97503451/099f01ee-5933-44bb-afd9-5c856f27a8e4 |





### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
