### PR TITLE
Backport: adding y offset to remove the tooltipbox border ovelaying the tip (#615)

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Checkbox.kt
@@ -59,7 +59,7 @@ fun CheckBox(
         ?: FluentTheme.controlTokens.tokens[ControlType.CheckBoxControlType] as CheckBoxTokens
     val checkBoxInfo = CheckBoxInfo(checked)
     val toggleModifier =
-        modifier.triStateToggleable(
+        Modifier.triStateToggleable(
             state = ToggleableState(checked),
             enabled = enabled,
             onClick = { onCheckedChanged(!checked) },
@@ -83,7 +83,7 @@ fun CheckBox(
             selected = checked,
             interactionSource = interactionSource
         )
-    val shape: Shape = RoundedCornerShape(token.fixedBorderRadius)
+    val shape: Shape = RoundedCornerShape(token.borderRadius(checkBoxInfo))
 
     val borders: List<BorderStroke> =
         token.borderStroke(checkBoxInfo = checkBoxInfo)
@@ -100,12 +100,12 @@ fun CheckBox(
     }
 
     Box(
-        modifier = Modifier.indication(interactionSource, null),
+        modifier = modifier.indication(interactionSource, null),
         contentAlignment = Alignment.Center
     ) {
         Spacer(
             modifier = Modifier
-                .size(token.fixedSize)
+                .size(token.size(checkBoxInfo = checkBoxInfo))
                 .clip(shape)
                 .background(backgroundColor)
                 .then(borderModifier)
@@ -116,7 +116,7 @@ fun CheckBox(
                 Icons.Filled.Done,
                 null,
                 modifier = Modifier
-                    .size(token.fixedIconSize)
+                    .size(token.iconSize(checkBoxInfo = checkBoxInfo))
                     .focusable(false)
                     .clearAndSetSemantics {},
                 tint = iconColor

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CheckBoxTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/CheckBoxTokens.kt
@@ -19,15 +19,6 @@ open class CheckBoxInfo(
 @Parcelize
 open class CheckBoxTokens : IControlToken, Parcelable {
 
-    @IgnoredOnParcel
-    val fixedSize: Dp = 20.dp
-
-    @IgnoredOnParcel
-    val fixedIconSize: Dp = 12.dp
-
-    @IgnoredOnParcel
-    val fixedBorderRadius: Dp = 4.dp
-
     @Composable
     open fun backgroundBrush(checkBoxInfo: CheckBoxInfo): StateBrush {
         return StateBrush(
@@ -100,5 +91,20 @@ open class CheckBoxTokens : IControlToken, Parcelable {
                 )
             )
         )
+    }
+
+    @Composable
+    open fun size(checkBoxInfo: CheckBoxInfo): Dp{
+        return 20.dp
+    }
+
+    @Composable
+    open fun iconSize(checkBoxInfo: CheckBoxInfo): Dp{
+        return 12.dp
+    }
+
+    @Composable
+    open fun borderRadius(checkBoxInfo: CheckBoxInfo): Dp{
+        return 4.dp
     }
 }

--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/ToolTip.kt
@@ -367,7 +367,7 @@ private fun Tooltip(
                         contentDescription = null,
                         tint = token.tipColor(tooltipInfo),
                         modifier = Modifier
-                            .offset { IntOffset(x = tipOffsetX.toInt(), y = 0) }
+                            .offset { IntOffset(x = tipOffsetX.toInt(), y = 1) }
                             .testTag(TOOLTIP_TIP_TEST_TAG)
                     )
                 }
@@ -394,7 +394,7 @@ private fun Tooltip(
                         imageVector = ToolTipIcons.Tip, contentDescription = null,
                         tint = token.tipColor(tooltipInfo),
                         modifier = Modifier
-                            .offset { IntOffset(x = tipOffsetX.toInt(), y = 0) }
+                            .offset { IntOffset(x = tipOffsetX.toInt(), y = -1) }
                             .rotate(180f)
                             .testTag(TOOLTIP_TIP_TEST_TAG)
                     )


### PR DESCRIPTION
Backport https://github.com/microsoft/fluentui-android/pull/615 https://github.com/microsoft/fluentui-android/pull/616