### PR TITLE
Defining role in order to imporve accessibility of v1 PopUp Menu Items 

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
@@ -65,27 +65,27 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
 
     private fun showPopupNoCheck(anchorView: View) {
         val popupMenuItems = arrayListOf(
-            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share), roleDescription = "Popup Menu item Button"),
-            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow), roleDescription = "Popup Menu item Button"),
+            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share), roleDescription = "Button"),
+            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow), roleDescription = "Button"),
             PopupMenuItem(
                 R.id.popup_menu_item_invite_people,
                 getString(R.string.popup_menu_item_invite_people),
-                roleDescription = "Popup Menu item Button"
+                roleDescription = "Button"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_refresh_page,
                 getString(R.string.popup_menu_item_refresh_page),
-                roleDescription = "Popup Menu item Button"
+                roleDescription = "Button"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_open_in_browser,
                 getString(R.string.popup_menu_item_open_in_browser),
-                roleDescription = "Popup Menu item Button"
+                roleDescription = "Button"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_multiline,
                 getString(R.string.popup_menu_item_multiline),
-                roleDescription = "Popup Menu item Button"
+                roleDescription = "Button"
             )
         )
 

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
@@ -8,7 +8,6 @@ package com.microsoft.fluentuidemo.demos
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import androidx.lifecycle.repeatOnLifecycle
 import com.microsoft.fluentui.popupmenu.PopupMenu
 import com.microsoft.fluentui.popupmenu.PopupMenuItem
 import com.microsoft.fluentui.snackbar.Snackbar
@@ -66,29 +65,24 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
 
     private fun showPopupNoCheck(anchorView: View) {
         val popupMenuItems = arrayListOf(
-            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share),
-                roleDescription = "Popup item"),
-            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow),
-                roleDescription = "Popup item"),
+            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share)),
+            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow)),
             PopupMenuItem(
                 R.id.popup_menu_item_invite_people,
-                getString(R.string.popup_menu_item_invite_people),
-                roleDescription = "Popup item"
+                getString(R.string.popup_menu_item_invite_people)
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_refresh_page,
-                getString(R.string.popup_menu_item_refresh_page),
-                roleDescription = "Popup item"
+                getString(R.string.popup_menu_item_refresh_page)
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_open_in_browser,
-                getString(R.string.popup_menu_item_open_in_browser),
-                roleDescription = "Popup item"
+                getString(R.string.popup_menu_item_open_in_browser)
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_multiline,
                 getString(R.string.popup_menu_item_multiline),
-                roleDescription = "Popup item"
+                roleDescription = "Popup Menu item"
             )
         )
 
@@ -111,23 +105,19 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
             PopupMenuItem(
                 R.id.popup_menu_item_all_news,
                 getString(R.string.popup_menu_item_all_news),
-                showDividerBelow = true,
-                roleDescription = "Popup item"
+                showDividerBelow = true
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_saved_news,
-                getString(R.string.popup_menu_item_saved_news),
-                roleDescription = "Popup item"
+                getString(R.string.popup_menu_item_saved_news)
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_news_from_sites,
-                getString(R.string.popup_menu_item_news_from_sites),
-                roleDescription = "Popup item"
+                getString(R.string.popup_menu_item_news_from_sites)
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_contoso_travel,
-                getString(R.string.popup_menu_item_contoso_travel),
-                roleDescription = "Popup item"
+                getString(R.string.popup_menu_item_contoso_travel)
             )
         )
 
@@ -157,7 +147,6 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
                     R.id.popup_menu_item_notify_outside,
                     getString(R.string.popup_menu_item_notify_outside),
                     R.drawable.ic_sync_24_filled,
-                    roleDescription = "Popup item"
                 ),
                 PopupMenuItem(
                     R.id.popup_menu_item_notify_inactive,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
@@ -65,24 +65,27 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
 
     private fun showPopupNoCheck(anchorView: View) {
         val popupMenuItems = arrayListOf(
-            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share)),
-            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow)),
+            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share), roleDescription = "Popup Menu item Button"),
+            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow), roleDescription = "Popup Menu item Button"),
             PopupMenuItem(
                 R.id.popup_menu_item_invite_people,
-                getString(R.string.popup_menu_item_invite_people)
+                getString(R.string.popup_menu_item_invite_people),
+                roleDescription = "Popup Menu item Button"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_refresh_page,
-                getString(R.string.popup_menu_item_refresh_page)
+                getString(R.string.popup_menu_item_refresh_page),
+                roleDescription = "Popup Menu item Button"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_open_in_browser,
-                getString(R.string.popup_menu_item_open_in_browser)
+                getString(R.string.popup_menu_item_open_in_browser),
+                roleDescription = "Popup Menu item Button"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_multiline,
                 getString(R.string.popup_menu_item_multiline),
-                roleDescription = "Popup Menu item"
+                roleDescription = "Popup Menu item Button"
             )
         )
 

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PopupMenuActivity.kt
@@ -8,6 +8,7 @@ package com.microsoft.fluentuidemo.demos
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import androidx.lifecycle.repeatOnLifecycle
 import com.microsoft.fluentui.popupmenu.PopupMenu
 import com.microsoft.fluentui.popupmenu.PopupMenuItem
 import com.microsoft.fluentui.snackbar.Snackbar
@@ -65,23 +66,29 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
 
     private fun showPopupNoCheck(anchorView: View) {
         val popupMenuItems = arrayListOf(
-            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share)),
-            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow)),
+            PopupMenuItem(R.id.popup_menu_item_share, getString(R.string.popup_menu_item_share),
+                roleDescription = "Popup item"),
+            PopupMenuItem(R.id.popup_menu_item_follow, getString(R.string.popup_menu_item_follow),
+                roleDescription = "Popup item"),
             PopupMenuItem(
                 R.id.popup_menu_item_invite_people,
-                getString(R.string.popup_menu_item_invite_people)
+                getString(R.string.popup_menu_item_invite_people),
+                roleDescription = "Popup item"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_refresh_page,
-                getString(R.string.popup_menu_item_refresh_page)
+                getString(R.string.popup_menu_item_refresh_page),
+                roleDescription = "Popup item"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_open_in_browser,
-                getString(R.string.popup_menu_item_open_in_browser)
+                getString(R.string.popup_menu_item_open_in_browser),
+                roleDescription = "Popup item"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_multiline,
-                getString(R.string.popup_menu_item_multiline)
+                getString(R.string.popup_menu_item_multiline),
+                roleDescription = "Popup item"
             )
         )
 
@@ -104,19 +111,23 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
             PopupMenuItem(
                 R.id.popup_menu_item_all_news,
                 getString(R.string.popup_menu_item_all_news),
-                showDividerBelow = true
+                showDividerBelow = true,
+                roleDescription = "Popup item"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_saved_news,
-                getString(R.string.popup_menu_item_saved_news)
+                getString(R.string.popup_menu_item_saved_news),
+                roleDescription = "Popup item"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_news_from_sites,
-                getString(R.string.popup_menu_item_news_from_sites)
+                getString(R.string.popup_menu_item_news_from_sites),
+                roleDescription = "Popup item"
             ),
             PopupMenuItem(
                 R.id.popup_menu_item_contoso_travel,
-                getString(R.string.popup_menu_item_contoso_travel)
+                getString(R.string.popup_menu_item_contoso_travel),
+                roleDescription = "Popup item"
             )
         )
 
@@ -145,7 +156,8 @@ class PopupMenuActivity : DemoActivity(), View.OnClickListener {
                 PopupMenuItem(
                     R.id.popup_menu_item_notify_outside,
                     getString(R.string.popup_menu_item_notify_outside),
-                    R.drawable.ic_sync_24_filled
+                    R.drawable.ic_sync_24_filled,
+                    roleDescription = "Popup item"
                 ),
                 PopupMenuItem(
                     R.id.popup_menu_item_notify_inactive,

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItem.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItem.kt
@@ -27,6 +27,7 @@ class PopupMenuItem : Parcelable {
     val iconResourceId: Int?
     var isChecked: Boolean
     val showDividerBelow: Boolean
+    var roleDescription: String?
 
     @JvmOverloads
     constructor(
@@ -35,13 +36,15 @@ class PopupMenuItem : Parcelable {
         @DrawableRes
         iconResourceId: Int? = null,
         isChecked: Boolean = false,
-        showDividerBelow: Boolean = false
+        showDividerBelow: Boolean = false,
+        roleDescription: String? = null
     ) {
         this.id = id
         this.title = title
         this.iconResourceId = iconResourceId
         this.isChecked = isChecked
         this.showDividerBelow = showDividerBelow
+        this.roleDescription = roleDescription
     }
 
     private constructor(parcel: Parcel) : this(
@@ -49,7 +52,8 @@ class PopupMenuItem : Parcelable {
         title = parcel.readString() ?: "",
         iconResourceId = parcel.readInt(),
         isChecked = parcel.readByte() != 0.toByte(),
-        showDividerBelow = parcel.readByte() != 0.toByte()
+        showDividerBelow = parcel.readByte() != 0.toByte(),
+        roleDescription = parcel.readString() ?: ""
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -58,6 +62,7 @@ class PopupMenuItem : Parcelable {
         parcel.writeValue(iconResourceId)
         parcel.writeByte(if (isChecked) 1 else 0)
         parcel.writeByte(if (showDividerBelow) 1 else 0)
+        parcel.writeString(roleDescription)
     }
 
     override fun describeContents(): Int = 0

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItem.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItem.kt
@@ -27,7 +27,7 @@ class PopupMenuItem : Parcelable {
     val iconResourceId: Int?
     var isChecked: Boolean
     val showDividerBelow: Boolean
-    var roleDescription: String?
+    var roleDescription: String = ""
 
     @JvmOverloads
     constructor(
@@ -37,14 +37,14 @@ class PopupMenuItem : Parcelable {
         iconResourceId: Int? = null,
         isChecked: Boolean = false,
         showDividerBelow: Boolean = false,
-        roleDescription: String? = null
+        roleDescription: String? = ""
     ) {
         this.id = id
         this.title = title
         this.iconResourceId = iconResourceId
         this.isChecked = isChecked
         this.showDividerBelow = showDividerBelow
-        this.roleDescription = roleDescription
+        this.roleDescription = roleDescription?: ""
     }
 
     private constructor(parcel: Parcel) : this(
@@ -53,7 +53,7 @@ class PopupMenuItem : Parcelable {
         iconResourceId = parcel.readInt(),
         isChecked = parcel.readByte() != 0.toByte(),
         showDividerBelow = parcel.readByte() != 0.toByte(),
-        roleDescription = parcel.readString() ?: ""
+        roleDescription = parcel.readString()
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
@@ -9,9 +9,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.PorterDuff
 import androidx.annotation.DrawableRes
-import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -20,6 +18,8 @@ import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.RadioButton
 import android.widget.TextView
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.microsoft.fluentui.menus.R
 import com.microsoft.fluentui.popupmenu.PopupMenu.Companion.DEFAULT_ITEM_CHECKABLE_BEHAVIOR
 import com.microsoft.fluentui.theming.FluentUIContextThemeWrapper
@@ -59,6 +59,7 @@ internal class PopupMenuItemView : TemplateView {
     private var showDividerBelow: Boolean = false
     private var showRadioButton: Boolean = false
     private var showCheckBox: Boolean = false
+    private var roleDescription: String? = null
 
     @JvmOverloads
     constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : super(FluentUIContextThemeWrapper(context,R.style.Theme_FluentUI_Menus), attrs, defStyleAttr)
@@ -68,6 +69,7 @@ internal class PopupMenuItemView : TemplateView {
         iconResourceId = popupMenuItem.iconResourceId
         isChecked = popupMenuItem.isChecked
         showDividerBelow = popupMenuItem.showDividerBelow
+        roleDescription = popupMenuItem.roleDescription
 
         updateViews()
     }
@@ -176,9 +178,9 @@ internal class PopupMenuItemView : TemplateView {
             context.getString(R.string.popup_menu_accessibility_item_state_not_checked)
 
         contentDescription = if (showRadioButton || showCheckBox)
-            "$title, $checkViewType $checkedState"
+            "$title, $checkViewType $checkedState, $roleDescription"
         else
-            title
+            "$title, $roleDescription"
     }
 
     private fun updateAccessibilityClickAction() {

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
@@ -30,22 +30,21 @@ import com.microsoft.fluentui.view.TemplateView
 internal class PopupMenuItemView : TemplateView {
     var itemCheckableBehavior: PopupMenu.ItemCheckableBehavior = DEFAULT_ITEM_CHECKABLE_BEHAVIOR
         set(value) {
-            if (field == value)
-                return
-            field = value
-
             when (itemCheckableBehavior) {
                 PopupMenu.ItemCheckableBehavior.SINGLE -> {
                     showRadioButton = true
                     showCheckBox = false
+                    showButton = false
                 }
                 PopupMenu.ItemCheckableBehavior.ALL -> {
                     showRadioButton = false
                     showCheckBox = true
+                    showButton = false
                 }
                 PopupMenu.ItemCheckableBehavior.NONE -> {
                     showRadioButton = false
                     showCheckBox = false
+                    showButton = true
                 }
             }
 
@@ -59,6 +58,7 @@ internal class PopupMenuItemView : TemplateView {
     private var showDividerBelow: Boolean = false
     private var showRadioButton: Boolean = false
     private var showCheckBox: Boolean = false
+    private var showButton: Boolean = false
     private var roleDescription: String? = null
 
     @JvmOverloads
@@ -171,6 +171,10 @@ internal class PopupMenuItemView : TemplateView {
             showCheckBox -> context.getString(R.string.popup_menu_accessibility_item_check_box)
             else -> ""
         }
+        val buttonViewString = if (showButton)
+            context.getString(R.string.popup_menu_accessibility_item_button)
+        else
+            ""
 
         val checkedState = if (isChecked)
             context.getString(R.string.popup_menu_accessibility_item_state_checked)
@@ -178,9 +182,9 @@ internal class PopupMenuItemView : TemplateView {
             context.getString(R.string.popup_menu_accessibility_item_state_not_checked)
 
         contentDescription = if (showRadioButton || showCheckBox)
-            "$title, $checkViewType $checkedState, $roleDescription"
+            "$title, $roleDescription, $checkViewType $checkedState"
         else
-            "$title, $roleDescription"
+            "$title, $roleDescription, $buttonViewString"
     }
 
     private fun updateAccessibilityClickAction() {

--- a/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
+++ b/fluentui_menus/src/main/java/com/microsoft/fluentui/popupmenu/PopupMenuItemView.kt
@@ -30,21 +30,22 @@ import com.microsoft.fluentui.view.TemplateView
 internal class PopupMenuItemView : TemplateView {
     var itemCheckableBehavior: PopupMenu.ItemCheckableBehavior = DEFAULT_ITEM_CHECKABLE_BEHAVIOR
         set(value) {
+            if (field == value)
+                return
+            field = value
+
             when (itemCheckableBehavior) {
                 PopupMenu.ItemCheckableBehavior.SINGLE -> {
                     showRadioButton = true
                     showCheckBox = false
-                    showButton = false
                 }
                 PopupMenu.ItemCheckableBehavior.ALL -> {
                     showRadioButton = false
                     showCheckBox = true
-                    showButton = false
                 }
                 PopupMenu.ItemCheckableBehavior.NONE -> {
                     showRadioButton = false
                     showCheckBox = false
-                    showButton = true
                 }
             }
 
@@ -58,7 +59,6 @@ internal class PopupMenuItemView : TemplateView {
     private var showDividerBelow: Boolean = false
     private var showRadioButton: Boolean = false
     private var showCheckBox: Boolean = false
-    private var showButton: Boolean = false
     private var roleDescription: String? = null
 
     @JvmOverloads
@@ -171,20 +171,15 @@ internal class PopupMenuItemView : TemplateView {
             showCheckBox -> context.getString(R.string.popup_menu_accessibility_item_check_box)
             else -> ""
         }
-        val buttonViewString = if (showButton)
-            context.getString(R.string.popup_menu_accessibility_item_button)
-        else
-            ""
-
         val checkedState = if (isChecked)
             context.getString(R.string.popup_menu_accessibility_item_state_checked)
         else
             context.getString(R.string.popup_menu_accessibility_item_state_not_checked)
 
-        contentDescription = if (showRadioButton || showCheckBox)
-            "$title, $roleDescription, $checkViewType $checkedState"
-        else
-            "$title, $roleDescription, $buttonViewString"
+        contentDescription =
+            if(!roleDescription.isNullOrEmpty()) "$title, $roleDescription"
+            else if (showRadioButton || showCheckBox) "$title, $checkViewType $checkedState"
+            else "$title"
     }
 
     private fun updateAccessibilityClickAction() {

--- a/fluentui_menus/src/main/res/values/strings.xml
+++ b/fluentui_menus/src/main/res/values/strings.xml
@@ -25,7 +25,5 @@
     <string name="popup_menu_accessibility_item_state_checked">checked</string>
     <!--Describes the state of a menu item that is not checked.-->
     <string name="popup_menu_accessibility_item_state_not_checked">not checked</string>
-    <!--Describes the button control.-->
-    <string name="popup_menu_accessibility_item_button">button</string>
 
 </resources>

--- a/fluentui_menus/src/main/res/values/strings.xml
+++ b/fluentui_menus/src/main/res/values/strings.xml
@@ -25,5 +25,7 @@
     <string name="popup_menu_accessibility_item_state_checked">checked</string>
     <!--Describes the state of a menu item that is not checked.-->
     <string name="popup_menu_accessibility_item_state_not_checked">not checked</string>
+    <!--Describes the button control.-->
+    <string name="popup_menu_accessibility_item_button">button</string>
 
 </resources>


### PR DESCRIPTION
### Problem 
There's no fixed role announcing for popUp menu NONE (nonChecked) type menu items
No role could be defined for PopUp Menu Items
### Root cause 

### Fix
Added a new param roleDescription, it can be passed into the function PopUpMenuItem() and it will be announced by talkback.
For NONE type popUpMenuItems, will announce "Button".
### Validations

(how the change was tested, including both manual and automated tests)

### ScreenRecording
( 🔊 watch with sound )

**BEFORE**

https://github.com/microsoft/fluentui-android/assets/68989156/869e5a50-045b-4b8a-b729-7e63bb5d4b9d


**AFTER**


https://github.com/microsoft/fluentui-android/assets/68989156/bf9b5148-83e7-4f4c-a80d-81c6a55ce6ce









### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
