### PR TITLE
CardNudge: RTL issue for swiping left/right

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.LayoutDirection
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.FluentGlobalTokens
@@ -240,7 +242,7 @@ class V2CardNudgeActivity : V2DemoActivity() {
                 LocalContext.current.resources.getString(R.string.fluentui_left_swiped)
             val rightSwiped =
                 LocalContext.current.resources.getString(R.string.fluentui_right_swiped)
-
+            val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
             Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
                 Box(
                     Modifier
@@ -261,7 +263,11 @@ class V2CardNudgeActivity : V2DemoActivity() {
                             .padding(horizontal = FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size160)),
                         style = FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Body1Strong].merge(
                             TextStyle(
-                                textAlign = if (swipeAmount > 0) TextAlign.Left else TextAlign.Right,
+                                textAlign =
+                                if (swipeAmount > 0) {
+                                    if(!isRtl) TextAlign.Left else TextAlign.Right
+                                } else {
+                                    if(!isRtl) TextAlign.Right else TextAlign.Left },
                                 color = if (abs(swipeAmount) > 0.3)
                                     FluentTheme.aliasTokens.errorAndStatusColor[FluentAliasTokens.ErrorAndStatusColorTokens.WarningForeground1].value()
                                 else
@@ -297,13 +303,25 @@ class V2CardNudgeActivity : V2DemoActivity() {
                                 }
                             } else null,
                             leftSwipeGesture = {
-                                swipeRight = false
-                                swipeLeft = true
+                                if(!isRtl){
+                                    swipeRight = false
+                                    swipeLeft = true
+                                }
+                                else{
+                                    swipeRight = true
+                                    swipeLeft = false
+                                }
                                 swipeAmount = it
                             },
                             rightSwipeGesture = {
-                                swipeRight = true
-                                swipeLeft = false
+                                if(!isRtl) {
+                                    swipeRight = true
+                                    swipeLeft = false
+                                }
+                                else{
+                                    swipeRight = false
+                                    swipeLeft = true
+                                }
                                 swipeAmount = it
                             }
 

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -134,15 +134,9 @@ fun CardNudge(
         ) {
             LaunchedEffect(state.offset.value) {
                 if (state.offset.value > 0.1F) {
-                    when {
-                        isRtl -> metadata.rightSwipeGesture?.invoke(-state.offset.value / maxWidth) //negative value for RTL for aligning the "Hide" Text appropriately
-                        else -> metadata.rightSwipeGesture?.invoke(state.offset.value / maxWidth)
-                    }
+                    metadata.rightSwipeGesture?.invoke(state.offset.value / maxWidth)
                 } else if (state.offset.value < -0.1F) {
-                    when {
-                        isRtl -> metadata.leftSwipeGesture?.invoke(-state.offset.value / maxWidth)
-                        else -> metadata.leftSwipeGesture?.invoke(state.offset.value / maxWidth)
-                    }
+                    metadata.leftSwipeGesture?.invoke(state.offset.value / maxWidth)
                 }
             }
 

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -18,10 +18,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.compose.FractionalThreshold
 import com.microsoft.fluentui.compose.rememberSwipeableState
@@ -91,6 +93,7 @@ fun CardNudge(
     val cardNudgeInfo = CardNudgeInfo()
     val animationSpec = TweenSpec<Float>(durationMillis = 300)
     val state = rememberSwipeableState(initialValue = SwipeGesture.NONE, animationSpec) { true }
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 
     BoxWithConstraints {
         val maxWidth = constraints.maxWidth.toFloat()
@@ -122,6 +125,7 @@ fun CardNudge(
                         0F to SwipeGesture.NONE,
                         maxWidth to SwipeGesture.RIGHT
                     ),
+                    reverseDirection = isRtl,
                     thresholds = { _, _ -> FractionalThreshold(0.3F) },
                     orientation = Orientation.Horizontal,
                 )
@@ -130,9 +134,15 @@ fun CardNudge(
         ) {
             LaunchedEffect(state.offset.value) {
                 if (state.offset.value > 0.1F) {
-                    metadata.rightSwipeGesture?.invoke(state.offset.value / maxWidth)
+                    when {
+                        isRtl -> metadata.rightSwipeGesture?.invoke(-state.offset.value / maxWidth) //negative value for RTL for aligning the "Hide" Text appropriately
+                        else -> metadata.rightSwipeGesture?.invoke(state.offset.value / maxWidth)
+                    }
                 } else if (state.offset.value < -0.1F) {
-                    metadata.leftSwipeGesture?.invoke(state.offset.value / maxWidth)
+                    when {
+                        isRtl -> metadata.leftSwipeGesture?.invoke(-state.offset.value / maxWidth)
+                        else -> metadata.leftSwipeGesture?.invoke(state.offset.value / maxWidth)
+                    }
                 }
             }
 


### PR DESCRIPTION
### Problem 
Swiping animation was not following the direction of swipe action (left or right).
The background "hide" text was not aligned correctly in RTL
### Root cause 
ReverseDirection was defaulting to "false" in swipeable.
Also, positive/ negative value for "text".
### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots


| Before                                                        |  After                                                      |
|----------------------------------------------|--------------------------------------------|
| <img src="https://github.com/microsoft/fluentui-android/assets/68989156/8416512a-a392-4ca3-b950-7b065ff599f6" width="200"/> | <img src="https://github.com/microsoft/fluentui-android/assets/68989156/a576be3b-fbc4-4e62-84fc-55825cb554e3" width="200"/>|


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
