### PR TITLE
v2 Persona List Avatar focus fix, and announce position in list as well

### DIFF
--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaList.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/PersonaList.kt
@@ -5,12 +5,19 @@ import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.stateDescription
+import com.microsoft.fluentui.persona.R
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarTokens
 import com.microsoft.fluentui.theme.token.controlTokens.BorderInset
 import com.microsoft.fluentui.theme.token.controlTokens.BorderInset.None
@@ -48,6 +55,8 @@ fun PersonaList(
 ) {
     val scope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
+    val positionString: String = LocalContext.current.resources.getString(R.string.position_string)
+    val statusString: String = LocalContext.current.resources.getString(R.string.status_string)
     LazyColumn(
         state = lazyListState, modifier = modifier.draggable(
             orientation = Orientation.Vertical,
@@ -58,9 +67,15 @@ fun PersonaList(
             },
         )
     ) {
-        items(personas) { item ->
+        itemsIndexed(personas) { index, item ->
             ListItem.Item(
                 text = item.title,
+                modifier = Modifier
+                    .clearAndSetSemantics {
+                        contentDescription = "${item.person.getName()}, ${item.subTitle}" + if(enableAvatarPresence) statusString.format( item.person.status )else ""
+                        stateDescription = if (personas.size > 1) positionString.format(index+1, personas.size ) else ""
+                        role = Role.Button
+                                          },
                 subText = item.subTitle,
                 secondarySubText = item.footer,
                 onClick = item.onClick,

--- a/fluentui_persona/src/main/res/values/strings.xml
+++ b/fluentui_persona/src/main/res/values/strings.xml
@@ -15,4 +15,8 @@
     <string name="Active">Active</string>
     <!-- String specifying the work status of a person -->
     <string name="Inactive">Inactive</string>
+    <!-- Describes the Numbering of Persona List items -->
+    <string name="position_string">Item %d in list of %d</string>
+    <!-- Status of a person -->
+    <string name="status_string">Status: %s</string>
 </resources>


### PR DESCRIPTION
### Problem 
1. The focus was going to avatar in persona List
2. It wasn't announcing position of item in the list

### Root cause 

### Fix
Here have used clearAndSetSemantics for each listItem by passing it as a modifier to listItem and also passing different contentDesc, stateDesc, and role.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

https://github.com/microsoft/fluentui-android/assets/68989156/0946ea62-13ee-4bc3-9e7a-7b104fb05770




### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
