### PR TITLE
updating anchors for drawer and bottomsheet and adding a 0 content check

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -105,8 +105,6 @@ class BottomSheetState(
     internal val hasShownState: Boolean
         get() = anchors.values.contains(BottomSheetValue.Shown)
 
-    internal val hasHiddenState: Boolean
-        get() = anchors.values.contains(BottomSheetValue.Hidden)
 
     /**
      * Fully expand the bottom sheet with animation and suspend until it if fully expanded or
@@ -296,12 +294,10 @@ fun BottomSheet(
                     fraction = {
                         if (sheetState.anchors.isEmpty()
                             || !sheetState.anchors.containsValue(BottomSheetValue.Expanded)
+                            || (sheetHeightState != null && sheetHeightState.value == 0f)
                         ) {
                             0.toFloat()
-                        } else if(sheetHeightState != null && sheetHeightState.value == 0f){
-                            0.toFloat()
-                        }
-                        else {
+                        }else {
                             calculateFraction(
                                 sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Shown }?.key!!,
                                 sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded }?.key!!,

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -386,13 +386,13 @@ private fun Modifier.bottomDrawerSwipeable(
                         *The old anchors won't have Open state, so we need to continue with Expanded state.
                         */
                         mapOf(
+                            bottomOpenStateY to DrawerValue.Expanded,
                             fullHeight to DrawerValue.Closed,
-                            bottomOpenStateY to DrawerValue.Expanded
                         )
                     } else {
                         mapOf(
-                            fullHeight to DrawerValue.Closed,
-                            bottomOpenStateY to DrawerValue.Open
+                            bottomOpenStateY to DrawerValue.Open,
+                            fullHeight to DrawerValue.Closed
                         )
                     }
                 } else {
@@ -404,26 +404,26 @@ private fun Modifier.bottomDrawerSwipeable(
                                 *The old anchors won't have Expanded state, so we need to continue with Open state.
                                 */
                                 mapOf(
-                                    fullHeight to DrawerValue.Closed,
-                                    bottomExpandedStateY to DrawerValue.Open // when drawerHeight is greater than maxOpenHeight but less than fullHeight, then Expanded state starts from fullHeight-drawerHeight
+                                    bottomExpandedStateY to DrawerValue.Open, // when drawerHeight is greater than maxOpenHeight but less than fullHeight, then Expanded state starts from fullHeight-drawerHeight
+                                    fullHeight to DrawerValue.Closed
                                 )
                             } else {
                                 mapOf(
+                                    bottomExpandedStateY to DrawerValue.Expanded, // when drawerHeight is greater than maxOpenHeight but less than fullHeight, then Expanded state starts from fullHeight-drawerHeight
                                     fullHeight to DrawerValue.Closed,
-                                    bottomExpandedStateY to DrawerValue.Expanded // when drawerHeight is greater than maxOpenHeight but less than fullHeight, then Expanded state starts from fullHeight-drawerHeight
                                 )
                             }
                         } else {
                             mapOf(
-                                fullHeight to DrawerValue.Closed,
                                 maxOpenHeight to DrawerValue.Open,
-                                bottomExpandedStateY to DrawerValue.Expanded
+                                bottomExpandedStateY to DrawerValue.Expanded,
+                                fullHeight to DrawerValue.Closed
                             )
                         }
                     } else {
                         mapOf(
-                            fullHeight to DrawerValue.Closed,
-                            maxOpenHeight to DrawerValue.Open
+                            maxOpenHeight to DrawerValue.Open,
+                            fullHeight to DrawerValue.Closed
                         )
                     }
                 }
@@ -441,21 +441,21 @@ private fun Modifier.bottomDrawerSwipeable(
         val anchors = if (drawerState.expandable) {
             if(drawerState.skipOpenState){
                 mapOf(
+                    0F to DrawerValue.Expanded,
                     fullHeight to DrawerValue.Closed,
-                    0F to DrawerValue.Expanded
                 )
             }
             else {
                 mapOf(
-                    fullHeight to DrawerValue.Closed,
                     maxOpenHeight to DrawerValue.Open,
-                    0F to DrawerValue.Expanded
+                    0F to DrawerValue.Expanded,
+                    fullHeight to DrawerValue.Closed
                 )
             }
         } else {
             mapOf(
-                fullHeight to DrawerValue.Closed,
-                maxOpenHeight to DrawerValue.Open
+                maxOpenHeight to DrawerValue.Open,
+                fullHeight to DrawerValue.Closed
             )
         }
         Modifier.swipeable(
@@ -781,12 +781,14 @@ private fun BottomDrawer(
         val scope = rememberCoroutineScope()
 
         Scrim(
-            open = !drawerState.isClosed,
+            open = !drawerState.isClosed || (drawerHeight != null && drawerHeight.value == 0f),
             onClose = onDismiss,
             fraction = {
                 if (drawerState.anchors.isEmpty()) {
                     0.toFloat()
-                } else {
+                } else if(drawerHeight != null && drawerHeight.value == 0f){
+                    0.toFloat()
+                } else{
                     var targetValue: DrawerValue = if(slideOver){
                         drawerState.anchors.maxBy { it.value }?.value!!
                     }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -784,9 +784,7 @@ private fun BottomDrawer(
             open = !drawerState.isClosed || (drawerHeight != null && drawerHeight.value == 0f),
             onClose = onDismiss,
             fraction = {
-                if (drawerState.anchors.isEmpty()) {
-                    0.toFloat()
-                } else if(drawerHeight != null && drawerHeight.value == 0f){
+                if (drawerState.anchors.isEmpty() || (drawerHeight != null && drawerHeight.value == 0f)) {
                     0.toFloat()
                 } else{
                     var targetValue: DrawerValue = if(slideOver){


### PR DESCRIPTION
### Problem 
Bottomsheet and drawer anchors are missing in some edge cases which results in crashes
### Root cause 
Map used to store anchors removes key-value pairs when there is a duplicate key causing to miss some anchors during animation resulting in null values
### Fix
Rearrange the keyvalue pairs to contain the default keyvalue that will be handle during the open, close and expand animations

### Validations
Manual testing
(how the change was tested, including both manual and automated tests)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
