### PR TITLE
adding sheetheight to 0 check

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -477,7 +477,7 @@ private fun Modifier.bottomSheetSwipeable(
 ): Modifier {
     var peekHeightPx = min(dpToPx(peekHeight), fullHeight * BottomSheetOpenFraction)
     val modifier = if (slideOver) {
-        if (sheetHeight != null) {
+        if (sheetHeight != null && sheetHeight != 0f) {
             val anchors = if (!expandable) {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,


### PR DESCRIPTION
### Problem 
Bottomsheet crashes the app when the sheet content is empty and showHandle is false
### Root cause 
Bottomsheet is calculating anchors for sheet with height 0
### Fix
adding an if check to skip calculating anchors when height is 0


This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
