### PR TITLE
BasicInput Activity Accessibility Related Improvements

### DIFF
--- a/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
@@ -17,6 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/demo_headline_padding_bottom"
+        android:accessibilityHeading="true"
         android:text="Different views of button" />
 
     <View

--- a/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
@@ -18,7 +18,7 @@
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/demo_headline_padding_bottom"
         android:accessibilityHeading="true"
-        android:text="Different views of button" />
+        android:text="@string/basic_input_activity_heading" />
 
     <View
         android:layout_width="match_parent"

--- a/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
@@ -17,7 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/demo_headline_padding_bottom"
-        android:text="@string/button" />
+        android:text="Different views of button" />
 
     <View
         android:layout_width="match_parent"

--- a/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
+++ b/FluentUI.Demo/src/main/res/layout/activity_basic_inputs.xml
@@ -37,7 +37,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="@string/button_disabled" />
+        android:text="@string/button_disabled"  />
 
     <!--For other button variants, style can be set in the widget.-->
 

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -315,6 +315,7 @@
 
     <!--Button-->
     <!-- text for buttons -->
+    <string name="basic_input_activity_heading">Different views of button</string>
     <string name="button">Button</string>
     <string name="buttonbar">ButtonBar</string>
     <string name="button_disabled">Disabled Button Example</string>

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -317,13 +317,13 @@
     <!-- text for buttons -->
     <string name="button">Button</string>
     <string name="buttonbar">ButtonBar</string>
-    <string name="button_disabled">Disabled Button</string>
-    <string name="button_borderless">Borderless Button</string>
-    <string name="button_borderless_disabled">Borderless Disabled Button</string>
-    <string name="button_large">Large Button</string>
-    <string name="button_large_disabled">Large Disabled Button</string>
-    <string name="button_outlined">Outlined Button</string>
-    <string name="button_outlined_disabled">Outlined Disabled Button</string>
+    <string name="button_disabled">Disabled Button Example</string>
+    <string name="button_borderless">Borderless Button Example</string>
+    <string name="button_borderless_disabled">Borderless Disabled Button Example</string>
+    <string name="button_large">Large Button Example</string>
+    <string name="button_large_disabled">Large Disabled Button Example</string>
+    <string name="button_outlined">Outlined Button Example</string>
+    <string name="button_outlined_disabled">Outlined Disabled Button Example</string>
 
     <!--CalendarView-->
     <string name="calendar_example_chosen_date">Choose a date</string>


### PR DESCRIPTION
### Problem 

1. "Button" heading is not descriptive enough
2. "Button" is not defined and announced as heading, might be confusing for some people relying on accessibility features.
3. Talback is announcing "Disabled Button Button" for "Disableb Button", because of it's text, so giving better text to the buttons

### Root cause 

### Fix

1. "Different views of button" is used as heading.
2. textView, setting accessibilityHeading = true.
3. Changed the text for buttons, appended example in text to differentiate

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
|![image](https://github.com/microsoft/fluentui-android/assets/68989156/a4a6d4da-380b-4626-b0fb-4da7a3a5daa3)|![Screenshot_2023-10-11-12-23-59-63_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/b54c7c18-9abd-467e-b1c1-78ebed379e3d)|



### Pull request checklist

This PR has considered:
- [ ] VoiceOver and Keyboard Accessibility
