### PR TITLE
adding alignment to pillbar

### DIFF
--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -231,6 +231,7 @@ fun PillButton(
  * @param modifier
  * @param style
  * @param showBackground
+ * @param pillAlignment
  * @param pillButtonTokens
  * @param pillBarTokens
  */
@@ -240,6 +241,7 @@ fun PillBar(
     modifier: Modifier = Modifier,
     style: FluentStyle = FluentStyle.Neutral,
     showBackground: Boolean = false,
+    pillAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     pillButtonTokens: PillButtonTokens? = null,
     pillBarTokens: PillBarTokens? = null
 ) {
@@ -261,7 +263,7 @@ fun PillBar(
             .background(if (showBackground) token.backgroundBrush(pillBarInfo) else SolidColor(Color.Unspecified))
             .focusable(enabled = false),
         contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        horizontalArrangement = Arrangement.spacedBy(8.dp, pillAlignment),
         state = lazyListState
     ) {
         metadataList.forEachIndexed { index, pillMetadata ->


### PR DESCRIPTION
### Problem 
Pill bar items are not aligned as required. It was restricted to center the pills always
### Root cause 
Alignment.CenterHorizontally is used and since the pillbar row is using fillmaxwidth, items are always center aligned 
### Fix
Adding alignment parameter so that user can customize the alignment of the pillbar

### Validations
Peer review

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
