### PR TITLE
adding swipedismiss flag for bottomdrawer

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
@@ -60,6 +60,7 @@ private fun CreateActivityUI() {
     var selectedContent by remember { mutableStateOf(ContentType.FULL_SCREEN_SCROLLABLE_CONTENT) }
     var slideOver by remember { mutableStateOf(false) }
     var showHandle by remember { mutableStateOf(true) }
+    var enableSwipeDismiss by remember { mutableStateOf(true) }
     var preventDismissalOnScrimClick by remember { mutableStateOf(false) }
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
@@ -69,6 +70,7 @@ private fun CreateActivityUI() {
             expandable = expandable,
             showHandle = showHandle,
             preventDismissalOnScrimClick = preventDismissalOnScrimClick,
+            enableSwipeDismiss = enableSwipeDismiss,
             drawerContent =
             if (listContent)
                 getAndroidViewAsContent(selectedContent)
@@ -232,6 +234,26 @@ private fun CreateActivityUI() {
                 )
             }
             item {
+                val showDismissText = stringResource(id = R.string.drawer_enable_swipe_dismiss)
+                ListItem.Header(title = showDismissText,
+                    modifier = Modifier
+                        .toggleable(
+                            value = enableSwipeDismiss,
+                            role = Role.Switch,
+                            onValueChange = { enableSwipeDismiss = !enableSwipeDismiss }
+                        )
+                        .clearAndSetSemantics {
+                            this.contentDescription = showDismissText
+                        },
+                    trailingAccessoryContent = {
+                        ToggleSwitch(
+                            onValueChange = { enableSwipeDismiss = it },
+                            checkedState = enableSwipeDismiss,
+                        )
+                    }
+                )
+            }
+            item {
                 ListItem.Header(title = stringResource(id = R.string.drawer_select_drawer_content))
                 ListItem.Item(text = stringResource(id = R.string.drawer_full_screen_size_scrollable_content),
                     onClick = {
@@ -337,6 +359,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     scrimVisible: Boolean,
     showHandle: Boolean,
     preventDismissalOnScrimClick: Boolean,
+    enableSwipeDismiss: Boolean,
     drawerContent: @Composable ((() -> Unit) -> Unit),
 ) {
     val scope = rememberCoroutineScope()
@@ -370,6 +393,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         scrimVisible = scrimVisible,
         slideOver = slideOver,
         showHandle = showHandle,
+        enableSwipeDismiss = enableSwipeDismiss,
         preventDismissalOnScrimClick = preventDismissalOnScrimClick
     )
 }

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -891,6 +891,7 @@
     <string name="prevent_scrim_click_dismissal">Prevent Dismissal on Scrim Click</string>
     <!-- UI Label for Show Handle -->
     <string name="drawer_show_handle">Show Handle</string>
+    <string name="drawer_enable_swipe_dismiss">Enable Swipe Dismiss</string>
 
     <!--V2 ToolTip-->
     <!-- UI Label for ToolTip Title-->

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
@@ -924,3 +924,42 @@ val <T> SwipeableState<T>.NonDismissiblePostDownNestedScrollConnection: NestedSc
         private fun Offset.toFloat(): Float = this.y
     }
 
+val <T> SwipeableState<T>.NonDismissiblePreUpPostDownNestedScrollConnection: NestedScrollConnection
+    get() = object : NestedScrollConnection {
+
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+            val delta = available.toFloat()
+            return if (delta < 0 && source == NestedScrollSource.Drag) {
+                performDrag(delta).toOffset()
+            } else {
+                Offset.Zero
+            }
+        }
+        override fun onPostScroll(
+            consumed: Offset,
+            available: Offset,
+            source: NestedScrollSource
+        ): Offset {
+            return if (source == NestedScrollSource.Drag && available.toFloat() < 0) {
+                performDrag(available.toFloat()).toOffset()
+            } else {
+                Offset.Zero
+            }
+        }
+
+        override suspend fun onPreFling(available: Velocity): Velocity {
+            val toFling = Offset(available.x, available.y).toFloat()
+            return if (toFling < 0 && offset.value > minBound) {
+                performFling(velocity = toFling)
+                // since we go to the anchor with tween settling, consume all for the best UX
+                available
+            } else {
+                Velocity.Zero
+            }
+        }
+
+        private fun Float.toOffset(): Offset = Offset(0f, this)
+
+        private fun Offset.toFloat(): Float = this.y
+    }
+


### PR DESCRIPTION
Adding swipeToDismiss flag to BottomDrawer. This flag allows bottomdrawer to be dismissed by finger swipe.


### Validations
Manual Test

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
