### PR TITLE
hardware-keyboard focus going in background when expanded

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/PersistentBottomSheet.kt
@@ -252,6 +252,9 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
         backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
+        backgroundViews?.forEach { view ->
+            setDescendantsFocusable(view, true)
+        }
     }
 
     fun expand(focusDrawerHandle: Boolean = true) {
@@ -261,11 +264,28 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
         backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) }
+        backgroundViews?.forEach { view ->
+            setDescendantsFocusable(view, false)
+        }
     }
+    fun setDescendantsFocusable(view: View, focusable: Boolean) {
+        view.isFocusable = focusable
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val child = view.getChildAt(i)
+                setDescendantsFocusable(child, focusable)
+            }
+        }
+    }
+
+
 
     fun hide(){
         persistentSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
         backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
+        backgroundViews?.forEach { view ->
+            setDescendantsFocusable(view, true)
+        }
     }
 
     fun show(expanded: Boolean = false, focusDrawerHandle: Boolean = true) {
@@ -279,6 +299,9 @@ class PersistentBottomSheet @JvmOverloads constructor(context: Context, attrs: A
             persistentSheetBinding.sheetDrawerHandle.requestFocus()
         }
         backgroundViews?.let { setImportantForAccessibility(it, View.IMPORTANT_FOR_ACCESSIBILITY_YES) }
+        backgroundViews?.forEach { view ->
+            setDescendantsFocusable(view, true)
+        }
     }
 
     fun updateBottomSheetLayoutParams(peekHeight: Int = itemLayoutParam.defaultPeekHeight,


### PR DESCRIPTION
### Problem 
The Hardware keyboard focus goes into background views (when pressing "TAB" key) when persistent bottom sheet is in expanded state.
### Root cause 

### Fix
set background views focusable = false, when sheet is expanded, and revert the action when it is collapsed or hidden etc.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

Before: (continuously pressing tab key in the video )

https://github.com/microsoft/fluentui-android/assets/68989156/1bb1961d-99e4-478a-bb44-e45974d441d1




After: 

https://github.com/microsoft/fluentui-android/assets/68989156/2d3fed11-25e6-41c1-afad-a17a4f570142




### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
