### PR TITLE
Demo App enchancement: "Choose your brand theme" clickable fix

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/AppProperties.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/AppProperties.kt
@@ -160,6 +160,7 @@ fun AppBarMenu() {
                     )
                 },
                 onClick = { showAppearanceDialog = !showAppearanceDialog },
+                border = BorderType.Bottom,
                 listItemTokens = CustomizedTokens.listItemTokens
             )
 
@@ -175,10 +176,8 @@ fun AppBarMenu() {
                 }
             }
 
-            ListItem.SectionHeader(
-                title = stringResource(id = R.string.choose_brand_theme),
-                enableChevron = false,
-                style = SectionHeaderStyle.Subtle,
+            ListItem.Item(
+                text = stringResource(id = R.string.choose_brand_theme),
                 listItemTokens = CustomizedTokens.listItemTokens
             )
             SetAppTheme()


### PR DESCRIPTION
### Problem 
"Choose your brnd theme:" item is clickable
### Root cause 
It is a section description
### Fix
Making it an item of lititem

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-09-05-10-43-55-86_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/6880d001-0085-4585-a11b-bfa5cb885114) | ![Screenshot_2023-09-05-10-47-59-71_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/acd1cab3-b182-42e5-ad78-4561e1118108) |
|![Screenshot_2023-09-05-10-44-07-22_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/972ebab3-cce0-4768-9b2c-58007a28f64a)|![Screenshot_2023-09-05-10-48-11-89_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/19756a71-7cf7-4e8a-bf4d-92acf283e928)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
