### PR TITLE
Drawer gap issue Fix

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
@@ -4,13 +4,20 @@ import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -28,6 +35,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tokenized.controls.Button
+import com.microsoft.fluentui.tokenized.controls.TextField
 import com.microsoft.fluentui.tokenized.divider.Divider
 import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentui.tokenized.notification.ToolTipBox
@@ -133,30 +141,47 @@ fun CreateToolTipActivityUI(context: Context) {
         Column {
             ListItem.Header(title = context.getString(R.string.menu_xOffset),
                 trailingAccessoryContent = {
-                    BasicTextField(value = xOffsetState.value,
-                        modifier = Modifier.testTag(TOOLTIP_ACTIVITY_X_OFFSET_TEXTFIELD_TAG),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        onValueChange = { xOffsetState.value = it.trim() })
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value = xOffsetState.value,
+                            onValueChange = { xOffsetState.value = it.trim() },
+                            modifier = Modifier.testTag(TOOLTIP_ACTIVITY_X_OFFSET_TEXTFIELD_TAG),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                        )
+                    }
                 }
             )
             ListItem.Header(title = context.getString(R.string.menu_yOffset),
                 trailingAccessoryContent = {
-                    BasicTextField(value = yOffsetState.value,
-                        modifier = Modifier.testTag(TOOLTIP_ACTIVITY_Y_OFFSET_TEXTFIELD_TAG),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        onValueChange = { yOffsetState.value = it.trim() })
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value = yOffsetState.value,
+                            onValueChange = { yOffsetState.value = it.trim() },
+                            modifier = Modifier.testTag(TOOLTIP_ACTIVITY_Y_OFFSET_TEXTFIELD_TAG),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                        )
+                    }
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_title),
                 trailingAccessoryContent = {
-                    BasicTextField(
-                        value = toolTipTitle.value,
-                        onValueChange = { toolTipTitle.value = it })
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value =toolTipTitle.value,
+                            onValueChange = { toolTipTitle.value = it.trim() },
+                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
+                        )
+                    }
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_text),
                 trailingAccessoryContent = {
-                    BasicTextField(
-                        value = toolTipText.value,
-                        onValueChange = { toolTipText.value = it })
+
+                    Box(Modifier.widthIn(100.dp,150.dp)) {
+                        TextField(
+                            value = toolTipText.value,
+                            onValueChange = { toolTipText.value = it.trim() },
+                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
+                        )
+                    }
                 })
             Divider()
         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivity.kt
@@ -4,20 +4,13 @@ import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -35,7 +28,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.tokenized.controls.Button
-import com.microsoft.fluentui.tokenized.controls.TextField
 import com.microsoft.fluentui.tokenized.divider.Divider
 import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentui.tokenized.notification.ToolTipBox
@@ -56,7 +48,7 @@ class V2ToolTipActivity : V2DemoActivity() {
     }
 
     override val paramsUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#params-35"
-    override val controlTokensUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-35"
+    override val controlTokensUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-34"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -141,47 +133,30 @@ fun CreateToolTipActivityUI(context: Context) {
         Column {
             ListItem.Header(title = context.getString(R.string.menu_xOffset),
                 trailingAccessoryContent = {
-                    Box(Modifier.widthIn(100.dp,150.dp)) {
-                        TextField(
-                            value = xOffsetState.value,
-                            onValueChange = { xOffsetState.value = it.trim() },
-                            modifier = Modifier.testTag(TOOLTIP_ACTIVITY_X_OFFSET_TEXTFIELD_TAG),
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-                        )
-                    }
+                    BasicTextField(value = xOffsetState.value,
+                        modifier = Modifier.testTag(TOOLTIP_ACTIVITY_X_OFFSET_TEXTFIELD_TAG),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        onValueChange = { xOffsetState.value = it.trim() })
                 }
             )
             ListItem.Header(title = context.getString(R.string.menu_yOffset),
                 trailingAccessoryContent = {
-                    Box(Modifier.widthIn(100.dp,150.dp)) {
-                        TextField(
-                            value = yOffsetState.value,
-                            onValueChange = { yOffsetState.value = it.trim() },
-                            modifier = Modifier.testTag(TOOLTIP_ACTIVITY_Y_OFFSET_TEXTFIELD_TAG),
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-                        )
-                    }
+                    BasicTextField(value = yOffsetState.value,
+                        modifier = Modifier.testTag(TOOLTIP_ACTIVITY_Y_OFFSET_TEXTFIELD_TAG),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        onValueChange = { yOffsetState.value = it.trim() })
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_title),
                 trailingAccessoryContent = {
-                    Box(Modifier.widthIn(100.dp,150.dp)) {
-                        TextField(
-                            value =toolTipTitle.value,
-                            onValueChange = { toolTipTitle.value = it.trim() },
-                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
-                        )
-                    }
+                    BasicTextField(
+                        value = toolTipTitle.value,
+                        onValueChange = { toolTipTitle.value = it })
                 })
             ListItem.Header(title = context.getString(R.string.tooltip_text),
                 trailingAccessoryContent = {
-
-                    Box(Modifier.widthIn(100.dp,150.dp)) {
-                        TextField(
-                            value = toolTipText.value,
-                            onValueChange = { toolTipText.value = it.trim() },
-                            keyboardOptions = KeyboardOptions(keyboardType=KeyboardType.Text)
-                        )
-                    }
+                    BasicTextField(
+                        value = toolTipText.value,
+                        onValueChange = { toolTipText.value = it })
                 })
             Divider()
         }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentGlobalTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentGlobalTokens.kt
@@ -267,6 +267,7 @@ object FluentGlobalTokens {
     }
 
     enum class ShadowTokens {
+        Shadow00,
         Shadow02,
         Shadow04,
         Shadow08,
@@ -277,6 +278,7 @@ object FluentGlobalTokens {
 
     fun elevation(token: ShadowTokens): Dp {
         return when (token) {
+            ShadowTokens.Shadow00 -> 0.dp
             ShadowTokens.Shadow02 -> 2.dp
             ShadowTokens.Shadow04 -> 4.dp
             ShadowTokens.Shadow08 -> 8.dp

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
@@ -40,8 +40,12 @@ open class DrawerTokens : IControlToken, Parcelable {
         )
 
     @Composable
-    open fun elevation(drawerInfo: DrawerInfo): Dp =
-        FluentGlobalTokens.elevation(FluentGlobalTokens.ShadowTokens.Shadow28)
+    open fun elevation(drawerInfo: DrawerInfo): Dp {
+        return if (drawerInfo.type == BehaviorType.LEFT_SLIDE_OVER || drawerInfo.type == BehaviorType.RIGHT_SLIDE_OVER || drawerInfo.type == BehaviorType.BOTTOM)
+            FluentGlobalTokens.elevation(FluentGlobalTokens.ShadowTokens.Shadow00)
+        else
+            FluentGlobalTokens.elevation(FluentGlobalTokens.ShadowTokens.Shadow28)
+    }
 
     @Composable
     open fun borderRadius(drawerInfo: DrawerInfo): Dp {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -849,7 +849,6 @@ fun Drawer(
                     else -> RoundedCornerShape(tokens.borderRadius(drawerInfo))
                 }
             val drawerElevation: Dp = tokens.elevation(drawerInfo)
-            val horizontalDrawerElevation: Dp = 0.dp
             val drawerBackgroundColor: Brush =
                 tokens.backgroundBrush(drawerInfo)
             val drawerHandleColor: Color = tokens.handleColor(drawerInfo)
@@ -891,7 +890,7 @@ fun Drawer(
                     modifier = modifier,
                     drawerState = drawerState,
                     drawerShape = drawerShape,
-                    drawerElevation = horizontalDrawerElevation,
+                    drawerElevation = drawerElevation,
                     drawerBackground = drawerBackgroundColor,
                     scrimColor = scrimColor,
                     scrimVisible = scrimVisible,

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -849,6 +849,7 @@ fun Drawer(
                     else -> RoundedCornerShape(tokens.borderRadius(drawerInfo))
                 }
             val drawerElevation: Dp = tokens.elevation(drawerInfo)
+            val horizontalDrawerElevation: Dp = 0.dp
             val drawerBackgroundColor: Brush =
                 tokens.backgroundBrush(drawerInfo)
             val drawerHandleColor: Color = tokens.handleColor(drawerInfo)
@@ -890,7 +891,7 @@ fun Drawer(
                     modifier = modifier,
                     drawerState = drawerState,
                     drawerShape = drawerShape,
-                    drawerElevation = drawerElevation,
+                    drawerElevation = horizontalDrawerElevation,
                     drawerBackground = drawerBackgroundColor,
                     scrimColor = scrimColor,
                     scrimVisible = scrimVisible,


### PR DESCRIPTION
### Problem 
navigation bar and left/ tight drawer were causing issues
### Root cause 
In horizontal drawers, we set shadow elevation = 0
### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-09-04-14-21-57-53_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/d58c96ac-10f9-4aff-b701-9294037a2dbd) | ![Screenshot_2023-09-04-16-01-25-09_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/6c51d831-dcdc-4769-ac94-df63dd518860)|
|![Screenshot_2023-09-04-16-01-07-60_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/0a5866f3-d607-44f3-bc4a-ea0261d68c3c)|![Screenshot_2023-09-04-16-01-41-87_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/c9118580-67aa-4b23-8b6e-d4b75d4efce2)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
