### PR TITLE
fixing crash on screen rotation

### DIFF
--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -24,8 +24,6 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
@@ -126,7 +124,6 @@ fun PeoplePicker(
     var lastRemovedPerson by rememberSaveable { mutableStateOf(Person()) }
     var isAdded: Boolean by rememberSaveable { mutableStateOf(true) }
     var accessibilityAnnouncement by rememberSaveable { mutableStateOf("") }
-    val focusRequester = remember { FocusRequester() }
 
     TextField(
         modifier = modifier
@@ -138,8 +135,7 @@ fun PeoplePicker(
                     }
                 }
                 true
-            }
-            .focusRequester(focusRequester),
+            },
         value = queryText,
         onValueChange = {
             queryText = it

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -194,7 +194,6 @@ fun PeoplePicker(
                             )
                             Spacer(modifier = Modifier.width(chipHorizontalSpacing))
                         }
-                        focusRequester.requestFocus()
                     }
 
                     if (selectedPeopleListSize != selectedPeopleList.size) {


### PR DESCRIPTION
### Problem 
focusRequester is causing crash on recomposition
### Root cause 
focusRequester should be used on events. here focusRequester is not used on events causing the crash on recomposition
### Fix
Removed the focusrequeter since it is not required as the work is done using the TextField

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
