### PR TITLE
extending navigation icon modifier so user can change clickable etc

### DIFF
--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -88,6 +88,7 @@ fun AppBar(
         ListItemIcons.Chevron,
         contentDescription = LocalContext.current.resources.getString(R.string.fluentui_chevron)
     ),
+    navigationIconModifier: Modifier? = null,
     rightAccessoryView: @Composable (RowScope.() -> Unit)? = null,
     searchBar: @Composable (RowScope.() -> Unit)? = null,
     bottomBar: @Composable (RowScope.() -> Unit)? = null,
@@ -145,11 +146,14 @@ fun AppBar(
                         navigationIcon,
                         modifier =
                         Modifier
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = rememberRipple(),
-                                enabled = true,
-                                onClick = navigationIcon.onClick ?: {}
+                            .then(
+                                navigationIconModifier
+                                    ?: Modifier.clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = rememberRipple(),
+                                        enabled = true,
+                                        onClick = navigationIcon.onClick ?: {}
+                                    )
                             )
                             .padding(token.navigationIconPadding(appBarInfo))
                             .size(token.leftIconSize(appBarInfo)),


### PR DESCRIPTION
### Problem 
User wants to change ripple effect color in v2 appBar
### Root cause 
Navigation Icon's modifier is not extended.
### Fix
Created a param NavigationIconModifer, user can pass then own modifiers. 

Example: 
![image](https://github.com/microsoft/fluentui-android/assets/68989156/45900c48-44d5-42f0-9be8-babf1e8946ed)


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots
N/A
### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
