### PR TITLE
V2 drawer & BottomDrawer New feature: option to disable dismissal on Scrim Click + onScrimClick API change + Unit Tests

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
@@ -300,6 +300,16 @@ class V2BottomDrawerUITest : BaseTest() {
         waitForDrawerClose()
         closeCheckForVerticalDrawer()
     }
+    @Test
+    fun testPreventBottomDrawerDismissalOnScrimClick(){
+        composeTestRule.onNodeWithText(getString(R.string.prevent_scrim_click_dismissal), useUnmergedTree = true).performClick()
+        composeTestRule.onNodeWithText(getString(R.string.drawer_open)).performClick()
+        openCheckForVerticalDrawer()
+        drawerScrim.performTouchInput {
+            click(Offset((0..width).random().toFloat(), (0..height).random().toFloat()))
+        }
+        openCheckForVerticalDrawer()
+    }
 }
 
 

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2DrawerActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2DrawerActivityUITest.kt
@@ -307,4 +307,15 @@ class V2DrawerActivityUITest : BaseTest() {
         closeCheckForVerticalDrawer()
     }
 
+    @Test
+    fun testPreventDrawerDismissalOnScrimClick(){
+        composeTestRule.onNodeWithText(getString(R.string.prevent_scrim_click_dismissal), useUnmergedTree = true).performClick()
+        composeTestRule.onNodeWithText("Open Drawer").performClick()
+        openCheckForVerticalDrawer()
+        drawerScrim.performTouchInput {
+            click(Offset((0..width).random().toFloat(), (0..height).random().toFloat()))
+        }
+        openCheckForVerticalDrawer()
+    }
+
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
@@ -60,6 +60,7 @@ private fun CreateActivityUI() {
     var selectedContent by remember { mutableStateOf(ContentType.FULL_SCREEN_SCROLLABLE_CONTENT) }
     var slideOver by remember { mutableStateOf(false) }
     var showHandle by remember { mutableStateOf(true) }
+    var preventDismissalOnScrimClick by remember { mutableStateOf(false) }
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
             slideOver = slideOver,
@@ -67,6 +68,7 @@ private fun CreateActivityUI() {
             skipOpenState = skipOpenState,
             expandable = expandable,
             showHandle = showHandle,
+            preventDismissalOnScrimClick = preventDismissalOnScrimClick,
             drawerContent =
             if (listContent)
                 getAndroidViewAsContent(selectedContent)
@@ -185,6 +187,26 @@ private fun CreateActivityUI() {
                             },
                             checkedState = skipOpenState,
                             enabledSwitch = expandable
+                        )
+                    }
+                )
+            }
+            item {
+                val preventDismissalOnScrimClickText = stringResource(id = R.string.prevent_scrim_click_dismissal)
+                ListItem.Header(title = preventDismissalOnScrimClickText,
+                    modifier = Modifier
+                        .toggleable(
+                            value = preventDismissalOnScrimClick,
+                            role = Role.Switch,
+                            onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick }
+                        )
+                        .clearAndSetSemantics {
+                            this.contentDescription = preventDismissalOnScrimClickText
+                        },
+                    trailingAccessoryContent = {
+                        ToggleSwitch(
+                            onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick },
+                            checkedState = preventDismissalOnScrimClick
                         )
                     }
                 )
@@ -314,6 +336,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     skipOpenState: Boolean,
     scrimVisible: Boolean,
     showHandle: Boolean,
+    preventDismissalOnScrimClick: Boolean,
     drawerContent: @Composable ((() -> Unit) -> Unit),
 ) {
     val scope = rememberCoroutineScope()
@@ -346,7 +369,8 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         drawerContent = { drawerContent(close) },
         scrimVisible = scrimVisible,
         slideOver = slideOver,
-        showHandle = showHandle
+        showHandle = showHandle,
+        preventDismissalOnScrimClick = preventDismissalOnScrimClick
     )
 }
 

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -1,6 +1,9 @@
 package com.microsoft.fluentuidemo.demos
 
+import android.content.Context
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -298,6 +301,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         drawerState = drawerState,
         drawerContent = { drawerContent(close) },
         behaviorType = behaviorType,
-        scrimVisible = scrimVisible
+        scrimVisible = scrimVisible,
+        onScrimClick = { Log.i("Drawer", "Scrim clicked to close") }
     )
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -68,6 +68,7 @@ private fun CreateActivityUI() {
     var dynamicSizeContent by remember { mutableStateOf(false) }
     var nestedDrawerContent by remember { mutableStateOf(false) }
     var listContent by remember { mutableStateOf(true) }
+    var preventDismissalOnScrimClick by remember { mutableStateOf(false) }
     var selectedContent by remember { mutableStateOf(ContentType.FULL_SCREEN_SCROLLABLE_CONTENT) }
     var selectedBehaviorType by remember { mutableStateOf(BehaviorType.BOTTOM_SLIDE_OVER) }
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -80,7 +81,8 @@ private fun CreateActivityUI() {
             } else {
                 getDynamicListGeneratorAsContent()
             },
-            scrimVisible = scrimVisible
+            scrimVisible = scrimVisible,
+            preventDismissalOnScrimClick = preventDismissalOnScrimClick
         )
         LazyColumn(horizontalAlignment = Alignment.CenterHorizontally) {
             item {
@@ -167,6 +169,26 @@ private fun CreateActivityUI() {
                         checkedState = scrimVisible
                     )
                 }
+                )
+            }
+            item {
+                val preventDismissalOnScrimClickText = stringResource(id = R.string.prevent_scrim_click_dismissal)
+                ListItem.Header(title = preventDismissalOnScrimClickText,
+                    modifier = Modifier
+                        .toggleable(
+                            value = preventDismissalOnScrimClick,
+                            role = Role.Switch,
+                            onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick }
+                        )
+                        .clearAndSetSemantics {
+                            this.contentDescription = preventDismissalOnScrimClickText
+                        },
+                    trailingAccessoryContent = {
+                        ToggleSwitch(
+                            onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick },
+                            checkedState = preventDismissalOnScrimClick
+                        )
+                    }
                 )
             }
 
@@ -272,7 +294,8 @@ private fun CreateActivityUI() {
 private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     behaviorType: BehaviorType,
     drawerContent: @Composable ((() -> Unit) -> Unit),
-    scrimVisible: Boolean = true
+    scrimVisible: Boolean = true,
+    preventDismissalOnScrimClick: Boolean
 ) {
     val scope = rememberCoroutineScope()
     val drawerState = rememberDrawerState()
@@ -302,6 +325,6 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         drawerContent = { drawerContent(close) },
         behaviorType = behaviorType,
         scrimVisible = scrimVisible,
-        onScrimClick = { Log.i("Drawer", "Scrim clicked to close") }
+        preventDismissalOnScrimClick = preventDismissalOnScrimClick
     )
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -1,9 +1,6 @@
 package com.microsoft.fluentuidemo.demos
 
-import android.content.Context
 import android.os.Bundle
-import android.util.Log
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -887,6 +887,8 @@
     <string name="drawer_expandable">Expandable</string>
     <!-- UI Label for direct swipe down dismiss-->
     <string name="skip_open_state">Skip Open State</string>
+    <!-- UI Label for direct swipe down dismiss-->
+    <string name="prevent_scrim_click_dismissal">Prevent Dismissal on Scrim Click</string>
     <!-- UI Label for Show Handle -->
     <string name="drawer_show_handle">Show Handle</string>
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -50,14 +50,8 @@ import com.microsoft.fluentui.tokenized.calculateFraction
 import com.microsoft.fluentui.util.dpToPx
 import com.microsoft.fluentui.util.pxToDp
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -301,10 +301,16 @@ private fun Scrim(
     open: Boolean,
     onClose: () -> Unit,
     fraction: () -> Float,
-    color: Color
+    color: Color,
+    onScrimClick: () -> Unit = {},
 ) {
     val dismissDrawer = if (open) {
-        Modifier.pointerInput(onClose) { detectTapGestures { onClose() } }
+        Modifier.pointerInput(onClose) {
+            detectTapGestures {
+                onClose()
+                onScrimClick()
+            }
+        }
     } else {
         Modifier
     }
@@ -473,6 +479,7 @@ private fun Modifier.bottomDrawerSwipeable(
  * drawer sheet
  * @param drawerBackground background color to be used for the drawer sheet
  * @param scrimColor color of the scrim that obscures content when the drawer is open
+ * @param onScrimClick callback to be invoked when the scrim is clicked
  *
  * @throws IllegalStateException when parent has [Float.POSITIVE_INFINITY] width
  */
@@ -487,7 +494,8 @@ private fun HorizontalDrawer(
     scrimColor: Color,
     scrimVisible: Boolean,
     onDismiss: () -> Unit,
-    drawerContent: @Composable () -> Unit
+    drawerContent: @Composable () -> Unit,
+    onScrimClick: () -> Unit = {}
 ) {
     BoxWithConstraints(modifier.fillMaxSize()) {
         val modalDrawerConstraints = constraints
@@ -531,6 +539,7 @@ private fun HorizontalDrawer(
                     calculateFraction(minValue, maxValue, drawerState.offset.value)
                 },
                 color = if (scrimVisible) scrimColor else Color.Transparent,
+                onScrimClick = onScrimClick
             )
 
             Box(
@@ -605,7 +614,8 @@ private fun TopDrawer(
     scrimColor: Color,
     scrimVisible: Boolean,
     onDismiss: () -> Unit,
-    drawerContent: @Composable () -> Unit
+    drawerContent: @Composable () -> Unit,
+    onScrimClick: () -> Unit = {}
 ) {
     BoxWithConstraints(modifier.fillMaxSize()) {
         val fullHeight = constraints.maxHeight.toFloat()
@@ -656,6 +666,7 @@ private fun TopDrawer(
                     calculateFraction(minValue, maxValue, drawerState.offset.value)
                 },
                 color = if (scrimVisible) scrimColor else Color.Transparent,
+                onScrimClick = onScrimClick
             )
 
             Box(
@@ -746,7 +757,8 @@ private fun BottomDrawer(
     slideOver: Boolean,
     showHandle: Boolean,
     onDismiss: () -> Unit,
-    drawerContent: @Composable () -> Unit
+    drawerContent: @Composable () -> Unit,
+    onScrimClick: () -> Unit = {}
 ) {
     BoxWithConstraints(modifier.fillMaxSize()) {
         val fullHeight = constraints.maxHeight.toFloat()
@@ -774,7 +786,7 @@ private fun BottomDrawer(
                         drawerState.anchors.maxBy { it.value }?.value!!
                     }
                     else if (drawerState.skipOpenState) {
-                        DrawerValue.Expanded
+                           DrawerValue.Expanded
                     } else {
                         DrawerValue.Open
                     }
@@ -786,6 +798,7 @@ private fun BottomDrawer(
                 }
             },
             color = if (scrimVisible) scrimColor else Color.Transparent,
+            onScrimClick = onScrimClick
         )
 
         Box(
@@ -934,6 +947,7 @@ private fun BottomDrawer(
  * @param scrimVisible create obscures background when scrim visible set to true when the drawer is open. The default value is true
  * @param drawerTokens tokens to provide appearance values. If not provided then drawer tokens will be picked from [FluentTheme]
  * @param drawerContent composable that represents content inside the drawer
+ * @param onScrimClick callback to be invoked when the scrim is clicked
  *
  * @throws IllegalStateException when parent has [Float.POSITIVE_INFINITY] width
  */
@@ -945,7 +959,8 @@ fun Drawer(
     drawerState: DrawerState = rememberDrawerState(),
     scrimVisible: Boolean = true,
     drawerTokens: DrawerTokens? = null,
-    drawerContent: @Composable () -> Unit
+    drawerContent: @Composable () -> Unit,
+    onScrimClick: () -> Unit = {},
 ) {
     if (drawerState.enable) {
         val themeID =
@@ -1000,7 +1015,8 @@ fun Drawer(
                     slideOver = behaviorType == BehaviorType.BOTTOM_SLIDE_OVER,
                     showHandle = true,
                     onDismiss = close,
-                    drawerContent = drawerContent
+                    drawerContent = drawerContent,
+                    onScrimClick = onScrimClick
                 )
                 BehaviorType.TOP -> TopDrawer(
                     modifier = modifier,
@@ -1012,7 +1028,8 @@ fun Drawer(
                     scrimColor = scrimColor,
                     scrimVisible = scrimVisible,
                     onDismiss = close,
-                    drawerContent = drawerContent
+                    drawerContent = drawerContent,
+                    onScrimClick = onScrimClick
                 )
 
                 BehaviorType.LEFT_SLIDE_OVER, BehaviorType.RIGHT_SLIDE_OVER -> HorizontalDrawer(
@@ -1025,7 +1042,8 @@ fun Drawer(
                     scrimColor = scrimColor,
                     scrimVisible = scrimVisible,
                     onDismiss = close,
-                    drawerContent = drawerContent
+                    drawerContent = drawerContent,
+                    onScrimClick = onScrimClick
                 )
             }
         }
@@ -1047,6 +1065,7 @@ fun Drawer(
  * @param windowInsetsType Type window insets to be passed to the bottom drawer window via PaddingValues params. The default value is WindowInsetsCompat.Type.systemBars()
  * @param drawerTokens tokens to provide appearance values. If not provided then drawer tokens will be picked from [FluentTheme]
  * @param drawerContent composable that represents content inside the drawer
+ * @param onScrimClick callback to be invoked when the scrim is clicked
  *
  * @throws IllegalStateException when parent has [Float.POSITIVE_INFINITY] width
  */
@@ -1060,7 +1079,8 @@ fun BottomDrawer(
     showHandle: Boolean = true,
     windowInsetsType: Int = WindowInsetsCompat.Type.systemBars(),
     drawerTokens: DrawerTokens? = null,
-    drawerContent: @Composable () -> Unit
+    drawerContent: @Composable () -> Unit,
+    onScrimClick: () -> Unit = {},
 ) {
     if (drawerState.enable) {
         val themeID =
@@ -1107,7 +1127,8 @@ fun BottomDrawer(
                 slideOver = slideOver,
                 showHandle = showHandle,
                 onDismiss = close,
-                drawerContent = drawerContent
+                drawerContent = drawerContent,
+                onScrimClick = onScrimClick
             )
         }
     }


### PR DESCRIPTION
### Problem 

1. The user needs to set telemetry for clicks outside a drawer of type ‘bottom slide over’ and disable the action of closing the drawer by such clicks. They also want to differentiate between closing the drawer via a button within it and clicking outside the drawer content.
2. An option to disable closing of Drawer when scrim is clicked is not present. 


### Root cause 
By design, 

1. there was no way of identifying or providing a callback for different type of closing.
2. Such option wasn't present

### Fix

1. Have Provided a callback for on Scrim Click
2. A new parameter preventDismissalOnScrimClick has been added to the API, which provides users this option

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots
Just an Example:
![image](https://github.com/microsoft/fluentui-android/assets/68989156/ff0d8c1f-3cd4-4174-a1e5-9f7921b10661)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Screenshot_2023-11-03-17-48-31-04_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/8665cd8b-d6ea-4a1f-81f7-914fa8a72668)|![image](https://github.com/microsoft/fluentui-android/assets/68989156/cb65b5c6-0379-4f2f-a641-9b9f3fb85424)|
|![Screenshot_2023-11-03-17-48-53-92_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/10ba8457-97c8-4c89-9a8a-7deed31ad152)|![image](https://github.com/microsoft/fluentui-android/assets/68989156/7afe1980-3c44-4f09-ac17-729409ed5aa2)|

### ScreenRecording:




https://github.com/microsoft/fluentui-android/assets/68989156/4f762812-d4a5-47a2-9214-073ad8ff4ec2





### Pull request checklist
This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
