### PR TITLE
Patch for Content description being announced twice for clickable icons

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -156,7 +156,6 @@ fun Icon(
             interactionSource = remember { MutableInteractionSource() },
             indication = LocalIndication.current,
             enabled = enabled,
-            onClickLabel = contentDescription,
             onClick = onClick
         ) else Modifier
     )


### PR DESCRIPTION
### Problem 
For clickable icon, it was annoucinging:
"<content desc>, double tap to <content desc>"
### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

After Fix:
It announces:
"<content desc>, double tap to activate>"

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
