### PR TITLE
Workaround for compose bom upgrade

### DIFF
--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion constants.apkCompileSdkVersion
+    compileSdkVersion constants.compileSdkVersion
     defaultConfig {
         applicationId 'com.microsoft.fluentuidemo'
         minSdkVersion 21
@@ -16,6 +16,16 @@ android {
         versionCode 74
         versionName '0.1.39'
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/FluentUI/build.gradle
+++ b/FluentUI/build.gradle
@@ -17,6 +17,16 @@ android {
         versionName project.ext.FluentUI_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,10 @@ apply plugin: "com.microsoft.hydralab.client-util"
 
 allprojects {
     project.ext {
-//        Maintaining different compileSdkVersions for APK and AAR in order to maintain parity with Compose BOM update
-//        https://issuetracker.google.com/issues/295457468
         constants = [
                 minSdkVersion: 21,
                 targetSdkVersion: 33,
-                compileSdkVersion: 33,
-                apkCompileSdkVersion: 34,
+                compileSdkVersion: 33
         ]
 
         androidxRunner            =    '1.5.0'

--- a/fluentui_calendar/build.gradle
+++ b/fluentui_calendar/build.gradle
@@ -18,6 +18,16 @@ android {
         versionName project.ext.fluentui_calendar_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildFeatures {
         viewBinding true

--- a/fluentui_ccb/build.gradle
+++ b/fluentui_ccb/build.gradle
@@ -17,6 +17,16 @@ android {
         versionName project.ext.fluentui_ccb_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_controls/build.gradle
+++ b/fluentui_controls/build.gradle
@@ -12,6 +12,16 @@ android {
         versionCode project.ext.fluentui_controls_version_code
         versionName project.ext.fluentui_controls_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_core/build.gradle
+++ b/fluentui_core/build.gradle
@@ -19,6 +19,16 @@ android {
         versionName project.ext.fluentui_core_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_drawer/build.gradle
+++ b/fluentui_drawer/build.gradle
@@ -21,6 +21,16 @@ android {
         versionName project.ext.fluentui_drawer_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_icons/build.gradle
+++ b/fluentui_icons/build.gradle
@@ -12,6 +12,16 @@ android {
         versionCode project.ext.fluentui_icons_version_code
         versionName project.ext.fluentui_icons_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_listitem/build.gradle
+++ b/fluentui_listitem/build.gradle
@@ -17,6 +17,16 @@ android {
         versionName project.ext.fluentui_listitem_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_menus/build.gradle
+++ b/fluentui_menus/build.gradle
@@ -17,6 +17,16 @@ android {
         versionName project.ext.fluentui_menus_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_notification/build.gradle
+++ b/fluentui_notification/build.gradle
@@ -12,6 +12,16 @@ android {
         versionCode project.ext.fluentui_notification_version_code
         versionName project.ext.fluentui_notification_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_others/build.gradle
+++ b/fluentui_others/build.gradle
@@ -17,6 +17,16 @@ android {
         versionCode project.ext.fluentui_others_version_code
         versionName project.ext.fluentui_others_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_peoplepicker/build.gradle
+++ b/fluentui_peoplepicker/build.gradle
@@ -18,6 +18,16 @@ android {
         versionName project.ext.fluentui_peoplepicker_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildFeatures {
         viewBinding true

--- a/fluentui_persona/build.gradle
+++ b/fluentui_persona/build.gradle
@@ -22,6 +22,16 @@ android {
         versionName project.ext.fluentui_persona_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_progress/build.gradle
+++ b/fluentui_progress/build.gradle
@@ -24,6 +24,16 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         consumerProguardFiles "consumer-rules.pro"
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_tablayout/build.gradle
+++ b/fluentui_tablayout/build.gradle
@@ -17,6 +17,16 @@ android {
         versionName project.ext.fluentui_tablayout_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_topappbars/build.gradle
+++ b/fluentui_topappbars/build.gradle
@@ -22,6 +22,16 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
         vectorDrawables.useSupportLibrary = true
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {

--- a/fluentui_transients/build.gradle
+++ b/fluentui_transients/build.gradle
@@ -20,6 +20,16 @@ android {
         versionName project.ext.fluentui_transients_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
+
+//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
+//      https://issuetracker.google.com/issues/295457468
+//      Remove once we plan to move to Android 34
+        configurations.all {
+            resolutionStrategy {
+                force("androidx.emoji2:emoji2-views-helper:1.3.0")
+                force("androidx.emoji2:emoji2:1.3.0")
+            }
+        }
     }
     buildTypes {
         release {


### PR DESCRIPTION
### Problem 
Compose BOM 2023.09.00 upgrade required Android SDK 34

### Root cause 
Compose BOM 2023.09.00 requires androidx.emoji library (v1.4.0) which requires Android 34 as compile SDK.

### Fix
Workaround was to force dependency for androidx.emoji v1.3.0

### Validations
- Compile Test
- UI Test
- Added aar to officemobile

### Pull request checklist
This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
