### PR TITLE
sectionheader clickable fix

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -197,7 +197,6 @@ private fun CreateListActivityUI(context: Context) {
             Column(Modifier.padding(top = 2.dp, bottom = 1.dp)) {
                 ListItem.SectionHeader(
                     title = "One-Line list",
-                    onClick={},
                     enableChevron = true,
                     enableContentOpenCloseTransition = true,
                     chevronOrientation = ChevronOrientation(90f, 0f),
@@ -209,7 +208,6 @@ private fun CreateListActivityUI(context: Context) {
                 )
                 ListItem.SectionHeader(
                     title = "Two-Line list",
-                    onClick={},
                     style = Subtle,
                     enableChevron = true,
                     enableContentOpenCloseTransition = true,
@@ -219,7 +217,6 @@ private fun CreateListActivityUI(context: Context) {
                 )
                 ListItem.SectionHeader(
                     title = "Three-Line list",
-                    onClick={},
                     enableChevron = false,
                     enableContentOpenCloseTransition = true,
                     trailingAccessoryContent = { RightContentToggle() },

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -627,7 +627,6 @@ object ListItem {
         title: String,
         modifier: Modifier = Modifier,
         titleMaxLines: Int = 1,
-        onClick: (() -> Unit)? = null,
         accessoryTextTitle: String? = null,
         accessoryTextOnClick: (() -> Unit)? = null,
         enabled: Boolean = true,
@@ -696,12 +695,11 @@ object ListItem {
                 .heightIn(min = cellHeight)
                 .background(backgroundColor)
                 .then(
-                    if(onClick != null){
+                    if(enableContentOpenCloseTransition && content != null){
                         Modifier.clickAndSemanticsModifier(
                             interactionSource,
                             onClick = {
                                 expandedState = !expandedState
-                                onClick
                             },
                             enabled,
                             rippleColor


### PR DESCRIPTION
### Problem 
Section header is clickable when used as a header
### Root cause 
Ripple is provided when there is no need for the header to be clicked
### Fix
Conditionally provide ripple

### Validations
Manual testing, peer review
(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
