### PR TITLE
Removing Experminetal Version of TextStyle

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,7 +42,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.ButtonTokens
  * @param contentDescription Content Description for Icon. Default: [null]
  * @param buttonTokens Tokens to customize appearance of button. Default: [null]
  */
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun Button(
     onClick: () -> Unit,


### PR DESCRIPTION
### Problem 
Referencing this issue: #338 
v2 Buttob uses Experimental TextStyle, and might cause issues with users who are ahead in jetpack compose version, as experimental api has been discontinued. 
### Root cause 

### Fix
Using the Fully supported TextStyle rather than Experimental  

### ScreenShots
**Before and After looks same as expected**

| Before                                       | After                                      |
|--------------------------------------|------------------------------------|
|![Screenshot_2023-10-17-15-24-52-37_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/b8853ac5-f925-4863-a491-4387862af33b)|![Screenshot_2023-10-17-15-24-56-64_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/4fc237c8-1744-4d02-9df4-d8dbbd49146f)|
