### PR TITLE
Tooltip, adding y offset to remove the tooltipbox border ovelaying the tip

### DIFF
--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
@@ -367,7 +367,7 @@ private fun Tooltip(
                         contentDescription = null,
                         tint = token.tipColor(tooltipInfo),
                         modifier = Modifier
-                            .offset(x = pxToDp(tipOffsetX), y = 0.dp)
+                            .offset(x = pxToDp(tipOffsetX), y = 1.dp)
                             .testTag(TOOLTIP_TIP_TEST_TAG)
                     )
                 }
@@ -394,7 +394,7 @@ private fun Tooltip(
                         imageVector = ToolTipIcons.Tip, contentDescription = null,
                         tint = token.tipColor(tooltipInfo),
                         modifier = Modifier
-                            .offset(x = pxToDp(tipOffsetX), y = 0.dp)
+                            .offset(x = pxToDp(tipOffsetX), y = (-1).dp)
                             .rotate(180f)
                             .testTag(TOOLTIP_TIP_TEST_TAG)
                     )


### PR DESCRIPTION
### Problem 
tooltip tip is having a border underneath causing design issue
### Root cause 
tooltip tip is placed at y-offset 0 which will show the box border 
### Fix
adding 1 dp of y offset on both sides will move the tip onto the box border removing the line

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots
Before
![3](https://github.com/microsoft/fluentui-android/assets/5608292/9a163e48-3649-448e-975b-ec1d112c6dad)

![2](https://github.com/microsoft/fluentui-android/assets/5608292/68ad2abe-9dea-4d00-940f-e8c549361948)


After

![4](https://github.com/microsoft/fluentui-android/assets/5608292/3bfde4c8-7fd1-453e-bc59-9574a23ae74e)

![1](https://github.com/microsoft/fluentui-android/assets/5608292/b80af731-3ee2-4551-b086-853bc95f60fc)



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
