### PR TITLE
CCB Multiline Bug Fix in v2CCBActivity

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ContextualCommandBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ContextualCommandBarActivity.kt
@@ -383,7 +383,7 @@ class V2ContextualCommandBarActivity : V2DemoActivity() {
                                         )
                                     }
                                 }
-                                LazyColumn(){
+                                LazyColumn{
                                     item {
                                         ContextualCommandBar(
                                             listOf(commandGroup2),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ContextualCommandBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ContextualCommandBarActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Divider
@@ -382,21 +383,25 @@ class V2ContextualCommandBarActivity : V2DemoActivity() {
                                         )
                                     }
                                 }
-                                ContextualCommandBar(
-                                    listOf(commandGroup2),
-                                    scrollable = false,
-                                    actionButtonPosition = ActionButtonPosition.None
-                                )
-                                ContextualCommandBar(
-                                    listOf(commandGroup3),
-                                    scrollable = false,
-                                    actionButtonPosition = ActionButtonPosition.None
-                                )
-                                ContextualCommandBar(
-                                    listOf(commandGroup4, commandGroup5),
-                                    scrollable = false,
-                                    actionButtonPosition = ActionButtonPosition.None
-                                )
+                                LazyColumn(){
+                                    item {
+                                        ContextualCommandBar(
+                                            listOf(commandGroup2),
+                                            scrollable = false,
+                                            actionButtonPosition = ActionButtonPosition.None
+                                        )
+                                        ContextualCommandBar(
+                                            listOf(commandGroup3),
+                                            scrollable = false,
+                                            actionButtonPosition = ActionButtonPosition.None
+                                        )
+                                        ContextualCommandBar(
+                                            listOf(commandGroup4, commandGroup5),
+                                            scrollable = false,
+                                            actionButtonPosition = ActionButtonPosition.None
+                                        )
+                                    }
+                                }
                             }
 
                         },


### PR DESCRIPTION
### Problem 
CCB in multiline was not showing all 4 groups, as you can see in before screenshot
### Root cause 
CCB is ConstraintLayout which basically is attached by spring to parent's TOP and BOTTOm, so it takes the whole space not leaving space for other items in the Bottom Drawer
### Fix
Enclosed them inside lazyColumn

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-09-08-17-21-46-21_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/7bccccd8-559a-4ff7-bc55-365cf5b35d42) | ![Screenshot_2023-09-08-17-21-51-40_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/9975a59e-15d0-4bfd-a81a-b3ff463b0fed) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
