### PR TITLE
Compose1.4.3

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -35,7 +35,6 @@ import androidx.compose.material.icons.outlined.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -85,8 +84,8 @@ private fun CreateActivityUI() {
             false
         )
     }
-    var offsetX by remember { mutableIntStateOf(0) }
-    var offsetY by remember { mutableIntStateOf(0) }
+    var offsetX by remember { mutableStateOf(0) }
+    var offsetY by remember { mutableStateOf(0) }
     Column {
         if (relativeToParentAnchor) {
             Row(

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
         appCompatVersion          =    '1.6.1'
         buildToolVersion          =    '31.0.0'
         composeActivityVersion    =    '1.7.2'
-        composeBomVersion         =    '2023.09.00'
+        composeBomVersion         =    '2023.06.01'
         composeTestVersion        =    '1.4.3'
         composeCompilerVersion    =    '1.4.7'
         constraintLayoutVersion   =    '2.1.4'


### PR DESCRIPTION
Downgrading to compose 1.4.3


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
