### PR TITLE
v1 people picker, persona chip etc font resizing clipping bug fix

### DIFF
--- a/fluentui_persona/src/main/res/layout/view_persona_chip.xml
+++ b/fluentui_persona/src/main/res/layout/view_persona_chip.xml
@@ -8,7 +8,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="@dimen/fluentui_persona_chip_height"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/fluentui_persona_chip_height"
+    android:gravity="center_vertical"
     android:orientation="horizontal"
     android:padding="@dimen/fluentui_persona_chip_padding">
 


### PR DESCRIPTION
### Problem 
Persona Chip was clipping the text when text resized to max from android settings.
### Root cause 
The personachip height is a specific height
### Fix
Not to use fixed height, instead use wrap content and give a minimum height

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Screenshot_2023-12-20-13-58-20-29_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/b78d1295-89d8-43ca-897c-27e7e50bc4b0)| ![Screenshot_2023-12-20-13-00-43-17_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/19723cae-8d0d-4e55-b8f8-03d00d07b33e) |  
|![Screenshot_2023-12-20-13-58-56-51_ad3b258aa0cd3ec091b47fe7b71fec5b](https://github.com/microsoft/fluentui-android/assets/68989156/ff0cec98-af26-4a2d-a231-d0af741c50df) | ![Screenshot_2023-12-20-13-59-15-37_138c6ebfedc8e8a8cd1938476bab217a](https://github.com/microsoft/fluentui-android/assets/68989156/619b9ce2-de17-45bb-bc21-658724aca7fa) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
