### PR TITLE
Menu Shadow Clipping Problem Fix

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/MenuTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/MenuTokens.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlInfo
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
@@ -30,7 +31,7 @@ open class MenuTokens : IControlToken, Parcelable {
         FluentGlobalTokens.cornerRadius(FluentGlobalTokens.CornerRadiusTokens.CornerRadius80)
 
     open fun elevation(menuInfo: MenuInfo): Dp =
-        FluentGlobalTokens.elevation(FluentGlobalTokens.ShadowTokens.Shadow16)
+        FluentGlobalTokens.elevation(FluentGlobalTokens.ShadowTokens.Shadow08)
 
     open fun bottomMargin(menuInfo: MenuInfo): Dp =
         FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size160)


### PR DESCRIPTION
### Problem 
The Shadow formed by menu pop-up was getting clipped off.
### Root cause 
The shadow token's value was going out of bounds
### Fix
Changed elevation token's value from 16 to 08.
I also tried with 10, but there was clipping visible in that:
<img src="https://github.com/microsoft/fluentui-android/assets/68989156/fe44d3ba-fba3-42a9-9c15-043aff5d2251" width="200">
If you carefully zoom you will notice clipping is visible in 10, hence went ahead with 08.


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-android/assets/68989156/3882ce6e-fac2-4eb0-9be7-f5d7a1923be6)| ![Screenshot_2023-09-08-13-21-26-38_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/36ad0f28-94d1-40cf-952c-8be31e7e1da6) |
|||

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
