### PR TITLE
Verticle Lists inconsistent icon color bug fix

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.*
 import com.microsoft.fluentui.theme.token.FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1
 import com.microsoft.fluentui.theme.token.FluentAliasTokens.BrandForegroundColorTokens.BrandForegroundDisabled1
@@ -110,7 +111,10 @@ open class ListItemTokens : IControlToken, Parcelable {
         return StateColor(
             rest = FluentTheme.aliasTokens.neutralForegroundColor[Foreground3].value(
                 themeMode = FluentTheme.themeMode
-            )
+            ),
+            disabled = FluentTheme.aliasTokens.neutralForegroundColor[ForegroundDisable1].value(
+                themeMode = FluentTheme.themeMode
+            ),
         )
     }
 

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -308,7 +308,12 @@ class ListContentBuilder {
                     subText = item.subTitle,
                     leadingAccessoryContent = {
                         if (item.icon != null) {
-                            Icon(item.icon, null, tint = token.iconColor(ListItemInfo()).rest)
+                            Icon(
+                                item.icon, null,
+                                tint = token.iconColor(ListItemInfo()).let {
+                                    if (item.enabled) it.rest else it.disabled
+                                }
+                            )
                         }
                     },
                     trailingAccessoryContent = item.accessory,


### PR DESCRIPTION
### Problem 
![image](https://github.com/microsoft/fluentui-android/assets/68989156/2f1ba0b7-3e86-452c-b695-10d0c1a78292)

### Root cause 
Disabled icon color was not defined in iconColor for listitems
### Fix
In this fix, have used ForegroundDisable1, which was also being used by TabItems disabled icons.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
|![image](https://github.com/microsoft/fluentui-android/assets/68989156/fd507a76-2c9a-4df4-961f-987a98c4a7c1)|![image](https://github.com/microsoft/fluentui-android/assets/68989156/a6dfc073-b91e-416d-9cf9-768e1acb01ee)|
|![image](https://github.com/microsoft/fluentui-android/assets/68989156/d9d45786-a0b4-48c7-86d8-edfc37912313)|![image](https://github.com/microsoft/fluentui-android/assets/68989156/b103888b-4711-42a2-9efe-a0836e837179)|



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
