### PR TITLE
removing fixed height for personaChip

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PersonaChipTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PersonaChipTokens.kt
@@ -238,12 +238,4 @@ open class PersonaChipTokens : IControlToken, Parcelable {
     open fun avatarSize(personaChipInfo: PersonaChipControlInfo): AvatarSize {
         return AvatarSize.Size16
     }
-
-    @Composable
-    open fun maxHeight(personaChipInfo: PersonaChipControlInfo): Dp {
-        return when (personaChipInfo.size) {
-            Small -> FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size200)
-            Medium -> FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size240)
-        }
-    }
 }

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaChip.kt
@@ -85,8 +85,6 @@ fun PersonaChip(
         token.avatarToTextSpacing(personaChipInfo = personaChipInfo)
     val cornerRadius =
         token.cornerRadius(personaChipInfo = personaChipInfo)
-    val maxHeight =
-        token.maxHeight(personaChipInfo = personaChipInfo)
     val selectedString = if (selected)
         LocalContext.current.resources.getString(R.string.fluentui_selected)
     else
@@ -101,7 +99,6 @@ fun PersonaChip(
         modifier = modifier
             .clip(RoundedCornerShape(cornerRadius))
             .background(backgroundColor)
-            .heightIn(max = maxHeight)
             .clickable(
                 enabled = enabled,
                 onClick = onClick ?: {},


### PR DESCRIPTION
### Problem 
Persona chip height does not change when the system font size is increased
### Root cause 
Personachip height is fixed and does not change based on text size
### Fix
Removed the height token. Now height will be the sum of text height and any additional padding

### Validations
Manual testing, peer review
(how the change was tested, including both manual and automated tests)

### Screenshots

Before
![Screenshot_20230907-113454](https://github.com/microsoft/fluentui-android/assets/5608292/3f73c6f6-eeb9-4acc-b5d5-3022cf5af083)

After
![Screenshot_20230907-113502](https://github.com/microsoft/fluentui-android/assets/5608292/4a97b306-eee1-403c-a69e-20dc19352cda)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
