### PR TITLE
Clickability related API changes to SectionHeader ListItem And Demo-App Enhancement

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -103,7 +103,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Header(title = "Text Only")
             ListItem.Item(
                 text = primaryText,
-                onClick = {}, 
+                onClick = {},
                 border = BorderType.Bottom,
                 borderInset = XXLarge,
                 primaryTextTrailingContent = { Icon20() }
@@ -197,6 +197,7 @@ private fun CreateListActivityUI(context: Context) {
             Column(Modifier.padding(top = 2.dp, bottom = 1.dp)) {
                 ListItem.SectionHeader(
                     title = "One-Line list",
+                    onClick={},
                     enableChevron = true,
                     enableContentOpenCloseTransition = true,
                     chevronOrientation = ChevronOrientation(90f, 0f),
@@ -208,6 +209,7 @@ private fun CreateListActivityUI(context: Context) {
                 )
                 ListItem.SectionHeader(
                     title = "Two-Line list",
+                    onClick={},
                     style = Subtle,
                     enableChevron = true,
                     enableContentOpenCloseTransition = true,
@@ -217,6 +219,7 @@ private fun CreateListActivityUI(context: Context) {
                 )
                 ListItem.SectionHeader(
                     title = "Three-Line list",
+                    onClick={},
                     enableChevron = false,
                     enableContentOpenCloseTransition = true,
                     trailingAccessoryContent = { RightContentToggle() },

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -627,6 +627,7 @@ object ListItem {
         title: String,
         modifier: Modifier = Modifier,
         titleMaxLines: Int = 1,
+        onClick: (() -> Unit)? = null,
         accessoryTextTitle: String? = null,
         accessoryTextOnClick: (() -> Unit)? = null,
         enabled: Boolean = true,
@@ -694,11 +695,19 @@ object ListItem {
                 .fillMaxWidth()
                 .heightIn(min = cellHeight)
                 .background(backgroundColor)
-                .clickAndSemanticsModifier(
-                    interactionSource,
-                    onClick = { expandedState = !expandedState },
-                    enabled,
-                    rippleColor
+                .then(
+                    if(onClick != null){
+                        Modifier.clickAndSemanticsModifier(
+                            interactionSource,
+                            onClick = {
+                                expandedState = !expandedState
+                                onClick
+                            },
+                            enabled,
+                            rippleColor
+                        )
+                    }
+                    else Modifier
                 )
                 .semantics(mergeDescendants = true) {
                     contentDescription =


### PR DESCRIPTION
### Problem 

1. SectionHeader was always clickable.
2. "Choose your brand theme:" in app properties was clickable

### Root cause 

### Fix

- Changed API of sectionHeader.
- Changed v2ListItemActivity sectionHeader calls to maintain the same clickability. 

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-09-05-10-43-55-86_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/e5e35178-2533-4c91-899d-c26e1ad8d461) | ![Screenshot_2023-09-06-00-53-14-93_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/14d17fb2-53b1-4c08-9e6b-d37351d8d60b) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
