### PR TITLE
Demo Tool Tip Activity: Text Fields dark mode bug

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
@@ -4,13 +4,20 @@ import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -28,6 +35,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tokenized.controls.Button
+import com.microsoft.fluentui.tokenized.controls.TextField
 import com.microsoft.fluentui.tokenized.divider.Divider
 import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentui.tokenized.notification.ToolTipBox
@@ -133,30 +141,47 @@ fun CreateToolTipActivityUI(context: Context) {
         Column {
             ListItem.Header(title = context.getString(R.string.menu_xOffset),
                 trailingAccessoryContent = {
-                    BasicTextField(value = xOffsetState.value,
-                        modifier = Modifier.testTag(TOOLTIP_ACTIVITY_X_OFFSET_TEXTFIELD_TAG),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        onValueChange = { xOffsetState.value = it.trim() })
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value = xOffsetState.value,
+                            onValueChange = { xOffsetState.value = it.trim() },
+                            modifier = Modifier.testTag(TOOLTIP_ACTIVITY_X_OFFSET_TEXTFIELD_TAG),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                        )
+                    }
                 }
             )
             ListItem.Header(title = context.getString(R.string.menu_yOffset),
                 trailingAccessoryContent = {
-                    BasicTextField(value = yOffsetState.value,
-                        modifier = Modifier.testTag(TOOLTIP_ACTIVITY_Y_OFFSET_TEXTFIELD_TAG),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        onValueChange = { yOffsetState.value = it.trim() })
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value = yOffsetState.value,
+                            onValueChange = { yOffsetState.value = it.trim() },
+                            modifier = Modifier.testTag(TOOLTIP_ACTIVITY_Y_OFFSET_TEXTFIELD_TAG),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                        )
+                    }
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_title),
                 trailingAccessoryContent = {
-                    BasicTextField(
-                        value = toolTipTitle.value,
-                        onValueChange = { toolTipTitle.value = it })
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value =toolTipTitle.value,
+                            onValueChange = { toolTipTitle.value = it.trim() },
+                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
+                        )
+                    }
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_text),
                 trailingAccessoryContent = {
-                    BasicTextField(
-                        value = toolTipText.value,
-                        onValueChange = { toolTipText.value = it })
+
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value = toolTipText.value,
+                            onValueChange = { toolTipText.value = it.trim() },
+                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
+                        )
+                    }
                 })
             Divider()
         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
@@ -166,7 +166,7 @@ fun CreateToolTipActivityUI(context: Context) {
                 trailingAccessoryContent = {
                     Box(Modifier.widthIn(100.dp,150.dp)) {
                         TextField(
-                            value =toolTipTitle.value,
+                            value = toolTipTitle.value,
                             onValueChange = { toolTipTitle.value = it.trim() },
                             keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
                         )
@@ -174,12 +174,11 @@ fun CreateToolTipActivityUI(context: Context) {
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_text),
                 trailingAccessoryContent = {
-
                     Box(Modifier.widthIn(100.dp,150.dp)) {
                         TextField(
                             value = toolTipText.value,
                             onValueChange = { toolTipText.value = it.trim() },
-                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
                         )
                     }
                 })


### PR DESCRIPTION
### Problem 
In demo app tool tip activity, we have various text fields to set offset and text values, those text filds were not visible in dark mode, neither the input cursor.
### Root cause 
Fluent Basic Fields were not being used, causing it visibility issues in the dark mode. 
### Fix
Used Fluent UI TextFields

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Screenshot_2023-09-04-12-52-50-08_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/9a9d7a5a-58d3-45cd-b788-28dd09d41bd3)| ![Screenshot_2023-09-04-16-58-18-21_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/25bd4efe-24da-4a32-a5b9-9e8c38cc00f0) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
