### PR TITLE
adding icon drawable support to card Nudge

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
@@ -65,6 +65,7 @@ class V2CardNudgeActivity : V2DemoActivity() {
             var swipeAmount: Float by rememberSaveable { mutableStateOf(0.0F) }
 
             var icon: Boolean by rememberSaveable { mutableStateOf(true) }
+            var iconType: Boolean by rememberSaveable { mutableStateOf(false) }
             var actionButton: Boolean by rememberSaveable { mutableStateOf(true) }
             var subtitle: String? by rememberSaveable { mutableStateOf(null) }
             var accentText: String? by rememberSaveable { mutableStateOf(null) }
@@ -100,6 +101,25 @@ class V2CardNudgeActivity : V2DemoActivity() {
                                         },
                                         modifier = Modifier.testTag(CARD_NUDGE_ICON_PARAM),
                                         checkedState = icon
+                                    )
+                                }
+                            )
+                        }
+                        item {
+                            ListItem.Item(
+                                enabled = icon,
+                                text = LocalContext.current.resources.getString(R.string.fluentui_icon),
+                                subText = if (!iconType)
+                                    LocalContext.current.resources.getString(R.string.fluentui_image_vector)
+                                else
+                                    LocalContext.current.resources.getString(R.string.fluentui_image_drawable),
+                                trailingAccessoryContent = {
+                                    ToggleSwitch(
+                                        enabledSwitch = icon,
+                                        onValueChange = {
+                                            iconType = it
+                                        },
+                                        checkedState = iconType
                                     )
                                 }
                             )
@@ -278,7 +298,8 @@ class V2CardNudgeActivity : V2DemoActivity() {
                     CardNudge(
                         metadata = CardNudgeMetaData(
                             message = LocalContext.current.resources.getString(R.string.fluentui_title),
-                            icon = if (icon) FluentIcon(Icons.Outlined.Call) else null,
+                            icon = if (icon && !iconType) FluentIcon(Icons.Outlined.Call, tint = Color.Unspecified) else null,
+                            iconDrawable = if(icon && iconType) R.drawable.avatar_amanda_brady else null,
                             subTitle = subtitle,
                             accentText = accentText,
                             accentIcon = if (accentImage) FluentIcon(Icons.Outlined.LocationOn) else null,

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CardNudgeTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CardNudgeTokens.kt
@@ -76,9 +76,11 @@ open class CardNudgeTokens : IControlToken, Parcelable {
     open fun borderSize(cardNudgeInfo: CardNudgeInfo): Dp =
         FluentGlobalTokens.strokeWidth(FluentGlobalTokens.StrokeWidthTokens.StrokeWidth10)
 
+    //Size of the icon if Icon ImageVector is used in CardNudgeMetaData
     @Composable
     open fun leftIconSize(cardNudgeInfo: CardNudgeInfo): Dp = 24.dp
 
+    //Size of the icon if IconDrawable is used in CardNudgeMetaData
     @Composable
     open fun leftIconBackgroundSize(cardNudgeInfo: CardNudgeInfo): Dp = 40.dp
 

--- a/fluentui_core/src/main/res/values/strings.xml
+++ b/fluentui_core/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Describes the primary and secondary Strings -->
     <string name="fluentui_primary">Primary</string>
     <string name="fluentui_secondary">Secondary</string>
@@ -14,6 +14,8 @@
     <!-- Describes the image component with accent color -->
     <string name="fluentui_accent_icon">Icon</string>
     <!-- Describes disabled action-->
+    <string name="fluentui_image_drawable" tools:ignore="MissingTranslation">ImageDrawable</string>
+    <string name="fluentui_image_vector" tools:ignore="MissingTranslation">ImageVector</string>
     <string name="fluentui_disabled">Disabled</string>
     <!-- Describes the action button component -->
     <string name="fluentui_action_button">Action Button</string>

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/CardNudge.kt
@@ -1,6 +1,7 @@
 package com.microsoft.fluentui.tokenized.notification
 
 import androidx.compose.animation.core.TweenSpec
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,10 +17,12 @@ import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
@@ -53,6 +56,7 @@ class CardNudgeMetaData(
     val message: String,
     val dismissOnClick: (() -> Unit)? = null,
     val icon: FluentIcon? = null,
+    val iconDrawable: Int? = null,
     val subTitle: String? = null,
     val accentText: String? = null,
     val accentIcon: FluentIcon? = null,
@@ -174,6 +178,14 @@ fun CardNudge(
                         tint = token.iconColor(cardNudgeInfo)
                     )
                 }
+            }else if(metadata.iconDrawable != null){
+                Image(
+                    painter = painterResource(metadata.iconDrawable),
+                    modifier = Modifier
+                        .size(token.leftIconBackgroundSize(cardNudgeInfo))
+                        .clip(CircleShape),
+                    contentDescription = ""
+                )
             }
 
             Column(


### PR DESCRIPTION
### Problem 
Icon does not support drawables
### Root cause 
Card nudge only takes fluentIcon which is an ImageVector
### Fix
Added IconDrawable param that take drawable values

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
![image](https://github.com/microsoft/fluentui-android/assets/5608292/504072de-59fd-4793-88ec-f977f1bb3b39) | ![image](https://github.com/microsoft/fluentui-android/assets/5608292/15b0bc08-ca9f-469c-b7e0-2b5f195892da)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
