### PR TITLE
V1 Persistent Bottom Sheet Accessibility Bug: Talkback Focus goes in background when Expended

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
@@ -81,7 +81,7 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
             getString(R.string.drawer_content_desc_collapse_state),
             getString(R.string.drawer_content_desc_expand_state)
         )
-        persistentBottomSheetDemo.backgroundViews = listOf(persistentBottomSheetBinding.demoMainContent, persistentBottomSheetBinding.scrollContainer)
+        persistentBottomSheetDemo.backgroundViews = listOf(persistentBottomSheetBinding.demoMainContent, persistentBottomSheetBinding.scrollContainer) // These views shouldn't get accessibility focus when Sheet is expanded
 
         mHorizontalSheet = arrayListOf(
             SheetItem(

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
@@ -81,6 +81,8 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
             getString(R.string.drawer_content_desc_collapse_state),
             getString(R.string.drawer_content_desc_expand_state)
         )
+        persistentBottomSheetDemo.backgroundViews = listOf(persistentBottomSheetBinding.demoMainContent, persistentBottomSheetBinding.scrollContainer)
+
         mHorizontalSheet = arrayListOf(
             SheetItem(
                 R.id.bottom_sheet_item_flag,

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -42,6 +43,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.ButtonTokens
  * @param contentDescription Content Description for Icon. Default: [null]
  * @param buttonTokens Tokens to customize appearance of button. Default: [null]
  */
+@OptIn(ExperimentalTextApi::class)
 @Composable
 fun Button(
     onClick: () -> Unit,

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,7 +42,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.ButtonTokens
  * @param contentDescription Content Description for Icon. Default: [null]
  * @param buttonTokens Tokens to customize appearance of button. Default: [null]
  */
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun Button(
     onClick: () -> Unit,

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -54,6 +54,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
     private var isDrawerHandleVisible = true
     private var sheetContainer: PersistentBottomSheetContentViewProvider.SheetContainerInfo? = null
     private var focusDrawerHandleInAccessibility = true
+    var backgroundViews: List<View>? = null
 
 
     init {
@@ -249,6 +250,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
+        setImportantForAccessibility(backgroundViews!!, View.IMPORTANT_FOR_ACCESSIBILITY_YES)
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {
@@ -257,10 +259,12 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) }
     }
 
     fun hide(){
         persistentSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
     }
 
     fun show(expanded: Boolean = false, focusDrawerHandle: Boolean = true) {
@@ -273,6 +277,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
     }
 
     fun updateBottomSheetLayoutParams(peekHeight: Int = itemLayoutParam.defaultPeekHeight,
@@ -439,6 +444,14 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             return true
         }
         return super.onKeyUp(keyCode, event)
+    }
+
+    fun setImportantForAccessibility(views: List<View>, important: Int) {
+        if(views!=null) {
+            for (view in views) {
+                view.importantForAccessibility = important
+            }
+        }
     }
 
 }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -54,7 +54,8 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
     private var isDrawerHandleVisible = true
     private var sheetContainer: PersistentBottomSheetContentViewProvider.SheetContainerInfo? = null
     private var focusDrawerHandleInAccessibility = true
-    var backgroundViews: List<View>? = null
+    var backgroundViews: List<View>? = null  //views in activity that will be hidden behind the Expanded sheet
+    // so focus doesn't reach to background Views when sheet is expanded
 
 
     init {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -251,7 +251,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
-        setImportantForAccessibility(backgroundViews!!, View.IMPORTANT_FOR_ACCESSIBILITY_YES)
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) }
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {


### PR DESCRIPTION
### Problem 
When PersitentBottomSheet is in EXPANDED state, and talkback focus is navigated, it also goes to background views that are hidden by the sheet.
### Root cause 
Important For Accessibility for background views not dynamically changing.
### Fix
Creating a member variable backgroundViews (list of Views) which can be set as the views that should not get focus when sheet is expanded. 
Expand(), Hide(), Collapse() etc functions take care of setting importantForAccessibiity attritbute for those views.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

Before:

https://github.com/microsoft/fluentui-android/assets/68989156/37a915f6-24b3-4a40-b64f-cef5fe891ee7


After:


https://github.com/microsoft/fluentui-android/assets/68989156/496acdb5-fef4-410d-8223-1ef9668814a6



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
