### PR TITLE
Backport:adding style to label component (#609)

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Label.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Label.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentAliasTokens.TypographyTokens
@@ -17,7 +18,12 @@ import com.microsoft.fluentui.theme.token.controlTokens.LabelTokens
  * @param text Label text
  * @param textStyle Text styling for the text. Default [TypographyTokens.Display]
  * @param colorStyle Color styling for the text. Default [ColorStyle.Primary]
- * @param textColorOverride Optional override for text color. Default is null. When set colorStyle is ignored.
+ * @param textColorOverride Optional override for text color. Default is null. When set colorStyle is ignored. This param is deprecated and will be removed in future releases. use [style] to override text color
+ * @param style Optional style for the text
+ * @param overflow TextOverflow value. Default is [TextOverflow.Clip]
+ * @param softWrap Whether the text should wrap when it reaches the end of the line. Default is true
+ * @param maxLines Maximum number of lines to display. Default is Int.MAX_VALUE
+ * @param minLines Minimum number of lines to display. Default is 1
  * @param modifier Optional modifier for Label
  * @param labelTokens Option tokens for label styling
  */
@@ -27,6 +33,11 @@ fun Label(
     textStyle: TypographyTokens = TypographyTokens.Display,
     colorStyle: ColorStyle = ColorStyle.Primary,
     textColorOverride: Color? = null,
+    style: TextStyle? = null,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
     modifier: Modifier = Modifier,
     labelTokens: LabelTokens? = null
 ) {
@@ -40,6 +51,10 @@ fun Label(
     BasicText(
         modifier = modifier,
         text = text,
-        style = textStyle.merge(TextStyle(color = textColor))
+        style = textStyle.merge(TextStyle(color = textColor)).merge(style),
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines
     )
 }


### PR DESCRIPTION
Backporting PR609 https://github.com/microsoft/fluentui-android/pull/609
Add new parameters to Label components to support text styling

### Validations
Automation testing

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
