### PR TITLE
Section header accessory

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,6 +55,8 @@ import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.listitem.ChevronOrientation
 import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentui.tokenized.notification.Badge
+import com.microsoft.fluentui.tokenized.notification.ToolTipBox
+import com.microsoft.fluentui.tokenized.notification.rememberTooltipState
 import com.microsoft.fluentui.tokenized.persona.Avatar
 import com.microsoft.fluentui.tokenized.persona.AvatarGroup
 import com.microsoft.fluentui.tokenized.persona.Group
@@ -64,6 +67,7 @@ import com.microsoft.fluentuidemo.V2DemoActivity
 import com.microsoft.fluentuidemo.icons.ListItemIcons
 import com.microsoft.fluentuidemo.icons.listitemicons.Folder40
 import com.microsoft.fluentuidemo.util.invokeToast
+import kotlinx.coroutines.launch
 
 class V2ListItemActivity : V2DemoActivity() {
     init {
@@ -194,10 +198,28 @@ private fun CreateListActivityUI(context: Context) {
                 border = BorderType.Bottom
             )
             ListItem.Header(title = "Section Headers with/without chevron")
+            val toolTipState = rememberTooltipState()
+            val scope = rememberCoroutineScope()
             Column(Modifier.padding(top = 2.dp, bottom = 1.dp)) {
                 ListItem.SectionHeader(
                     title = "One-Line list",
                     enableChevron = true,
+                    titleTrailingContent = {
+                        ToolTipBox(
+                            title = "",
+                            text = "This is a tooltip",
+                            tooltipState = toolTipState
+                        ) {
+                            Icon(
+                                painter = painterResource(id = drawable.ic_icon__16x16_checkmark),
+                                contentDescription = "Flag",
+                                tint = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value(
+                                    themeMode
+                                ),
+                                onClick = { scope.launch { toolTipState.show() } }
+                            )
+                        }
+                    },
                     enableContentOpenCloseTransition = true,
                     chevronOrientation = ChevronOrientation(90f, 0f),
                     accessoryTextTitle = "Action",

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -315,4 +315,9 @@ open class ListItemTokens : IControlToken, Parcelable {
             }
         }
     }
+
+    @Composable
+    open fun textAccessoryContentTextSpacing(listItemInfo: ListItemInfo): Dp {
+        return FluentGlobalTokens.size(FluentGlobalTokens.SizeTokens.Size40)
+    }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -275,6 +275,7 @@ object ListItem {
         val borderColor = token.borderColor(listItemInfo).getColorByState(
             enabled = enabled, selected = false, interactionSource = interactionSource
         )
+        val textAccessoryContentTextSpacing = token.textAccessoryContentTextSpacing(listItemInfo)
         val leadingAccessoryAlignment = when (leadingAccessoryContentAlignment) {
             Alignment.Top -> Alignment.TopCenter
             Alignment.Bottom -> Alignment.BottomCenter
@@ -292,15 +293,14 @@ object ListItem {
                 .height(IntrinsicSize.Max)
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
                 .then(
-                    if(onClick != null){
+                    if (onClick != null) {
                         Modifier.clickAndSemanticsModifier(
                             interactionSource,
                             onClick = onClick,
                             enabled,
                             rippleColor
                         )
-                    }
-                    else Modifier
+                    } else Modifier
                 )
         ) {
             if (leadingAccessoryContent != null && textAlignment == ListItemTextAlignment.Regular) {
@@ -343,7 +343,7 @@ object ListItem {
                 Column(Modifier.padding(vertical = padding.calculateTopPadding())) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(textAccessoryContentTextSpacing)
                     ) {
                         if (primaryTextLeadingContent != null) {
                             primaryTextLeadingContent()
@@ -373,7 +373,7 @@ object ListItem {
                     if (textAlignment == ListItemTextAlignment.Regular) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(textAccessoryContentTextSpacing)
                         ) {
                             if (bottomContent != null) {
                                 Row(modifier.padding(top = 7.dp, bottom = 7.dp)) {
@@ -630,6 +630,8 @@ object ListItem {
         accessoryTextTitle: String? = null,
         accessoryTextOnClick: (() -> Unit)? = null,
         enabled: Boolean = true,
+        titleLeadingContent: (@Composable () -> Unit)? = null,
+        titleTrailingContent: (@Composable () -> Unit)? = null,
         style: SectionHeaderStyle = SectionHeaderStyle.Bold,
         enableChevron: Boolean = true,
         chevronOrientation: ChevronOrientation = ChevronOrientation(0f, 0f),
@@ -682,6 +684,7 @@ object ListItem {
         val borderColor = token.borderColor(listItemInfo).getColorByState(
             enabled = enabled, selected = false, interactionSource = interactionSource
         )
+        val textAccessoryContentTextSpacing = token.textAccessoryContentTextSpacing(listItemInfo)
         val chevronTint = token.chevronTint(listItemInfo)
         var expandedState by rememberSaveable { mutableStateOf(false) }
         val rotationState by animateFloatAsState(
@@ -695,7 +698,7 @@ object ListItem {
                 .heightIn(min = cellHeight)
                 .background(backgroundColor)
                 .then(
-                    if(enableContentOpenCloseTransition && content != null){
+                    if (enableContentOpenCloseTransition && content != null) {
                         Modifier.clickAndSemanticsModifier(
                             interactionSource,
                             onClick = {
@@ -704,8 +707,7 @@ object ListItem {
                             enabled,
                             rippleColor
                         )
-                    }
-                    else Modifier
+                    } else Modifier
                 )
                 .semantics(mergeDescendants = true) {
                     contentDescription =
@@ -715,7 +717,9 @@ object ListItem {
                             } else {
                                 collapsedString
                             }
-                        } else {""}
+                        } else {
+                            ""
+                        }
                 }
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
         ) {
@@ -750,13 +754,24 @@ object ListItem {
                                     tint = chevronTint
                                 )
                             }
-                            BasicText(
-                                modifier = Modifier.clearAndSetSemantics { },
-                                text = title,
-                                style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
-                                maxLines = titleMaxLines,
-                                overflow = TextOverflow.Ellipsis
-                            )
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(textAccessoryContentTextSpacing)
+                            ) {
+                                if(titleLeadingContent != null){
+                                    titleLeadingContent()
+                                }
+                                BasicText(
+                                    modifier = Modifier.clearAndSetSemantics { },
+                                    text = title,
+                                    style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
+                                    maxLines = titleMaxLines,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                if(titleTrailingContent != null){
+                                    titleTrailingContent()
+                                }
+                            }
                         }
 
                     }


### PR DESCRIPTION
### Problem 
Section header does not have a scope to add additional composable after the title.
### Root cause 
No provision to add a composable in section header Api.
### Fix
Added trailing and leading accessory for title in section header.

### Validations
Demo app and peer review
(how the change was tested, including both manual and automated tests)

### Screenshots

Before   
![WhatsApp Image 2023-09-15 at 1 30 26 PM](https://github.com/microsoft/fluentui-android/assets/5608292/8b9af5b1-5744-43c8-bfbb-dce9c23f61ea)

                                    
After
![Untitled](https://github.com/microsoft/fluentui-android/assets/5608292/7bdcbed5-5311-4e03-acd9-a70a2652fee0)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
