### PR TITLE
Ripple Effect for navigation Icon in v2 App Bar

### DIFF
--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Composable=
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -79,6 +79,7 @@ fun AppBar(
     logo: @Composable (() -> Unit)? = null,
     searchMode: Boolean = false,
     navigationIcon: FluentIcon = FluentIcon(AppBarIcons.Arrowback, flipOnRtl = true),
+    navigationIconModifier: Modifier = Modifier,
     postTitleIcon: FluentIcon = FluentIcon(),
     preSubtitleIcon: FluentIcon = FluentIcon(),
     postSubtitleIcon: FluentIcon = FluentIcon(
@@ -140,7 +141,9 @@ fun AppBar(
                 if (appBarSize != AppBarSize.Large && navigationIcon.isIconAvailable()) {
                     Icon(
                         navigationIcon,
-                        modifier = Modifier
+                        modifier =
+                        Modifier
+                            .then(navigationIconModifier)
                             .padding(token.navigationIconPadding(appBarInfo))
                             .size(token.leftIconSize(appBarInfo)),
                         tint = token.navigationIconColor(appBarInfo)

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -200,7 +200,7 @@ fun AppBar(
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
-                            if (postTitleIcon.isIconAvailable()  && appBarSize == AppBarSize.Small)
+                            if (postTitleIcon.isIconAvailable() && appBarSize == AppBarSize.Small)
                                 Icon(
                                     postTitleIcon.value(),
                                     postTitleIcon.contentDescription,

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -53,7 +53,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
  * @param logo Composable to be placed at left of Title. Guideline is to not increase a size of 32x32. Default: [null]
  * @param searchMode Boolean to enable/disable searchMode. Default: [false]
  * @param navigationIcon Navigate Back Icon to be placed at extreme left. Default: [SearchBarIcons.Arrowback]
- * @param navigationIconModifier Modifier for navigation Icon to change behaviour especially for click. Default: [null]
  * @param postTitleIcon Icon to be placed after title making the title clickable. Default: Empty [FluentIcon]
  * @param preSubtitleIcon Icon to be placed before subtitle. Default: Empty [FluentIcon]
  * @param postSubtitleIcon Icon to be placed after subtitle. Default: [ListItemIcons.Chevron]
@@ -83,7 +82,6 @@ fun AppBar(
     logo: @Composable (() -> Unit)? = null,
     searchMode: Boolean = false,
     navigationIcon: FluentIcon = FluentIcon(AppBarIcons.Arrowback, flipOnRtl = true),
-    navigationIconModifier: Modifier? = null,
     postTitleIcon: FluentIcon = FluentIcon(),
     preSubtitleIcon: FluentIcon = FluentIcon(),
     postSubtitleIcon: FluentIcon = FluentIcon(
@@ -147,14 +145,11 @@ fun AppBar(
                         navigationIcon,
                         modifier =
                         Modifier
-                            .then(
-                                navigationIconModifier
-                                    ?: Modifier.clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = rememberRipple(),
-                                        enabled = true,
-                                        onClick = navigationIcon.onClick ?: {}
-                                    )
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = rememberRipple(),
+                                enabled = true,
+                                onClick = navigationIcon.onClick ?: {}
                             )
                             .padding(token.navigationIconPadding(appBarInfo))
                             .size(token.leftIconSize(appBarInfo)),

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -53,6 +53,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
  * @param logo Composable to be placed at left of Title. Guideline is to not increase a size of 32x32. Default: [null]
  * @param searchMode Boolean to enable/disable searchMode. Default: [false]
  * @param navigationIcon Navigate Back Icon to be placed at extreme left. Default: [SearchBarIcons.Arrowback]
+ * @param navigationIconModifier Modifier for navigation Icon to change behaviour especially for click. Default: [null]
  * @param postTitleIcon Icon to be placed after title making the title clickable. Default: Empty [FluentIcon]
  * @param preSubtitleIcon Icon to be placed before subtitle. Default: Empty [FluentIcon]
  * @param postSubtitleIcon Icon to be placed after subtitle. Default: [ListItemIcons.Chevron]

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -200,7 +200,7 @@ fun AppBar(
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
-                            if (postTitleIcon.isIconAvailable() && appBarSize == AppBarSize.Small)
+                            if (postTitleIcon.isIconAvailable()  && appBarSize == AppBarSize.Small)
                                 Icon(
                                     postTitleIcon.value(),
                                     postTitleIcon.contentDescription,

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -3,9 +3,12 @@ package com.microsoft.fluentui.tokenized
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.Composable=
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -79,7 +82,7 @@ fun AppBar(
     logo: @Composable (() -> Unit)? = null,
     searchMode: Boolean = false,
     navigationIcon: FluentIcon = FluentIcon(AppBarIcons.Arrowback, flipOnRtl = true),
-    navigationIconModifier: Modifier = Modifier,
+    navigationIconModifier: Modifier? = null,
     postTitleIcon: FluentIcon = FluentIcon(),
     preSubtitleIcon: FluentIcon = FluentIcon(),
     postSubtitleIcon: FluentIcon = FluentIcon(
@@ -143,7 +146,15 @@ fun AppBar(
                         navigationIcon,
                         modifier =
                         Modifier
-                            .then(navigationIconModifier)
+                            .then(
+                                navigationIconModifier
+                                    ?: Modifier.clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = rememberRipple(),
+                                        enabled = true,
+                                        onClick = navigationIcon.onClick ?: {}
+                                    )
+                            )
                             .padding(token.navigationIconPadding(appBarInfo))
                             .size(token.leftIconSize(appBarInfo)),
                         tint = token.navigationIconColor(appBarInfo)


### PR DESCRIPTION
### Problem 
The user waned to show ripple effect in Navigation Icon.
### Root cause 
The modifier wasn't extended
### Fix

- The modifier "NavigationIconModifier" can be passed to change default behaviour/ look.
- Default behaviour of ripple on navigation icon click has been added


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

Before: (No ripple)

https://github.com/microsoft/fluentui-android/assets/68989156/93dc1c1d-e80f-4507-b004-1a5902c3448f


After (Ripple Effect)


https://github.com/microsoft/fluentui-android/assets/68989156/d1ad1264-c040-4d6e-b57b-61e7e1120e98



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
