### PR TITLE
Created new token for nav icon ripple color for v2 AppBar

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -79,6 +79,11 @@ open class AppBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
+    open fun navigationIconRippleColor(): Color {
+        return Color.Unspecified
+    }
+
+    @Composable
     open fun titleIconColor(info: AppBarInfo): Color {
         return when (info.style) {
             FluentStyle.Neutral ->

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -15,8 +15,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.BlendMode.Companion.Color
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode.Companion.Color
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -70,7 +72,6 @@ const val APP_BAR = "Fluent App bar"
 const val APP_BAR_SUBTITLE = "Fluent App bar Subtitle"
 const val APP_BAR_BOTTOM_BAR = "Fluent App bar Bottom bar"
 const val APP_BAR_SEARCH_BAR = "Fluent App bar Search bar"
-
 @OptIn(ExperimentalTextApi::class)
 @Composable
 fun AppBar(
@@ -98,8 +99,10 @@ fun AppBar(
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
+
     val token = appBarTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AppBarControlType] as AppBarTokens
+
 
     val appBarInfo = AppBarInfo(style, appBarSize)
     Box(
@@ -147,7 +150,7 @@ fun AppBar(
                         Modifier
                             .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
-                                indication = rememberRipple(),
+                                indication = rememberRipple(color = token.navigationIconRippleColor()),
                                 enabled = true,
                                 onClick = navigationIcon.onClick ?: {}
                             )


### PR DESCRIPTION
### Problem 
Customization for Ripple Color in Nav Icon of v2 App bar not allowed.
### Root cause 

### Fix
Created a token in AppBarTokens to solve this issue which can be overriden

### Validations

(how the change was tested, including both manual and automated tests)

### Example

`class CustomAppBarTokens : AppBarTokens() {
 
    @Composable
    override fun navigationIconRippleColor(): Color {
        // Return the color you want here
        return Color.Red
    }
}`
Output:
![image](https://github.com/microsoft/fluentui-android/assets/68989156/2a99414c-bc35-4cfd-9413-9b513660dfcf)
### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
