### PR TITLE
changed selected string of Pill button for v2 cardNudge only

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2CardNudgeActivity.kt
@@ -291,7 +291,8 @@ class V2CardNudgeActivity : V2DemoActivity() {
                                             buttonPressed,
                                             Toast.LENGTH_SHORT
                                         ).show()
-                                    }
+                                    },
+                                    isPartOfCardNudge = true
                                 ) else null,
                             dismissOnClick = if (dismissEnabled) {
                                 {

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -57,6 +57,7 @@ data class PillMetaData(
     var enabled: Boolean = true,
     var selected: Boolean = false,
     var notificationDot: Boolean = false,
+    var isPartOfCardNudge: Boolean = false,
 )
 
 /**
@@ -145,7 +146,8 @@ fun PillButton(
         onClick = pillMetaData.onClick
     )
 
-    val selectedString = if (pillMetaData.selected)
+    val selectedString = if(pillMetaData.isPartOfCardNudge) ""
+    else if (pillMetaData.selected)
         LocalContext.current.resources.getString(R.string.fluentui_selected)
     else
         LocalContext.current.resources.getString(R.string.fluentui_not_selected)


### PR DESCRIPTION
### Problem 
The pill button (Sction button) of card nudge was announcing "not selected" in talkback. This is due to the fact that slected string of pill button could either be "selected" or "not selected", now i added one more option to make it ""(empty string)
### Root cause 

### Fix
In Pill metadata, have added an attribute boolean isPartOfCardNudge, 
if it's true, selcted string is set to empty string

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots
before

https://github.com/microsoft/fluentui-android/assets/68989156/aa34153b-491c-4e23-be80-ac790d3e048f

after

https://github.com/microsoft/fluentui-android/assets/68989156/4c34641c-b6a4-417f-92c5-179ca31c1db4



|


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
