### PR TITLE
updating the drawer position to offset instead of anchors

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -293,7 +293,7 @@ private class DrawerPositionProvider(val offset: IntOffset) : PopupPositionProvi
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize
     ): IntOffset {
-        return IntOffset(anchorBounds.left + offset.x, anchorBounds.top + offset.y)
+        return IntOffset(offset.x, offset.y)
     }
 }
 


### PR DESCRIPTION
### Problem 
Drawer is created at wrong anchor points.
### Root cause 
Drawer position provider provide with wrong position.
### Fix
Updated position provider to return just the offset and not the anchors.


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
