### PR TITLE
ToolTip X OffsetFix

### DIFF
--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
@@ -367,7 +367,7 @@ private fun Tooltip(
                         contentDescription = null,
                         tint = token.tipColor(tooltipInfo),
                         modifier = Modifier
-                            .offset(x = pxToDp(tipOffsetX), y = 0.dp)
+                            .offset { IntOffset(x = tipOffsetX.toInt(), y = 0) }
                             .testTag(TOOLTIP_TIP_TEST_TAG)
                     )
                 }
@@ -394,7 +394,7 @@ private fun Tooltip(
                         imageVector = ToolTipIcons.Tip, contentDescription = null,
                         tint = token.tipColor(tooltipInfo),
                         modifier = Modifier
-                            .offset(x = pxToDp(tipOffsetX), y = 0.dp)
+                            .offset { IntOffset(x = tipOffsetX.toInt(), y = 0) }
                             .rotate(180f)
                             .testTag(TOOLTIP_TIP_TEST_TAG)
                     )

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -308,7 +309,7 @@ private fun Tooltip(
     var tipAlignment: Alignment by rememberSaveable(stateSaver = TipAlignmentSaver) {
         mutableStateOf(Alignment.TopCenter)
     }
-    var tipOffsetX = 0.0f
+    var tipOffsetX by rememberSaveable { mutableStateOf(0.0f) }
     val isRTL = LocalLayoutDirection.current == LayoutDirection.Rtl
 
     val tooltipPositionProvider =
@@ -328,10 +329,10 @@ private fun Tooltip(
             tipOffsetX = dpToPx(offset.x) + if (isRTL) (tooltipCenter - parentCenter).toFloat() else
                 (parentCenter - tooltipCenter).toFloat()
 
-            if(tipOffsetX + tooltipCenter > tooltipContentBounds.right){
+            if(tipOffsetX + tooltipCenter > tooltipContentBounds.right - dpToPx(24.dp)){
                 tipOffsetX =  tooltipContentBounds.right - tooltipCenter - dpToPx(24.dp)
             }
-            else if(tipOffsetX + tooltipCenter < tooltipContentBounds.left) {
+            else if(tipOffsetX + tooltipCenter < tooltipContentBounds.left + dpToPx(24.dp)) {
                 tipOffsetX =  tooltipContentBounds.left - tooltipCenter + dpToPx(24.dp)
             }
         }


### PR DESCRIPTION
### Problem 
XOffset for tip is not coming properly
### Root cause 
XOffset  value was not remembersavable hence the initially value is coming in recomposition.

### Fix
Added remembersavable to retain new value across recompostion. Added proper range check to place tooltip within ToolTipbox bound.

### Validations

Manual Validation & Automated testcase

### Screenshots

| Before                                       | After                                      |
|![image](https://github.com/microsoft/fluentui-android/assets/97503451/6ee3a7fb-1dfe-45a4-b05b-454404a5f81f)
 |
 ![image](https://github.com/microsoft/fluentui-android/assets/97503451/20f84fe4-df6c-4866-8eac-7f216c63663e)

![image](https://github.com/microsoft/fluentui-android/assets/97503451/fe264641-b02f-4fba-a4a1-eb04c9cf04d9) |






### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
