### PR TITLE
adding undefined object for tokenset

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
@@ -25,6 +25,8 @@ interface IControlTokens {
     }
 }
 
+class UndefinedControlType: IControlToken
+
 /**
  * Extend the ControlToken to add token for custom control or providing new token to existing Fluent Control. *
  */
@@ -120,7 +122,7 @@ open class ControlTokens : IControlTokens {
                 ControlType.ToggleSwitchControlType -> ToggleSwitchTokens()
                 ControlType.TooltipControlType -> TooltipTokens()
                 else -> {
-                    throw java.lang.RuntimeException("$type not defined")
+                    UndefinedControlType()
                 }
             }
         }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/ControlTokens.kt
@@ -25,7 +25,7 @@ interface IControlTokens {
     }
 }
 
-class UndefinedControlType: IControlToken
+object UndefinedControlToken: IControlToken
 
 /**
  * Extend the ControlToken to add token for custom control or providing new token to existing Fluent Control. *
@@ -122,7 +122,7 @@ open class ControlTokens : IControlTokens {
                 ControlType.ToggleSwitchControlType -> ToggleSwitchTokens()
                 ControlType.TooltipControlType -> TooltipTokens()
                 else -> {
-                    UndefinedControlType()
+                    UndefinedControlToken
                 }
             }
         }


### PR DESCRIPTION
### Problem 
Cannot conditionally evalute if the tokenset returns any control token if non existent controltype is used
### Root cause 
ControlTokenset throws runtime exception if not control type is found causing crash.
### Fix
Created undefined object of IControlToken which will be returned if ControlType is not found

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
