### PR TITLE
Stop race condition - Compose 1.4.3

### DIFF
--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Snackbar.kt
@@ -53,15 +53,27 @@ class SnackbarMetadata(
 ) : NotificationMetadata {
 
     override fun clicked() {
-        if (continuation.isActive) continuation.resume(NotificationResult.CLICKED)
+        try {
+            if (continuation.isActive) continuation.resume(NotificationResult.CLICKED)
+        } catch (e: Exception){
+            // This can happen if there is a race condition b/w two events. In that case, we ignore the second event.
+        }
     }
 
     override fun dismiss() {
-        if (continuation.isActive) continuation.resume(NotificationResult.DISMISSED)
+        try {
+            if (continuation.isActive) continuation.resume(NotificationResult.DISMISSED)
+        } catch (e: Exception){
+            // This can happen if there is a race condition b/w two events. In that case, we ignore the second event.
+        }
     }
 
     override fun timedOut() {
-        if (continuation.isActive) continuation.resume(NotificationResult.TIMEOUT)
+        try {
+            if (continuation.isActive) continuation.resume(NotificationResult.TIMEOUT)
+        } catch (e: Exception) {
+            // This can happen if there is a race condition b/w two events. In that case, we ignore the second event.
+        }
     }
 }
 


### PR DESCRIPTION
### Problem 
When dimiss / timedout is called simultaneously, then a race condition occurs where isActive is true but resume has already been called. This results in a crash.

### Root cause 
isActive takes time to update.

### Fix
Wrapping code block in try catch since second removal is a no-op and we don't want to crash in that case.

### Validations
Checked app not crashing, snackbar working as expected.

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
