### PR TITLE
Adding disabled UI for v2textfield

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -168,7 +168,15 @@ fun TextField(
                 Spacer(Modifier.requiredWidth(16.dp))
             }
             Column(Modifier.weight(1F)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(modifier = Modifier.background(
+                    token
+                        .textAreaBackgroundBrush(textFieldInfo)
+                        .getBrushByState(
+                            enabled = enabled,
+                            selected = false,
+                            interactionSource = remember { MutableInteractionSource() }
+                        )
+                ), verticalAlignment = Alignment.CenterVertically) {
                     BasicTextField(
                         value = value,
                         onValueChange = onValueChange,
@@ -216,7 +224,11 @@ fun TextField(
                         },
                         textStyle = token.inputTextTypography(textFieldInfo).merge(
                             TextStyle(
-                                color = token.inputTextColor(textFieldInfo),
+                                color = token.inputTextColor(textFieldInfo).getColorByState(
+                                    enabled = enabled,
+                                    selected = false,
+                                    interactionSource = remember { MutableInteractionSource() }
+                                ),
                                 textDirection = TextDirection.ContentOrLtr
                             )
                         ),
@@ -239,7 +251,7 @@ fun TextField(
                                 )
                         )
                     }
-                    if (value.isNotBlank() && trailingAccessoryIcon?.isIconAvailable() == true) {
+                    if (enabled && value.isNotBlank() && trailingAccessoryIcon?.isIconAvailable() == true) {
                         Icon(
                             trailingAccessoryIcon,
                             Modifier

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TextFieldTokens.kt
@@ -13,6 +13,8 @@ import com.microsoft.fluentui.theme.token.ControlInfo
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.IControlToken
+import com.microsoft.fluentui.theme.token.StateBrush
+import com.microsoft.fluentui.theme.token.StateColor
 import kotlinx.parcelize.Parcelize
 
 open class TextFieldInfo(
@@ -28,6 +30,18 @@ open class TextFieldTokens : IControlToken, Parcelable {
     @Composable
     open fun backgroundBrush(textFieldInfo: TextFieldInfo): Brush {
         return SolidColor(FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value())
+    }
+
+    @Composable
+    open fun textAreaBackgroundBrush(textFieldInfo: TextFieldInfo): StateBrush {
+        return StateBrush(
+            rest = SolidColor(FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background1].value()),
+            disabled = SolidColor(
+                FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                    themeMode = FluentTheme.themeMode
+                )
+            )
+        )
     }
 
     @Composable
@@ -95,8 +109,11 @@ open class TextFieldTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun inputTextColor(textFieldInfo: TextFieldInfo): Color {
-        return FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value()
+    open fun inputTextColor(textFieldInfo: TextFieldInfo): StateColor {
+        return StateColor(
+            rest = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(),
+            disabled = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value()
+        )
     }
 
     @Composable


### PR DESCRIPTION
### Problem 
V2 Textfield when disabled does not show disabled ui
### Root cause 
Disable case not handled
### Fix
Added disable tokens for background and text color

### Validations
Manual testing and peer review
(how the change was tested, including both manual and automated tests)

### Screenshots
Disabled textfield
![image](https://github.com/microsoft/fluentui-android/assets/5608292/39f89ef7-be3f-4e18-8ec7-0a9dc8c5926b)

Enabled textfield
![image](https://github.com/microsoft/fluentui-android/assets/5608292/fee25a51-8fe9-4977-af86-dac25bc0da8e)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
