### PR TITLE
Adding end padding for snackbar text

### DIFF
--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -125,7 +125,7 @@ fun Snackbar(
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.SnackbarControlType] as SnackBarTokens
 
     val snackBarInfo = SnackBarInfo(metadata.style, !metadata.subTitle.isNullOrBlank())
-    var textPaddingValues = if(metadata.actionText != null) PaddingValues(start = 16.dp, top = 12.dp, bottom = 12.dp, end = 16.dp) else PaddingValues(start = 16.dp, top = 12.dp, bottom = 12.dp)
+    var textPaddingValues = if(metadata.actionText == null && !metadata.enableDismiss ) PaddingValues(start = 16.dp, top = 12.dp, bottom = 12.dp, end = 16.dp) else PaddingValues(start = 16.dp, top = 12.dp, bottom = 12.dp)
 
     NotificationContainer(
         notificationMetadata = metadata,


### PR DESCRIPTION
### Problem 
End padding of the snackbar does not exist
### Root cause 
No end padding provided in the snackbar impl
### Fix
Added end padding conditionally

### Validations
peer review and manual testing
(how the change was tested, including both manual and automated tests)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
