### PR TITLE
Fluent Icon Lateral Inversion Bug Fix for Right-To-Left Scenarios

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/V2DemoActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/V2DemoActivity.kt
@@ -204,6 +204,7 @@ open class V2DemoActivity : ComponentActivity() {
                             navigationIcon = FluentIcon(
                                 SearchBarIcons.Arrowback,
                                 contentDescription = stringResource(id = R.string.app_bar_layout_navigation_icon_clicked),
+                                flipOnRtl = true,
                                 onClick = { Navigation.backNavigation(this) }
                             ),
                             style = AppThemeViewModel.appThemeStyle.value,

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toolingGraphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -165,16 +166,16 @@ fun Icon(
             .then(modifier)
             .toolingGraphicsLayer()
             .defaultSizeFor(painter)
+            .then(
+                if (flipOnRtl && LocalLayoutDirection.current == LayoutDirection.Rtl)
+                    Modifier.scale(-1F, 1F)
+                else
+                    Modifier
+            )
             .paint(
                 painter,
                 colorFilter = colorFilter,
-                contentScale = ContentScale.Fit
-            )
-            .then(
-                if (flipOnRtl && LocalLayoutDirection.current == LayoutDirection.Rtl)
-                    Modifier.scale(-1F, -1F)
-                else
-                    Modifier
+                contentScale = ContentScale.Fit,
             )
             .then(semantics)
     )


### PR DESCRIPTION
### Problem 
Icon were not flipping when RTL forced.
### Root cause 
Modifier order and scaling values
### Fix
Corrected the order, and fixed the issue

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| RTL   | Before                                       | After                                      |
|-------|----------------------------------|---------------------------------|
|✅| ![Screenshot_2023-09-07-20-40-07-24_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/ad40a240-0562-4e92-baaa-da7dd10a2ff8) | ![Screenshot_2023-09-07-20-40-12-29_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/d4cd246d-a972-43af-9d77-288c3023ea05) |
|❌|![Screenshot_2023-09-07-20-53-33-02_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/0bca787a-965d-43f8-b090-c59d0f2a1e92)|![Screenshot_2023-09-07-20-53-33-02_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/dc4b102a-8b5b-4309-ad45-316287826e25)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
