### PR TITLE
Drawer position flag

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -206,27 +206,6 @@ private fun CreateActivityUI() {
                     )
                 }
                 item {
-                    val relativeToParentAnchorText =
-                        stringResource(id = R.string.drawer_relative_to_parent_anchor)
-                    ListItem.Header(title = relativeToParentAnchorText, modifier = Modifier
-                        .toggleable(
-                            value = relativeToParentAnchor,
-                            role = Role.Switch,
-                            onValueChange = { relativeToParentAnchor = !relativeToParentAnchor }
-                        )
-                        .clearAndSetSemantics {
-                            this.contentDescription = relativeToParentAnchorText
-                        }, trailingAccessoryContent = {
-                        ToggleSwitch(
-                            onValueChange = {
-                                relativeToParentAnchor = !relativeToParentAnchor
-                            },
-                            checkedState = relativeToParentAnchor
-                        )
-                    }
-                    )
-                }
-                item {
                     val preventDismissalOnScrimClickText =
                         stringResource(id = R.string.prevent_scrim_click_dismissal)
                     ListItem.Header(title = preventDismissalOnScrimClickText,
@@ -260,14 +239,14 @@ private fun CreateActivityUI() {
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "+ 10 dp",
-                                    enabled = relativeToParentAnchor,
+                                    enabled = true,
                                     onClick = { offsetX += 10 })
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Button(
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "- 10 dp",
-                                    enabled = relativeToParentAnchor,
+                                    enabled = true,
                                     onClick = { offsetX -= 10 })
                             }
                         }
@@ -282,14 +261,14 @@ private fun CreateActivityUI() {
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "+ 10 dp",
-                                    enabled = relativeToParentAnchor,
+                                    enabled = true,
                                     onClick = { offsetY += 10 })
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Button(
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "- 10 dp",
-                                    enabled = relativeToParentAnchor,
+                                    enabled = true,
                                     onClick = { offsetY -= 10 })
                             }
                         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -115,7 +115,6 @@ private fun CreateActivityUI() {
                     getDynamicListGeneratorAsContent()
                 },
                 scrimVisible = scrimVisible,
-                relativeToParentAnchor,
                 IntOffset(offsetX, offsetY),
                 preventDismissalOnScrimClick = preventDismissalOnScrimClick
             )
@@ -207,14 +206,16 @@ private fun CreateActivityUI() {
                     )
                 }
                 item {
-                    ListItem.Header(title = "Relative to parent Anchor", modifier = Modifier
+                    val relativeToParentAnchorText =
+                        stringResource(id = R.string.drawer_relative_to_parent_anchor)
+                    ListItem.Header(title = relativeToParentAnchorText, modifier = Modifier
                         .toggleable(
                             value = relativeToParentAnchor,
                             role = Role.Switch,
                             onValueChange = { relativeToParentAnchor = !relativeToParentAnchor }
                         )
                         .clearAndSetSemantics {
-                            this.contentDescription = "relative bounds"
+                            this.contentDescription = relativeToParentAnchorText
                         }, trailingAccessoryContent = {
                         ToggleSwitch(
                             onValueChange = {
@@ -399,7 +400,6 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     behaviorType: BehaviorType,
     drawerContent: @Composable ((() -> Unit) -> Unit),
     scrimVisible: Boolean = true,
-    relativeBounds: Boolean = true,
     offset: IntOffset = IntOffset.Zero,
     preventDismissalOnScrimClick: Boolean
 ) {
@@ -429,7 +429,6 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     Drawer(
         drawerState = drawerState,
         offset = offset,
-        placeRelativeToAnchor = relativeBounds,
         drawerContent = { drawerContent(close) },
         behaviorType = behaviorType,
         scrimVisible = scrimVisible,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -1,26 +1,42 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.ThemeMode
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.controlTokens.BehaviorType
+import com.microsoft.fluentui.theme.token.controlTokens.ButtonSize
+import com.microsoft.fluentui.theme.token.controlTokens.ButtonStyle
+import com.microsoft.fluentui.tokenized.controls.Button
+import com.microsoft.fluentui.tokenized.controls.Label
 import com.microsoft.fluentui.tokenized.controls.RadioButton
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.drawer.Drawer
@@ -68,220 +84,306 @@ private fun CreateActivityUI() {
     var preventDismissalOnScrimClick by remember { mutableStateOf(false) }
     var selectedContent by remember { mutableStateOf(ContentType.FULL_SCREEN_SCROLLABLE_CONTENT) }
     var selectedBehaviorType by remember { mutableStateOf(BehaviorType.BOTTOM_SLIDE_OVER) }
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
-            selectedBehaviorType,
-            if (listContent)
-                getAndroidViewAsContent(selectedContent)
-            else if (nestedDrawerContent) {
-                getDrawerAsContent()
-            } else {
-                getDynamicListGeneratorAsContent()
-            },
-            scrimVisible = scrimVisible,
-            preventDismissalOnScrimClick = preventDismissalOnScrimClick
+    var relativeBounds by remember {
+        mutableStateOf(
+            false
         )
-        LazyColumn(horizontalAlignment = Alignment.CenterHorizontally) {
-            item {
-                ListItem.Header(title = stringResource(id = R.string.drawer_select_drawer_type))
-                ListItem.Item(text = stringResource(id = R.string.drawer_top),
-                    subText = stringResource(id = R.string.drawer_top_description),
-                    subTextMaxLines = Int.MAX_VALUE,
-                    onClick = { selectedBehaviorType = BehaviorType.TOP },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedBehaviorType = BehaviorType.TOP
-                            },
-                            selected = selectedBehaviorType == BehaviorType.TOP
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_bottom),
-                    subText = stringResource(id = R.string.drawer_bottom_description),
-                    subTextMaxLines = Int.MAX_VALUE,
-                    onClick = { selectedBehaviorType = BehaviorType.BOTTOM },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedBehaviorType = BehaviorType.BOTTOM
-                            },
-                            selected = selectedBehaviorType == BehaviorType.BOTTOM
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_left_slide_over),
-                    subText = stringResource(id = R.string.drawer_left_slide_over_description),
-                    subTextMaxLines = Int.MAX_VALUE,
-                    onClick = { selectedBehaviorType = BehaviorType.LEFT_SLIDE_OVER },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedBehaviorType = BehaviorType.LEFT_SLIDE_OVER
-                            },
-                            selected = selectedBehaviorType == BehaviorType.LEFT_SLIDE_OVER
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_right_slide_over),
-                    subText = stringResource(id = R.string.drawer_right_slide_over_description),
-                    subTextMaxLines = Int.MAX_VALUE,
-                    onClick = { selectedBehaviorType = BehaviorType.RIGHT_SLIDE_OVER },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedBehaviorType = BehaviorType.RIGHT_SLIDE_OVER
-                            },
-                            selected = selectedBehaviorType == BehaviorType.RIGHT_SLIDE_OVER
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_bottom_slide_over),
-                    subText = stringResource(id = R.string.drawer_bottom_slide_over_description),
-                    subTextMaxLines = Int.MAX_VALUE,
-                    onClick = { selectedBehaviorType = BehaviorType.BOTTOM_SLIDE_OVER },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedBehaviorType = BehaviorType.BOTTOM_SLIDE_OVER
-                            },
-                            selected = selectedBehaviorType == BehaviorType.BOTTOM_SLIDE_OVER
-                        )
-                    }
-                )
+    }
+    var offsetX by remember { mutableIntStateOf(0) }
+    var offsetY by remember { mutableIntStateOf(0) }
+    Column {
+        if(relativeBounds){
+            Row(
+                Modifier
+                    .width(500.dp)
+                    .height(100.dp)
+                    .border(width = 2.dp, color = Color.Red),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically) {
+                Label(text = "Random composable. Drawer starts from below", textStyle = FluentAliasTokens.TypographyTokens.Body1Strong)
             }
-            item {
-                val scrimVisibleText = stringResource(id = R.string.drawer_scrim_visible)
-                ListItem.Header(title = scrimVisibleText, modifier = Modifier
-                    .toggleable(
-                        value = scrimVisible,
-                        role = Role.Switch,
-                        onValueChange = { scrimVisible = !scrimVisible }
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+
+            CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
+                selectedBehaviorType,
+                if (listContent)
+                    getAndroidViewAsContent(selectedContent)
+                else if (nestedDrawerContent) {
+                    getDrawerAsContent()
+                } else {
+                    getDynamicListGeneratorAsContent()
+                },
+                scrimVisible = scrimVisible,
+                relativeBounds,
+                IntOffset(offsetX, offsetY),
+                preventDismissalOnScrimClick = preventDismissalOnScrimClick
+            )
+            LazyColumn(horizontalAlignment = Alignment.CenterHorizontally) {
+                item {
+                    ListItem.Header(title = stringResource(id = R.string.drawer_select_drawer_type))
+                    ListItem.Item(text = stringResource(id = R.string.drawer_top),
+                        subText = stringResource(id = R.string.drawer_top_description),
+                        subTextMaxLines = Int.MAX_VALUE,
+                        onClick = { selectedBehaviorType = BehaviorType.TOP },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedBehaviorType = BehaviorType.TOP
+                                },
+                                selected = selectedBehaviorType == BehaviorType.TOP
+                            )
+                        }
                     )
-                    .clearAndSetSemantics {
-                        this.contentDescription = scrimVisibleText
-                    }, trailingAccessoryContent = {
-                    ToggleSwitch(
-                        onValueChange = { scrimVisible = !scrimVisible },
-                        checkedState = scrimVisible
+                    ListItem.Item(text = stringResource(id = R.string.drawer_bottom),
+                        subText = stringResource(id = R.string.drawer_bottom_description),
+                        subTextMaxLines = Int.MAX_VALUE,
+                        onClick = { selectedBehaviorType = BehaviorType.BOTTOM },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedBehaviorType = BehaviorType.BOTTOM
+                                },
+                                selected = selectedBehaviorType == BehaviorType.BOTTOM
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_left_slide_over),
+                        subText = stringResource(id = R.string.drawer_left_slide_over_description),
+                        subTextMaxLines = Int.MAX_VALUE,
+                        onClick = { selectedBehaviorType = BehaviorType.LEFT_SLIDE_OVER },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedBehaviorType = BehaviorType.LEFT_SLIDE_OVER
+                                },
+                                selected = selectedBehaviorType == BehaviorType.LEFT_SLIDE_OVER
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_right_slide_over),
+                        subText = stringResource(id = R.string.drawer_right_slide_over_description),
+                        subTextMaxLines = Int.MAX_VALUE,
+                        onClick = { selectedBehaviorType = BehaviorType.RIGHT_SLIDE_OVER },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedBehaviorType = BehaviorType.RIGHT_SLIDE_OVER
+                                },
+                                selected = selectedBehaviorType == BehaviorType.RIGHT_SLIDE_OVER
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_bottom_slide_over),
+                        subText = stringResource(id = R.string.drawer_bottom_slide_over_description),
+                        subTextMaxLines = Int.MAX_VALUE,
+                        onClick = { selectedBehaviorType = BehaviorType.BOTTOM_SLIDE_OVER },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedBehaviorType = BehaviorType.BOTTOM_SLIDE_OVER
+                                },
+                                selected = selectedBehaviorType == BehaviorType.BOTTOM_SLIDE_OVER
+                            )
+                        }
                     )
                 }
-                )
-            }
-            item {
-                val preventDismissalOnScrimClickText = stringResource(id = R.string.prevent_scrim_click_dismissal)
-                ListItem.Header(title = preventDismissalOnScrimClickText,
-                    modifier = Modifier
+                item {
+                    val scrimVisibleText = stringResource(id = R.string.drawer_scrim_visible)
+                    ListItem.Header(title = scrimVisibleText, modifier = Modifier
                         .toggleable(
-                            value = preventDismissalOnScrimClick,
+                            value = scrimVisible,
                             role = Role.Switch,
-                            onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick }
+                            onValueChange = { scrimVisible = !scrimVisible }
                         )
                         .clearAndSetSemantics {
-                            this.contentDescription = preventDismissalOnScrimClickText
-                        },
-                    trailingAccessoryContent = {
+                            this.contentDescription = scrimVisibleText
+                        }, trailingAccessoryContent = {
                         ToggleSwitch(
-                            onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick },
-                            checkedState = preventDismissalOnScrimClick
+                            onValueChange = { scrimVisible = !scrimVisible },
+                            checkedState = scrimVisible
                         )
                     }
-                )
-            }
+                    )
+                }
+                item {
+                    ListItem.Header(title = "Relative Bounds", modifier = Modifier
+                        .toggleable(
+                            value = relativeBounds,
+                            role = Role.Switch,
+                            onValueChange = { relativeBounds = !relativeBounds }
+                        )
+                        .clearAndSetSemantics {
+                            this.contentDescription = "relative bounds"
+                        }, trailingAccessoryContent = {
+                        ToggleSwitch(
+                            onValueChange = { relativeBounds = !relativeBounds },
+                            checkedState = relativeBounds
+                        )
+                    }
+                    )
+                }
+                item {
+                    val preventDismissalOnScrimClickText = stringResource(id = R.string.prevent_scrim_click_dismissal)
+                    ListItem.Header(title = preventDismissalOnScrimClickText,
+                        modifier = Modifier
+                            .toggleable(
+                                value = preventDismissalOnScrimClick,
+                                role = Role.Switch,
+                                onValueChange = {
+                                    preventDismissalOnScrimClick = !preventDismissalOnScrimClick
+                                }
+                            )
+                            .clearAndSetSemantics {
+                                this.contentDescription = preventDismissalOnScrimClickText
+                            },
+                        trailingAccessoryContent = {
+                            ToggleSwitch(
+                                onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick },
+                                checkedState = preventDismissalOnScrimClick
+                            )
+                        }
+                    )
+                }
+                item{
+                    ListItem.Header(title = "Offset: X $offsetX.dp",
+                        modifier = Modifier.fillMaxWidth(),
+                        trailingAccessoryContent = {
+                            Row {
+                                Button(
+                                    style = ButtonStyle.Button,
+                                    size = ButtonSize.Medium,
+                                    text = "+ 10 dp",
+                                    enabled = relativeBounds,
+                                    onClick = { offsetX += 10 })
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Button(
+                                    style = ButtonStyle.Button,
+                                    size = ButtonSize.Medium,
+                                    text = "- 10 dp",
+                                    enabled = relativeBounds,
+                                    onClick = { offsetX -= 10 })
+                            }
+                        }
+                    )
+                }
+                item{
+                    ListItem.Header(title = "Offset: Y $offsetY.dp",
+                        modifier = Modifier.fillMaxWidth(),
+                        trailingAccessoryContent = {
+                            Row(){
+                                Button(
+                                    style = ButtonStyle.Button,
+                                    size = ButtonSize.Medium,
+                                    text = "+ 10 dp",
+                                    enabled = relativeBounds,
+                                    onClick = { offsetY += 10 })
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Button(
+                                    style = ButtonStyle.Button,
+                                    size = ButtonSize.Medium,
+                                    text = "- 10 dp",
+                                    enabled = relativeBounds,
+                                    onClick = { offsetY -= 10 })
+                            }
+                        }
+                    )
+                }
 
-            item {
-                ListItem.Header(title = stringResource(id = R.string.drawer_select_drawer_content))
-                ListItem.Item(text = stringResource(id = R.string.drawer_full_screen_size_scrollable_content),
-                    onClick = {
-                        selectedContent = ContentType.FULL_SCREEN_SCROLLABLE_CONTENT
-                        listContent = true
-                        nestedDrawerContent = false
-                        dynamicSizeContent = false
-                    },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedContent = ContentType.FULL_SCREEN_SCROLLABLE_CONTENT
-                                listContent = true
-                                nestedDrawerContent = false
-                                dynamicSizeContent = false
-                            },
-                            selected = selectedContent == ContentType.FULL_SCREEN_SCROLLABLE_CONTENT && listContent
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_more_than_half_screen_content),
-                    onClick = {
-                        selectedContent = ContentType.EXPANDABLE_SIZE_CONTENT
-                        listContent = true
-                        nestedDrawerContent = false
-                        dynamicSizeContent = false
-                    },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedContent = ContentType.EXPANDABLE_SIZE_CONTENT
-                                listContent = true
-                                nestedDrawerContent = false
-                                dynamicSizeContent = false
-                            },
-                            selected = selectedContent == ContentType.EXPANDABLE_SIZE_CONTENT && listContent
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_less_than_half_screen_content),
-                    onClick = {
-                        selectedContent = ContentType.WRAPPED_SIZE_CONTENT
-                        listContent = true
-                        dynamicSizeContent = false
-                        nestedDrawerContent = false
-                    },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                selectedContent = ContentType.WRAPPED_SIZE_CONTENT
-                                listContent = true
-                                dynamicSizeContent = false
-                                nestedDrawerContent = false
-                            },
-                            selected = selectedContent == ContentType.WRAPPED_SIZE_CONTENT && listContent
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_dynamic_size_content),
-                    onClick = {
-                        dynamicSizeContent = true
-                        nestedDrawerContent = false
-                        listContent = false
-                    },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                dynamicSizeContent = true
-                                nestedDrawerContent = false
-                                listContent = false
-                            },
-                            selected = dynamicSizeContent
-                        )
-                    }
-                )
-                ListItem.Item(text = stringResource(id = R.string.drawer_nested_drawer_content),
-                    onClick = {
-                        nestedDrawerContent = true
-                        dynamicSizeContent = false
-                        listContent = false
-                    },
-                    trailingAccessoryContent = {
-                        RadioButton(
-                            onClick = {
-                                nestedDrawerContent = true
-                                dynamicSizeContent = false
-                                listContent = false
-                            },
-                            selected = nestedDrawerContent
-                        )
-                    }
-                )
+                item {
+                    ListItem.Header(title = stringResource(id = R.string.drawer_select_drawer_content))
+                    ListItem.Item(text = stringResource(id = R.string.drawer_full_screen_size_scrollable_content),
+                        onClick = {
+                            selectedContent = ContentType.FULL_SCREEN_SCROLLABLE_CONTENT
+                            listContent = true
+                            nestedDrawerContent = false
+                            dynamicSizeContent = false
+                        },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedContent = ContentType.FULL_SCREEN_SCROLLABLE_CONTENT
+                                    listContent = true
+                                    nestedDrawerContent = false
+                                    dynamicSizeContent = false
+                                },
+                                selected = selectedContent == ContentType.FULL_SCREEN_SCROLLABLE_CONTENT && listContent
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_more_than_half_screen_content),
+                        onClick = {
+                            selectedContent = ContentType.EXPANDABLE_SIZE_CONTENT
+                            listContent = true
+                            nestedDrawerContent = false
+                            dynamicSizeContent = false
+                        },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedContent = ContentType.EXPANDABLE_SIZE_CONTENT
+                                    listContent = true
+                                    nestedDrawerContent = false
+                                    dynamicSizeContent = false
+                                },
+                                selected = selectedContent == ContentType.EXPANDABLE_SIZE_CONTENT && listContent
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_less_than_half_screen_content),
+                        onClick = {
+                            selectedContent = ContentType.WRAPPED_SIZE_CONTENT
+                            listContent = true
+                            dynamicSizeContent = false
+                            nestedDrawerContent = false
+                        },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    selectedContent = ContentType.WRAPPED_SIZE_CONTENT
+                                    listContent = true
+                                    dynamicSizeContent = false
+                                    nestedDrawerContent = false
+                                },
+                                selected = selectedContent == ContentType.WRAPPED_SIZE_CONTENT && listContent
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_dynamic_size_content),
+                        onClick = {
+                            dynamicSizeContent = true
+                            nestedDrawerContent = false
+                            listContent = false
+                        },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    dynamicSizeContent = true
+                                    nestedDrawerContent = false
+                                    listContent = false
+                                },
+                                selected = dynamicSizeContent
+                            )
+                        }
+                    )
+                    ListItem.Item(text = stringResource(id = R.string.drawer_nested_drawer_content),
+                        onClick = {
+                            nestedDrawerContent = true
+                            dynamicSizeContent = false
+                            listContent = false
+                        },
+                        trailingAccessoryContent = {
+                            RadioButton(
+                                onClick = {
+                                    nestedDrawerContent = true
+                                    dynamicSizeContent = false
+                                    listContent = false
+                                },
+                                selected = nestedDrawerContent
+                            )
+                        }
+                    )
+                }
             }
         }
     }
@@ -292,6 +394,8 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     behaviorType: BehaviorType,
     drawerContent: @Composable ((() -> Unit) -> Unit),
     scrimVisible: Boolean = true,
+    relativeBounds: Boolean = true,
+    offset: IntOffset = IntOffset.Zero,
     preventDismissalOnScrimClick: Boolean
 ) {
     val scope = rememberCoroutineScope()
@@ -319,6 +423,8 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
 
     Drawer(
         drawerState = drawerState,
+        offset = offset,
+        relativeBounds = relativeBounds,
         drawerContent = { drawerContent(close) },
         behaviorType = behaviorType,
         scrimVisible = scrimVisible,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -26,11 +25,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.microsoft.fluentui.theme.FluentTheme
-import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.controlTokens.BehaviorType
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonSize
@@ -84,7 +80,7 @@ private fun CreateActivityUI() {
     var preventDismissalOnScrimClick by remember { mutableStateOf(false) }
     var selectedContent by remember { mutableStateOf(ContentType.FULL_SCREEN_SCROLLABLE_CONTENT) }
     var selectedBehaviorType by remember { mutableStateOf(BehaviorType.BOTTOM_SLIDE_OVER) }
-    var relativeBounds by remember {
+    var relativeToParentAnchor by remember {
         mutableStateOf(
             false
         )
@@ -92,15 +88,19 @@ private fun CreateActivityUI() {
     var offsetX by remember { mutableIntStateOf(0) }
     var offsetY by remember { mutableIntStateOf(0) }
     Column {
-        if(relativeBounds){
+        if (relativeToParentAnchor) {
             Row(
                 Modifier
                     .width(500.dp)
                     .height(100.dp)
                     .border(width = 2.dp, color = Color.Red),
                 horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically) {
-                Label(text = "Random composable. Drawer starts from below", textStyle = FluentAliasTokens.TypographyTokens.Body1Strong)
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Label(
+                    text = "Random composable. Drawer starts from below",
+                    textStyle = FluentAliasTokens.TypographyTokens.Body1Strong
+                )
             }
         }
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -115,7 +115,7 @@ private fun CreateActivityUI() {
                     getDynamicListGeneratorAsContent()
                 },
                 scrimVisible = scrimVisible,
-                relativeBounds,
+                relativeToParentAnchor,
                 IntOffset(offsetX, offsetY),
                 preventDismissalOnScrimClick = preventDismissalOnScrimClick
             )
@@ -207,24 +207,27 @@ private fun CreateActivityUI() {
                     )
                 }
                 item {
-                    ListItem.Header(title = "Relative Bounds", modifier = Modifier
+                    ListItem.Header(title = "Relative to parent Anchor", modifier = Modifier
                         .toggleable(
-                            value = relativeBounds,
+                            value = relativeToParentAnchor,
                             role = Role.Switch,
-                            onValueChange = { relativeBounds = !relativeBounds }
+                            onValueChange = { relativeToParentAnchor = !relativeToParentAnchor }
                         )
                         .clearAndSetSemantics {
                             this.contentDescription = "relative bounds"
                         }, trailingAccessoryContent = {
                         ToggleSwitch(
-                            onValueChange = { relativeBounds = !relativeBounds },
-                            checkedState = relativeBounds
+                            onValueChange = {
+                                relativeToParentAnchor = !relativeToParentAnchor
+                            },
+                            checkedState = relativeToParentAnchor
                         )
                     }
                     )
                 }
                 item {
-                    val preventDismissalOnScrimClickText = stringResource(id = R.string.prevent_scrim_click_dismissal)
+                    val preventDismissalOnScrimClickText =
+                        stringResource(id = R.string.prevent_scrim_click_dismissal)
                     ListItem.Header(title = preventDismissalOnScrimClickText,
                         modifier = Modifier
                             .toggleable(
@@ -239,13 +242,15 @@ private fun CreateActivityUI() {
                             },
                         trailingAccessoryContent = {
                             ToggleSwitch(
-                                onValueChange = { preventDismissalOnScrimClick = !preventDismissalOnScrimClick },
+                                onValueChange = {
+                                    preventDismissalOnScrimClick = !preventDismissalOnScrimClick
+                                },
                                 checkedState = preventDismissalOnScrimClick
                             )
                         }
                     )
                 }
-                item{
+                item {
                     ListItem.Header(title = "Offset: X $offsetX.dp",
                         modifier = Modifier.fillMaxWidth(),
                         trailingAccessoryContent = {
@@ -254,36 +259,36 @@ private fun CreateActivityUI() {
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "+ 10 dp",
-                                    enabled = relativeBounds,
+                                    enabled = relativeToParentAnchor,
                                     onClick = { offsetX += 10 })
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Button(
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "- 10 dp",
-                                    enabled = relativeBounds,
+                                    enabled = relativeToParentAnchor,
                                     onClick = { offsetX -= 10 })
                             }
                         }
                     )
                 }
-                item{
+                item {
                     ListItem.Header(title = "Offset: Y $offsetY.dp",
                         modifier = Modifier.fillMaxWidth(),
                         trailingAccessoryContent = {
-                            Row(){
+                            Row {
                                 Button(
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "+ 10 dp",
-                                    enabled = relativeBounds,
+                                    enabled = relativeToParentAnchor,
                                     onClick = { offsetY += 10 })
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Button(
                                     style = ButtonStyle.Button,
                                     size = ButtonSize.Medium,
                                     text = "- 10 dp",
-                                    enabled = relativeBounds,
+                                    enabled = relativeToParentAnchor,
                                     onClick = { offsetY -= 10 })
                             }
                         }
@@ -424,7 +429,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     Drawer(
         drawerState = drawerState,
         offset = offset,
-        relativeBounds = relativeBounds,
+        placeRelativeToAnchor = relativeBounds,
         drawerContent = { drawerContent(close) },
         behaviorType = behaviorType,
         scrimVisible = scrimVisible,

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -891,7 +891,6 @@
     <string name="prevent_scrim_click_dismissal">Prevent Dismissal on Scrim Click</string>
     <!-- UI Label for Show Handle -->
     <string name="drawer_show_handle">Show Handle</string>
-    <string name="drawer_relative_to_parent_anchor"> Relative to parent Anchor</string>
 
     <!--V2 ToolTip-->
     <!-- UI Label for ToolTip Title-->

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -891,6 +891,7 @@
     <string name="prevent_scrim_click_dismissal">Prevent Dismissal on Scrim Click</string>
     <!-- UI Label for Show Handle -->
     <string name="drawer_show_handle">Show Handle</string>
+    <string name="drawer_relative_to_parent_anchor"> Relative to parent Anchor</string>
 
     <!--V2 ToolTip-->
     <!-- UI Label for ToolTip Title-->

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -951,8 +951,8 @@ private fun BottomDrawer(
  * @param behaviorType opening behaviour of drawer. Default is BOTTOM
  * @param drawerState state of the drawer
  * @param scrimVisible create obscures background when scrim visible set to true when the drawer is open. The default value is true
- * @param relativeBounds when true, the drawer will be drawn relative to its parent anchor. The default value is false
- * @param offset offset of the drawer from the anchor. The default value is (0,0). Offset does not work if the [relativeBounds] is set to false.
+ * @param placeRelativeToAnchor when true, the drawer will be drawn relative to its parent anchor. The default value is false
+ * @param offset offset of the drawer from the anchor. The default value is (0,0). Offset does not work if the [placeRelativeToAnchor] is set to false.
  * @param drawerTokens tokens to provide appearance values. If not provided then drawer tokens will be picked from [FluentTheme]
  * @param drawerContent composable that represents content inside the drawer
  * @param preventDismissalOnScrimClick when true, the drawer will not be dismissed when the scrim is clicked
@@ -967,7 +967,7 @@ fun Drawer(
     behaviorType: BehaviorType = BehaviorType.BOTTOM,
     drawerState: DrawerState = rememberDrawerState(),
     scrimVisible: Boolean = true,
-    relativeBounds: Boolean = false,
+    placeRelativeToAnchor: Boolean = false,
     offset: IntOffset = IntOffset(0, 0),
     drawerTokens: DrawerTokens? = null,
     drawerContent: @Composable () -> Unit,
@@ -991,7 +991,7 @@ fun Drawer(
         Popup(
             onDismissRequest = close,
             popupPositionProvider = popupPositionProvider,
-            properties = PopupProperties(focusable = true, clippingEnabled = !relativeBounds)
+            properties = PopupProperties(focusable = true, clippingEnabled = !placeRelativeToAnchor)
         )
         {
             val drawerShape: Shape =

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -951,7 +951,8 @@ private fun BottomDrawer(
  * @param behaviorType opening behaviour of drawer. Default is BOTTOM
  * @param drawerState state of the drawer
  * @param scrimVisible create obscures background when scrim visible set to true when the drawer is open. The default value is true
- * @param offset offset of the drawer from the anchor. The default value is (0,0)
+ * @param relativeBounds when true, the drawer will be drawn relative to its parent anchor. The default value is false
+ * @param offset offset of the drawer from the anchor. The default value is (0,0). Offset does not work if the [relativeBounds] is set to false.
  * @param drawerTokens tokens to provide appearance values. If not provided then drawer tokens will be picked from [FluentTheme]
  * @param drawerContent composable that represents content inside the drawer
  * @param preventDismissalOnScrimClick when true, the drawer will not be dismissed when the scrim is clicked
@@ -966,6 +967,7 @@ fun Drawer(
     behaviorType: BehaviorType = BehaviorType.BOTTOM,
     drawerState: DrawerState = rememberDrawerState(),
     scrimVisible: Boolean = true,
+    relativeBounds: Boolean = false,
     offset: IntOffset = IntOffset(0, 0),
     drawerTokens: DrawerTokens? = null,
     drawerContent: @Composable () -> Unit,
@@ -989,7 +991,7 @@ fun Drawer(
         Popup(
             onDismissRequest = close,
             popupPositionProvider = popupPositionProvider,
-            properties = PopupProperties(focusable = true, clippingEnabled = false)
+            properties = PopupProperties(focusable = true, clippingEnabled = !relativeBounds)
         )
         {
             val drawerShape: Shape =


### PR DESCRIPTION
### Problem 
Drawer recent clipping changes caused a breaking change. 
### Root cause 
Drawer popup properties are update to not clip to the screen window
### Fix
Created a flag to whether clip to the boundaries or create a relative position for drawer popup

### Validations
Manual testing
(how the change was tested, including both manual and automated tests)

### Screenshots

When relative bounds is false
![Screenshot_20240125-143327](https://github.com/microsoft/fluentui-android/assets/5608292/6211d294-7a7c-494a-9ed7-25ea3420b317)
When relative bounds is true
![Screenshot_20240125-143335](https://github.com/microsoft/fluentui-android/assets/5608292/508c6a70-266d-41af-97b9-8429a100377d)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
