### PR TITLE
adding heading semantic for appbar

### DIFF
--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -261,7 +263,8 @@ fun AppBar(
                         text = title,
                         modifier = Modifier
                             .padding(token.textPadding(appBarInfo))
-                            .weight(1F),
+                            .weight(1F)
+                            .semantics { heading()  },
                         style = titleTextStyle.merge(
                             TextStyle(
                                 color = token.titleTextColor(appBarInfo)


### PR DESCRIPTION
### Problem 
Appbar title semantics does not announce heading
### Root cause 
semantics not set to appbar title
### Fix
Adding semantics to appbar

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
