### PR TITLE
Enhance TalkBack Accessibility: Regularize Focus Order in BottomSheet Content as per Visual Cue

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -357,7 +357,7 @@ fun BottomSheet(
                 .shadow(sheetElevation)
                 .clip(sheetShape)
                 .background(sheetBackgroundColor)
-                .semantics(mergeDescendants = true) {
+                .semantics(mergeDescendants = false) {
                     if (sheetState.isVisible) {
                         if (enableSwipeDismiss) {
                             dismiss {


### PR DESCRIPTION
### Problem 
THe talkback focus was going from Header to header skipping tab items.
Check ScreenRecording for better Understanding
### Root cause 
BottomSheet's Semantic Properties were being apllied to it's nested content
### Fix
Do not apply those semantic properties to it's content

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

Before 


https://github.com/microsoft/fluentui-android/assets/68989156/9406f0b6-5f86-457c-a523-5674ec5bd7de

After


https://github.com/microsoft/fluentui-android/assets/68989156/6bec4f33-c657-464a-a74c-2e0a7d21c785





### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
