### PR TITLE
Sticky Behaviour feature for v2 BottomSheet

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -321,7 +321,7 @@ private fun CreateActivityUI() {
                 ToggleSwitch(checkedState = stickyBehaviorState,
                     onValueChange = {
                         stickyBehaviorState = it
-                        if(stickyBehaviorState == false) {
+                        if(!stickyBehaviorState) {
                             stickyThresholdUpwardDrag = null
                             stickyThresholdDownwardDrag = null
                         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -317,8 +317,10 @@ private fun CreateActivityUI() {
                 )
                 Slider(
                     modifier = Modifier.width(100.dp).height(50.dp).padding(0.dp, 0.dp, 0.dp, 0.dp),
-                    value = stickyThresholdUpwardDrag?:56f,
-                    onValueChange = { stickyThresholdUpwardDrag = it },
+                    value = stickyThresholdUpwardDrag,
+                    onValueChange = { stickyThresholdUpwardDrag = it
+                                    peekHeightState+=0.0001.dp
+                                    },
                     valueRange = 0f..500f,
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],
@@ -351,8 +353,10 @@ private fun CreateActivityUI() {
                 )
                 Slider(
                     modifier = Modifier.width(100.dp).height(50.dp).padding(0.dp, 0.dp, 0.dp, 0.dp),
-                    value = stickyThresholdDownwardDrag?:56f,
-                    onValueChange = { stickyThresholdDownwardDrag = it },
+                    value = stickyThresholdDownwardDrag,
+                    onValueChange = { stickyThresholdDownwardDrag = it
+                                    peekHeightState+=0.0001.dp
+                                    },
                     valueRange = 0f..500f,
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -104,11 +104,8 @@ private fun CreateActivityUI() {
 
     var peekHeightState by remember { mutableStateOf(110.dp) }
 
-    //var stickyThreshold by remember { mutableStateOf(Pair(56f,56f)) }
-    var stickyThresholdUpwardDrag: Float? by remember { mutableStateOf(null) }
-    var stickyThresholdDownwardDrag: Float? by remember { mutableStateOf(null) }
-
-    var stickyBehaviorState by remember { mutableStateOf(false) }
+    var stickyThresholdUpwardDrag: Float by remember { mutableStateOf(56f) }
+    var stickyThresholdDownwardDrag: Float by remember { mutableStateOf(56f) }
 
     var hidden by remember { mutableStateOf(true) }
 
@@ -154,7 +151,6 @@ private fun CreateActivityUI() {
         sheetState = bottomSheetState,
         slideOver = slideOverState,
         enableSwipeDismiss = enableSwipeDismiss,
-        stickyBehavior = stickyBehaviorState,
         stickyThresholdUpward = stickyThresholdUpwardDrag,
         stickyThresholdDownward = stickyThresholdDownwardDrag
     ) {
@@ -304,35 +300,7 @@ private fun CreateActivityUI() {
                     onValueChange = { enableSwipeDismiss = it }
                 )
             }
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(30.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                BasicText(
-                    text = "Sticky Behavior",
-                    modifier = Modifier.weight(1F),
-                    style = TextStyle(
-                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
-                            themeMode = ThemeMode.Auto
-                        )
-                    )
-                )
-                ToggleSwitch(checkedState = stickyBehaviorState,
-                    onValueChange = {
-                        stickyBehaviorState = it
-                        if(!stickyBehaviorState) {
-                            stickyThresholdUpwardDrag = null
-                            stickyThresholdDownwardDrag = null
-                        }
-                        else {
-                            stickyThresholdUpwardDrag = 56f
-                            stickyThresholdDownwardDrag = 56f
-                        }
-                    }
-                )
-            }
-            // New Row for Sticky Threshold
+            // New Row for Sticky Threshold Downward Drag
             Row(
                 horizontalArrangement = Arrangement.spacedBy(30.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -355,8 +323,7 @@ private fun CreateActivityUI() {
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],
                         activeTrackColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color10],
-                    ),
-                    enabled = stickyBehaviorState
+                    )
                 )
                 BasicText(
                     text = "%.1fdp".format(stickyThresholdUpwardDrag),
@@ -367,7 +334,7 @@ private fun CreateActivityUI() {
                     )
                 )
             }
-            // New Row for Sticky Threshold
+            // New Row for Sticky Threshold Upward Drag
             Row(
                 horizontalArrangement = Arrangement.spacedBy(30.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -390,8 +357,7 @@ private fun CreateActivityUI() {
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],
                         activeTrackColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color10],
-                    ),
-                    enabled = stickyBehaviorState
+                    )
                 )
                 BasicText(
                     text = "%.1fdp".format(stickyThresholdDownwardDrag),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -11,11 +11,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Slider
+import androidx.compose.material.SliderDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.ArrowForward
@@ -32,6 +35,7 @@ import androidx.compose.material.icons.outlined.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -100,6 +104,12 @@ private fun CreateActivityUI() {
 
     var peekHeightState by remember { mutableStateOf(110.dp) }
 
+    //var stickyThreshold by remember { mutableStateOf(Pair(56f,56f)) }
+    var stickyThresholdUpwardDrag: Float? by remember { mutableStateOf(null) }
+    var stickyThresholdDownwardDrag: Float? by remember { mutableStateOf(null) }
+
+    var stickyBehaviorState by remember { mutableStateOf(false) }
+
     var hidden by remember { mutableStateOf(true) }
 
     val bottomSheetState = rememberBottomSheetState(BottomSheetValue.Shown)
@@ -143,7 +153,10 @@ private fun CreateActivityUI() {
         showHandle = showHandleState,
         sheetState = bottomSheetState,
         slideOver = slideOverState,
-        enableSwipeDismiss = enableSwipeDismiss
+        enableSwipeDismiss = enableSwipeDismiss,
+        stickyBehavior = stickyBehaviorState,
+        stickyThresholdUpward = stickyThresholdUpwardDrag,
+        stickyThresholdDownward = stickyThresholdDownwardDrag
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -289,6 +302,104 @@ private fun CreateActivityUI() {
                     modifier = Modifier.testTag(BOTTOM_SHEET_ENABLE_SWIPE_DISMISS_TEST_TAG),
                     checkedState = enableSwipeDismiss,
                     onValueChange = { enableSwipeDismiss = it }
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(30.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BasicText(
+                    text = "Sticky Behavior",
+                    modifier = Modifier.weight(1F),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+                ToggleSwitch(checkedState = stickyBehaviorState,
+                    onValueChange = {
+                        stickyBehaviorState = it
+                        if(stickyBehaviorState == false) {
+                            stickyThresholdUpwardDrag = null
+                            stickyThresholdDownwardDrag = null
+                        }
+                        else {
+                            stickyThresholdUpwardDrag = 56f
+                            stickyThresholdDownwardDrag = 56f
+                        }
+                    }
+                )
+            }
+            // New Row for Sticky Threshold
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(30.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BasicText(
+                    text = "Sticky Threshold Upward Drag",
+                    modifier = Modifier.weight(1F),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+                Slider(
+                    modifier = Modifier.width(100.dp).height(50.dp).padding(0.dp, 0.dp, 0.dp, 0.dp),
+                    value = stickyThresholdUpwardDrag?:56f,
+                    onValueChange = { stickyThresholdUpwardDrag = it },
+                    valueRange = 0f..500f,
+                    colors = SliderDefaults.colors(
+                        thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],
+                        activeTrackColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color10],
+                    ),
+                    enabled = stickyBehaviorState
+                )
+                BasicText(
+                    text = "%.1fdp".format(stickyThresholdUpwardDrag),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+            }
+            // New Row for Sticky Threshold
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(30.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BasicText(
+                    text = "Sticky Threshold Downward Drag",
+                    modifier = Modifier.weight(1F),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+                Slider(
+                    modifier = Modifier.width(100.dp).height(50.dp).padding(0.dp, 0.dp, 0.dp, 0.dp),
+                    value = stickyThresholdDownwardDrag?:56f,
+                    onValueChange = { stickyThresholdDownwardDrag = it },
+                    valueRange = 0f..500f,
+                    colors = SliderDefaults.colors(
+                        thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],
+                        activeTrackColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color10],
+                    ),
+                    enabled = stickyBehaviorState
+                )
+                BasicText(
+                    text = "%.1fdp".format(stickyThresholdDownwardDrag),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
                 )
             }
             Row(

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -210,6 +210,9 @@ private const val BottomSheetOpenFraction = 0.5f
  * @param slideOver if true, then sheetContent would be drawn in full length & it just get slided
  * in the visible region. If false then, the sheetContainer placed at the bottom & its height could be at peekHeight, fullheight or hidden when dragged by Handle or swipe down.
  * @param enableSwipeDismiss if false, bottomSheet will not be dismissed after swipe down gesture. Default value is false.
+ * @param stickyBehavior if true, bottomSheet will stick to the Expanded and Shown State when dragged beyond the stickyThresholdUpward or stickyThresholdDownward. Default value is false. When it's false the default Up and Down Drag Threshold value is 56dp
+ * @param stickyThresholdUpward the threshold value for drag up gesture when stickyBehavior is true. Default value is Null. If StickyBehavior is true then stickyThresholdUpward should be provided.
+ * @param stickyThresholdDownward the threshold value for drag down gesture when stickyBehavior is true. Default value is Null. If StickyBehavior is true then stickyThresholdUpward should be provided.
  * @param bottomSheetTokens tokens to provide appearance values. If not provided then bottomSheet
  * tokens will be picked from [AppThemeController]
  * @param content The content of rest of the screen.
@@ -519,9 +522,9 @@ private fun Modifier.bottomSheetSwipeable(
                         val fromKey = anchors.entries.firstOrNull { it.value == from }?.key
                         val toKey = anchors.entries.firstOrNull { it.value == to }?.key
                         if (fromKey != null && toKey != null && fromKey < toKey) {
-                            FixedThreshold(stickyThresholdUpward!!.dp) // Threshold for drag down
+                            FixedThreshold(stickyThresholdDownward!!.dp) // Threshold for drag down
                         } else {
-                            FixedThreshold(stickyThresholdDownward!!.dp)  // Threshold for drag up
+                            FixedThreshold(stickyThresholdUpward!!.dp)  // Threshold for drag up
                         }
                     },
                     resistance = null

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -211,7 +211,7 @@ private const val BottomSheetOpenFraction = 0.5f
  * in the visible region. If false then, the sheetContainer placed at the bottom & its height could be at peekHeight, fullheight or hidden when dragged by Handle or swipe down.
  * @param enableSwipeDismiss if false, bottomSheet will not be dismissed after swipe down gesture. Default value is false.
  * @param stickyThresholdUpward The threshold for the upward drag gesture till which the sheet behaves sticky. Default value is 56f.
- * @param stickyThresholdDownward The threshold for the downward drag gesture till which the sheet behaves sticky. Default value is 56f.
+ * @param stickyThresholdDownward The threshold for the downward drag gesture till which the sheet behaves sticky. Default value is 56f.y
  * @param bottomSheetTokens tokens to provide appearance values. If not provided then bottomSheet
  * tokens will be picked from [AppThemeController]
  * @param content The content of rest of the screen.
@@ -513,9 +513,10 @@ private fun Modifier.bottomSheetSwipeable(
                     val toKey = anchors.entries.firstOrNull { it.value == to }?.key
                     if (fromKey != null && toKey != null && fromKey < toKey) {
                         FixedThreshold(stickyThresholdDownward!!.dp) // Threshold for drag down
-                    } else {
+                    } else if(fromKey != null && toKey != null && fromKey > toKey) {
                         FixedThreshold(stickyThresholdUpward!!.dp)  // Threshold for drag up
                     }
+                    else { FixedThreshold(56.dp) } //fallback if null
                 },
                 resistance = null
             )

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -511,12 +511,10 @@ private fun Modifier.bottomSheetSwipeable(
                 thresholds = { from, to ->
                     val fromKey = anchors.entries.firstOrNull { it.value == from }?.key
                     val toKey = anchors.entries.firstOrNull { it.value == to }?.key
-                    if (fromKey != null && toKey != null && fromKey < toKey) {
-                        FixedThreshold(stickyThresholdDownward!!.dp) // Threshold for drag down
-                    } else if(fromKey != null && toKey != null && fromKey > toKey) {
-                        FixedThreshold(stickyThresholdUpward!!.dp)  // Threshold for drag up
-                    }
-                    else { FixedThreshold(56.dp) } //fallback if null
+
+                    if(fromKey == null || toKey == null) { FixedThreshold(56.dp) } //in case of null defaulting to 56.dp threshold
+                    else if (fromKey < toKey) { FixedThreshold(stickyThresholdDownward.dp) } // Threshold for drag down
+                    else{ FixedThreshold(stickyThresholdUpward.dp) } // Threshold for drag up
                 },
                 resistance = null
             )
@@ -546,11 +544,10 @@ private fun Modifier.bottomSheetSwipeable(
             thresholds = { from, to ->
                 val fromKey = anchors.entries.firstOrNull { it.value == from }?.key
                 val toKey = anchors.entries.firstOrNull { it.value == to }?.key
-                if (fromKey != null && toKey != null && fromKey < toKey) {
-                    FixedThreshold(stickyThresholdUpward!!.dp) // Threshold for drag up
-                } else {
-                    FixedThreshold(stickyThresholdDownward!!.dp)  // Threshold for drag down
-                }
+
+                if(fromKey == null || toKey == null) { FixedThreshold(56.dp) } //in case of null defaulting to 56 as a fallback
+                else if (fromKey < toKey) { FixedThreshold(stickyThresholdDownward.dp) } // Threshold for drag down
+                else{ FixedThreshold(stickyThresholdUpward.dp) } // Threshold for drag up
             },
             resistance = null
         )


### PR DESCRIPTION
### Problem 
Sticky behavior of the sheet was set to 56dp and not customizable.
### Root cause 
By design
### Fix
Now, we let users define the sticky threshold for both upward and downward drag. 
Check the screen recording to see how changing the threshold affects the sticky behavior of the bottomSheet.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Screenshot_2023-12-13-16-03-02-67_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/21604fd1-0e1e-478e-bb6b-0b514cab6c94) | ![image](https://github.com/microsoft/fluentui-android/assets/68989156/c3244053-f043-4929-b6d1-6c33c82f8153)) |


https://github.com/microsoft/fluentui-android/assets/68989156/f79984fe-b90b-48a9-85aa-52511e629552



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
