### PR TITLE
Accessibility Role for Each BottomSheetDialog items

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/BottomSheetActivity.kt
@@ -187,7 +187,8 @@ class BottomSheetActivity : DemoActivity(), BottomSheetItem.OnClickListener {
                         BottomSheetItem(
                             R.id.bottom_sheet_item_alarm,
                             R.drawable.ic_alert_24_regular,
-                            getString(R.string.bottom_sheet_item_alarm_title)
+                            getString(R.string.bottom_sheet_item_alarm_title),
+                            roleDescription = "Clickable Button" //Example of setting role description for accessibility
                         ),
                         BottomSheetItem(
                             R.id.bottom_sheet_item_time_zone,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/BottomSheetActivity.kt
@@ -188,7 +188,7 @@ class BottomSheetActivity : DemoActivity(), BottomSheetItem.OnClickListener {
                             R.id.bottom_sheet_item_alarm,
                             R.drawable.ic_alert_24_regular,
                             getString(R.string.bottom_sheet_item_alarm_title),
-                            roleDescription = "Clickable Button" //Example of setting role description for accessibility
+                            roleDescription = "Button" //Example of setting role description for accessibility
                         ),
                         BottomSheetItem(
                             R.id.bottom_sheet_item_time_zone,

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
@@ -86,7 +86,6 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
             listItemView.layoutDensity = ListItemView.LayoutDensity.COMPACT
             listItemView.background = R.drawable.bottom_sheet_item_ripple_background
             listItemView.disabled = item.disabled
-            var clickedItem: BottomSheetItem? = null
             if (textAppearance != 0) {
                 listItemView.titleStyleRes = textAppearance
             }
@@ -116,18 +115,15 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
             listItemView.setOnClickListener {
                 onBottomSheetItemClickListener?.onBottomSheetItemClick(item)
-                clickedItem = item
             }
-            ViewCompat.setAccessibilityDelegate(this.itemView,
+            ViewCompat.setAccessibilityDelegate(listItemView,
                 object : AccessibilityDelegateCompat() {
                     override fun onInitializeAccessibilityNodeInfo(
                         v: View,
                         info: AccessibilityNodeInfoCompat
                     ) {
                         super.onInitializeAccessibilityNodeInfo(v, info)
-                        clickedItem?.let {
-                            info.roleDescription = it.roleDescription
-                        }
+                        info.roleDescription = item.roleDescription
                     }
                 }
             )

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
@@ -8,9 +8,13 @@ package com.microsoft.fluentui.bottomsheet
 import android.content.Context
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.annotation.StyleRes
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.microsoft.fluentui.bottomsheet.BottomSheetItem.Companion.NO_ID
@@ -82,6 +86,7 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
             listItemView.layoutDensity = ListItemView.LayoutDensity.COMPACT
             listItemView.background = R.drawable.bottom_sheet_item_ripple_background
             listItemView.disabled = item.disabled
+            var clickedItem: BottomSheetItem? = null
             if (textAppearance != 0) {
                 listItemView.titleStyleRes = textAppearance
             }
@@ -111,7 +116,21 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
             listItemView.setOnClickListener {
                 onBottomSheetItemClickListener?.onBottomSheetItemClick(item)
+                clickedItem = item
             }
+            ViewCompat.setAccessibilityDelegate(this.itemView,
+                object : AccessibilityDelegateCompat() {
+                    override fun onInitializeAccessibilityNodeInfo(
+                        v: View,
+                        info: AccessibilityNodeInfoCompat
+                    ) {
+                        super.onInitializeAccessibilityNodeInfo(v, info)
+                        clickedItem?.let {
+                            info.roleDescription = it.roleDescription
+                        }
+                    }
+                }
+            )
         }
     }
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetDialog.kt
@@ -10,9 +10,6 @@ import android.os.Build
 import android.view.View
 import android.view.Window
 import androidx.annotation.StyleRes
-import androidx.core.view.AccessibilityDelegateCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.microsoft.fluentui.drawer.DrawerDialog
 import com.microsoft.fluentui.drawer.R
 import com.microsoft.fluentui.drawer.databinding.ViewBottomSheetBinding

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetDialog.kt
@@ -48,20 +48,6 @@ class BottomSheetDialog : DrawerDialog, BottomSheetItem.OnClickListener {
         }
 
         setContentView(binding.root)
-
-        ViewCompat.setAccessibilityDelegate(binding.root,
-            object : AccessibilityDelegateCompat() {
-                override fun onInitializeAccessibilityNodeInfo(
-                    v: View,
-                    info: AccessibilityNodeInfoCompat
-                ) {
-                    super.onInitializeAccessibilityNodeInfo(v, info)
-                    clickedItem?.let {
-                        info.roleDescription = it.roleDescription
-                    }
-                }
-            }
-        )
     }
 
     private fun createHeader(headerItem: BottomSheetItem): View {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetDialog.kt
@@ -10,6 +10,9 @@ import android.os.Build
 import android.view.View
 import android.view.Window
 import androidx.annotation.StyleRes
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.microsoft.fluentui.drawer.DrawerDialog
 import com.microsoft.fluentui.drawer.R
 import com.microsoft.fluentui.drawer.databinding.ViewBottomSheetBinding
@@ -45,6 +48,20 @@ class BottomSheetDialog : DrawerDialog, BottomSheetItem.OnClickListener {
         }
 
         setContentView(binding.root)
+
+        ViewCompat.setAccessibilityDelegate(binding.root,
+            object : AccessibilityDelegateCompat() {
+                override fun onInitializeAccessibilityNodeInfo(
+                    v: View,
+                    info: AccessibilityNodeInfoCompat
+                ) {
+                    super.onInitializeAccessibilityNodeInfo(v, info)
+                    clickedItem?.let {
+                        info.roleDescription = it.roleDescription
+                    }
+                }
+            }
+        )
     }
 
     private fun createHeader(headerItem: BottomSheetItem): View {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
@@ -50,7 +50,6 @@ class BottomSheetItem : Parcelable {
         id: Int = NO_ID,
         @DrawableRes imageId: Int = NO_ID,
         title: String,
-        roleDescription: String = "Button",
         subtitle: String = "",
         useDivider: Boolean = false,
         @ColorInt imageTint: Int = 0,
@@ -58,10 +57,10 @@ class BottomSheetItem : Parcelable {
         customBitmap: Bitmap? = null,
         disabled: Boolean = false,
         @DrawableRes accessoryImageId: Int = NO_ID,
-        accessoryBitmap: Bitmap? = null
+        accessoryBitmap: Bitmap? = null,
+        roleDescription: String = "Button",
     ) {
         this.id = id
-        this.roleDescription = roleDescription
         this.imageId = imageId
         this.title = title
         this.subtitle = subtitle
@@ -72,13 +71,13 @@ class BottomSheetItem : Parcelable {
         this.disabled = disabled
         this.accessoryImageId = accessoryImageId
         this.accessoryBitmap = accessoryBitmap
+        this.roleDescription = roleDescription
     }
 
     private constructor(parcel: Parcel) : this(
         id = parcel.readInt(),
         imageId = parcel.readInt(),
         title = parcel.readString() ?: "",
-        roleDescription = parcel.readString() ?: "Button",
         subtitle = parcel.readString() ?: "",
         useDivider = parcel.readInt() == 1,
         imageTint = parcel.readInt(),
@@ -86,14 +85,14 @@ class BottomSheetItem : Parcelable {
         customBitmap = parcel.readParcelable(Bitmap::class.java.classLoader),
         disabled = parcel.readInt() == 1,
         accessoryImageId = parcel.readInt(),
-        accessoryBitmap = parcel.readParcelable(Bitmap::class.java.classLoader)
+        accessoryBitmap = parcel.readParcelable(Bitmap::class.java.classLoader),
+        roleDescription = parcel.readString() ?: "Button",
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeInt(id)
         parcel.writeInt(imageId)
         parcel.writeString(title)
-        parcel.writeString(roleDescription)
         parcel.writeString(subtitle)
         parcel.writeInt(if (useDivider) 1 else 0)
         parcel.writeInt(imageTint)
@@ -102,6 +101,7 @@ class BottomSheetItem : Parcelable {
         parcel.writeInt(if (disabled) 1 else 0)
         parcel.writeInt(accessoryImageId)
         parcel.writeValue(accessoryBitmap)
+        parcel.writeString(roleDescription)
     }
 
     override fun describeContents(): Int = 0
@@ -114,7 +114,6 @@ class BottomSheetItem : Parcelable {
         if (id != other.id) return false
         if (imageId != other.imageId) return false
         if (title != other.title) return false
-        if (roleDescription != other.roleDescription) return false
         if (subtitle != other.subtitle) return false
         if (useDivider != other.useDivider) return false
         if (imageTint != other.imageTint) return false
@@ -123,6 +122,7 @@ class BottomSheetItem : Parcelable {
         if (disabled != other.disabled) return false
         if (accessoryImageId != other.accessoryImageId) return false
         if (accessoryBitmap != other.accessoryBitmap) return false
+        if (roleDescription != other.roleDescription) return false
 
         return true
     }
@@ -131,7 +131,6 @@ class BottomSheetItem : Parcelable {
         var result = id
         result = 31 * result + imageId
         result = 31 * result + title.hashCode()
-        result = 31 * result + roleDescription.hashCode()
         result = 31 * result + subtitle.hashCode()
         result = 31 * result + useDivider.hashCode()
         result = 31 * result + imageTint
@@ -140,6 +139,7 @@ class BottomSheetItem : Parcelable {
         result = 31 * result + disabled.hashCode()
         result = 31 * result + accessoryImageId.hashCode()
         result = 31 * result + (accessoryBitmap?.hashCode() ?: 0)
+        result = 31 * result + roleDescription.hashCode()
         return result
     }
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.fluentui.bottomsheet
 
+import android.content.ClipDescription
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Parcel
@@ -29,6 +30,7 @@ class BottomSheetItem : Parcelable {
     }
 
     val id: Int
+    val roleDescription: String
     @DrawableRes
     val imageId: Int
     val title: String
@@ -48,6 +50,7 @@ class BottomSheetItem : Parcelable {
         id: Int = NO_ID,
         @DrawableRes imageId: Int = NO_ID,
         title: String,
+        roleDescription: String = "Button",
         subtitle: String = "",
         useDivider: Boolean = false,
         @ColorInt imageTint: Int = 0,
@@ -58,6 +61,7 @@ class BottomSheetItem : Parcelable {
         accessoryBitmap: Bitmap? = null
     ) {
         this.id = id
+        this.roleDescription = roleDescription
         this.imageId = imageId
         this.title = title
         this.subtitle = subtitle
@@ -74,6 +78,7 @@ class BottomSheetItem : Parcelable {
         id = parcel.readInt(),
         imageId = parcel.readInt(),
         title = parcel.readString() ?: "",
+        roleDescription = parcel.readString() ?: "Button",
         subtitle = parcel.readString() ?: "",
         useDivider = parcel.readInt() == 1,
         imageTint = parcel.readInt(),
@@ -88,6 +93,7 @@ class BottomSheetItem : Parcelable {
         parcel.writeInt(id)
         parcel.writeInt(imageId)
         parcel.writeString(title)
+        parcel.writeString(roleDescription)
         parcel.writeString(subtitle)
         parcel.writeInt(if (useDivider) 1 else 0)
         parcel.writeInt(imageTint)
@@ -108,6 +114,7 @@ class BottomSheetItem : Parcelable {
         if (id != other.id) return false
         if (imageId != other.imageId) return false
         if (title != other.title) return false
+        if (roleDescription != other.roleDescription) return false
         if (subtitle != other.subtitle) return false
         if (useDivider != other.useDivider) return false
         if (imageTint != other.imageTint) return false
@@ -124,6 +131,7 @@ class BottomSheetItem : Parcelable {
         var result = id
         result = 31 * result + imageId
         result = 31 * result + title.hashCode()
+        result = 31 * result + roleDescription.hashCode()
         result = 31 * result + subtitle.hashCode()
         result = 31 * result + useDivider.hashCode()
         result = 31 * result + imageTint

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
@@ -5,7 +5,6 @@
 
 package com.microsoft.fluentui.bottomsheet
 
-import android.content.ClipDescription
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Parcel
@@ -30,7 +29,6 @@ class BottomSheetItem : Parcelable {
     }
 
     val id: Int
-    val roleDescription: String
     @DrawableRes
     val imageId: Int
     val title: String
@@ -45,6 +43,8 @@ class BottomSheetItem : Parcelable {
     val accessoryImageId: Int
     val accessoryBitmap: Bitmap?
 
+    val roleDescription: String
+
     @JvmOverloads
     constructor(
         id: Int = NO_ID,
@@ -58,7 +58,7 @@ class BottomSheetItem : Parcelable {
         disabled: Boolean = false,
         @DrawableRes accessoryImageId: Int = NO_ID,
         accessoryBitmap: Bitmap? = null,
-        roleDescription: String = "Button",
+        roleDescription: String = "",
     ) {
         this.id = id
         this.imageId = imageId
@@ -86,7 +86,7 @@ class BottomSheetItem : Parcelable {
         disabled = parcel.readInt() == 1,
         accessoryImageId = parcel.readInt(),
         accessoryBitmap = parcel.readParcelable(Bitmap::class.java.classLoader),
-        roleDescription = parcel.readString() ?: "Button",
+        roleDescription = parcel.readString() ?: "",
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {


### PR DESCRIPTION
### Problem 
Accessibility Role can't be set by users.

### Root cause 
By design there's no direct access to listitemViews in BottomSheetAdapter.

### Fix
Defined role description attribute for BottomSheetItem and A corresponding delegate for it in BottomSheetDialogue

### Validations

(how the change was tested, including both manual and automated tests)

### ScreenRecording


https://github.com/microsoft/fluentui-android/assets/68989156/4b065bb4-79c9-4d61-a053-d027de76c5b6



### Pull request checklist

This PR has considered:

