### PR TITLE
v1 Persistent Bottom Sheet talkback focus collapse issue, Collapse-set-accessibility-to-imp

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -251,7 +251,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
-        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES)  }
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -251,7 +251,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
-        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) }
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -251,7 +251,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
-        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES)  }
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES)     }
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -251,7 +251,7 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
         if(focusDrawerHandle) {
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
-        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES)     }
+        backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {


### PR DESCRIPTION
### Problem 
The "importantForAccessibility" attribute was being wrongly set when collapse() action is performed for Persistent bottom Sheet
### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
