### PR TITLE
Fix Accessibility Issues: Persona Chip Activity and List Item Header

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2PersonaChipActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2PersonaChipActivity.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -158,7 +160,8 @@ class V2PersonaChipActivity : V2DemoActivity() {
                 item {
                     BasicText(
                         text = "Basic Persona chip",
-                        style = TextStyle(color = brandTextColor, fontSize = 20.sp)
+                        style = TextStyle(color = brandTextColor, fontSize = 20.sp),
+                        modifier = Modifier.semantics { heading() }
                     )
                 }
                 item {
@@ -330,7 +333,8 @@ class V2PersonaChipActivity : V2DemoActivity() {
                         style = TextStyle(
                             color = brandTextColor,
                             fontSize = 20.sp
-                        )
+                        ),
+                        modifier = Modifier.semantics { heading() }
                     )
                 }
                 item {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -1,6 +1,5 @@
 package com.microsoft.fluentui.tokenized.listitem
 
-import android.util.Log
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
@@ -21,9 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -1,5 +1,6 @@
 package com.microsoft.fluentui.tokenized.listitem
 
+import android.util.Log
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
@@ -20,6 +21,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -1023,7 +1027,7 @@ object ListItem {
                 .fillMaxWidth()
                 .heightIn(min = cellHeight)
                 .background(backgroundColor)
-                .focusable(false)
+                .focusProperties { canFocus = false }
         ) {
             Row(
                 Modifier


### PR DESCRIPTION
### Problem 
1. V2 PersonaChip Activity didn't have headings marked as accessibility headings.
2. V2 Tab Bar had an extra focus element via ListItem Header. Fixed in List Item Header

### Fix
1. Marked text elements as accessibility heading.
2. Used focusProperties to make element non focusable instead of focusable(false)

### Validations
Manual Validation.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
