### PR TITLE
updating rtl for textfield

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -202,11 +202,7 @@ fun TextField(
                         decorationBox = decorationBox ?: { innerTextField ->
                             if (value.isEmpty() && !hintText.isNullOrBlank()) {
                                 Box(
-                                    Modifier.fillMaxWidth(),
-                                    contentAlignment = if (LocalLayoutDirection.current == LayoutDirection.Rtl)
-                                        Alignment.CenterEnd
-                                    else
-                                        Alignment.CenterStart
+                                    Modifier.fillMaxWidth()
                                 ) {
                                     BasicText(
                                         hintText,
@@ -229,7 +225,7 @@ fun TextField(
                                     selected = false,
                                     interactionSource = remember { MutableInteractionSource() }
                                 ),
-                                textDirection = TextDirection.ContentOrLtr
+                                textDirection = if(LocalLayoutDirection.current == LayoutDirection.Ltr) TextDirection.Ltr else TextDirection.Rtl
                             )
                         ),
                         cursorBrush = token.cursorColor(textFieldInfo)

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -163,11 +163,7 @@ fun PeoplePicker(
             Box(
                 Modifier
                     .fillMaxWidth()
-                    .semantics { this.contentDescription = accessibilityAnnouncement },
-                contentAlignment = if (LocalLayoutDirection.current == LayoutDirection.Rtl)
-                    Alignment.CenterEnd
-                else
-                    Alignment.CenterStart
+                    .semantics { this.contentDescription = accessibilityAnnouncement }
             ) {
                 FlowRow {
                     if (selectedPeopleList.isNotEmpty()) {


### PR DESCRIPTION
### Problem 
v2textfield text does not comply to RTL layout. People picker fails the same because it internally used v2 textfield
### Root cause 
content alignment condition has been explicitly added to the textfield which is causing the issue
### Fix
Removed the condition and updated the cursor direction as well

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
