### PR TITLE
removing if condition for finding drawer height

### DIFF
--- a/FluentUI.Demo/src/main/AndroidManifest.xml
+++ b/FluentUI.Demo/src/main/AndroidManifest.xml
@@ -43,7 +43,8 @@
             android:windowSoftInputMode="adjustResize" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2DialogActivity" />
         <activity android:name="com.microsoft.fluentuidemo.V2DesignTokensActivity" />
-        <activity android:name="com.microsoft.fluentuidemo.demos.V2DrawerActivity" />
+        <activity android:name="com.microsoft.fluentuidemo.demos.V2DrawerActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity android:name="com.microsoft.fluentuidemo.demos.V2LabelActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2ListItemActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2MenuActivity"

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.focusTarget
@@ -630,6 +631,7 @@ private fun TopDrawer(
 
         Box(
             modifier = Modifier
+                .alpha(0f)
                 .layout { measurable, constraints ->
                     val placeable = measurable.measure(constraints)
                     layout(placeable.width, placeable.height) {


### PR DESCRIPTION
### Problem 
Drawer height changes on orientation change
### Root cause 
on orientation change "finding drawer height" code is not being called
### Fix
Removed if condition and check the drawer height every time.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

Before
![23-03-30-14-46-34_035402 (1)](https://github.com/microsoft/fluentui-android/assets/5608292/d7164709-dab5-44de-b029-5d78c97559b1)



After
![23-03-30-14-43-48_035126](https://github.com/microsoft/fluentui-android/assets/5608292/059187d0-9843-42e6-b1c7-d53ab678f72e)



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
