### PR TITLE
making offset fetching from anchors fault tolerant

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
@@ -802,6 +802,13 @@ private fun computeTarget(
 private fun <T> Map<Float, T>.getOffset(state: T): Float? {
     return entries.firstOrNull { it.value == state }?.key
 }
+
+/**
+ * This functions return the most probable offset for the given state if exact match isn't found
+ * @param state Int value of the state
+ * @return Float value of the offset
+
+ */
 private fun <T> Map<Float, T>.getFaultTolerantOffset(state: Int): Float? {
     return entries.firstOrNull { it.value == state }?.key ?: when (state) {
         1 -> keys.minOrNull()

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
@@ -332,6 +332,30 @@ open class SwipeableState<T>(
             }
         }
     }
+    /**
+     * Set the state to the target value by starting an animation.
+     *
+     * @param targetValue The new value to animate to.
+     * @param anim The animation that will be used to animate to the new value.
+     */
+    suspend fun faultTolerantAnimateTo(targetValue: Int, anim: AnimationSpec<Float> = animationSpec) {
+        latestNonEmptyAnchorsFlow.collect { anchors ->
+            try {
+                val targetOffset = anchors.getFaultTolerantOffset(targetValue)
+                requireNotNull(targetOffset) {
+                    "The target value must have an associated anchor."
+                }
+                animateInternalToOffset(targetOffset, anim)
+            } finally {
+                val endOffset = absoluteOffset.value
+                val endValue = anchors
+                    // fighting rounding error once again, anchor should be as close as 0.5 pixels
+                    .filterKeys { anchorOffset -> abs(anchorOffset - endOffset) < 0.5f }
+                    .values.firstOrNull() ?: currentValue
+                currentValue = endValue
+            }
+        }
+    }
 
     /**
      * Perform fling with settling to one of the anchors which is determined by the given
@@ -778,6 +802,15 @@ private fun computeTarget(
 private fun <T> Map<Float, T>.getOffset(state: T): Float? {
     return entries.firstOrNull { it.value == state }?.key
 }
+private fun <T> Map<Float, T>.getFaultTolerantOffset(state: Int): Float? {
+    return entries.firstOrNull { it.value == state }?.key ?: when (state) {
+        1 -> keys.minOrNull()
+        2 -> keys.sorted().getOrNull(1)?:keys.minOrNull()
+        3 -> keys.maxOrNull()
+        else -> null
+    }
+}
+
 
 /**
  * Contains useful defaults for [swipeable] and [SwipeableState].

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -195,14 +195,14 @@ class DrawerState(
         }
         if (targetValue != currentValue) {
             try {
-                animateTo(targetValue = targetValue, AnimationSpec)
+                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
 
             } catch (e: Exception) {
                 //TODO: When previous instance of drawer changes its content & closed then on
                 // re-triggering the same drawer, it open but stuck to end of screen due to
                 // JobCancellationException thrown with message "ScopeCoroutine was cancelled".
                 // Hence re-triggering "animateTo". Check for better sol
-                animateTo(targetValue = targetValue, AnimationSpec)
+                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
             } finally {
                 animationInProgress = false
             }
@@ -221,9 +221,9 @@ class DrawerState(
     suspend fun close() {
         animationInProgress = true
         try {
-            animateTo(DrawerValue.Closed, AnimationSpec)
+            faultTolerantAnimateTo(DrawerValue.Closed.ordinal, AnimationSpec)
         } catch (e: Exception) {
-            animateTo(DrawerValue.Closed, AnimationSpec)
+            faultTolerantAnimateTo(DrawerValue.Closed.ordinal, AnimationSpec)
         } finally {
             animationInProgress = false
             enable = false
@@ -255,9 +255,9 @@ class DrawerState(
         }
         if (targetValue != currentValue) {
             try {
-                animateTo(targetValue = targetValue, AnimationSpec)
+                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
             } catch (e: Exception) {
-                animateTo(targetValue = targetValue, AnimationSpec)
+                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
             } finally {
                 animationInProgress = false
             }


### PR DESCRIPTION
### Problem 

We are seeing this crash: 
`java.lang.IllegalArgumentException: The target value must have an associated anchor.
  at com.microsoft.fluentui.compose.SwipeableState$animateTo$2.emit(SwipeableState.java:321)
  at com.microsoft.fluentui.compose.SwipeableState$animateTo$2.emit(SwipeableState.java:318)
  at kotlinx.coroutines.flow.FlowKt__LimitKt.emitAbort$FlowKt__LimitKt(FlowKt__LimitKt.java:73)
  at kotlinx.coroutines.flow.FlowKt__LimitKt.access$emitAbort$FlowKt__LimitKt(FlowKt__LimitKt.java:1)
  at kotlinx.coroutines.flow.FlowKt__LimitKt$take$2$1.emit(FlowKt__LimitKt.java:63)
  at kotlinx.coroutines.flow.FlowKt__TransformKt.filter(FlowKt__TransformKt.java:21)
  at com.microsoft.fluentui.compose.SwipeableState$special$$inlined$filter$1$2.emit(SwipeableState.java:223)
  at androidx.compose.material.SwipeableState$special$$inlined$filter$1$2.emit$bridge(SwipeableState.java)
  at kotlinx.coroutines.flow.internal.SafeCollectorKt$emitFun$1.invoke(SafeCollectorKt.java:15)
  at kotlinx.coroutines.flow.internal.SafeCollectorKt$emitFun$1.invoke(SafeCollectorKt.java:15)
  at kotlinx.coroutines.flow.internal.SafeCollector.emit(SafeCollector.java:87)
  at kotlinx.coroutines.flow.internal.SafeCollector.emit(SafeCollector.java)
  at androidx.compose.runtime.SnapshotStateKt__SnapshotFlowKt$snapshotFlow$1.invokeSuspend(SnapshotStateKt__SnapshotFlowKt.java:133)
  at androidx.compose.runtime.SnapshotStateKt__SnapshotFlowKt$snapshotFlow$1.invoke(SnapshotStateKt__SnapshotFlowKt.java)
  at androidx.compose.runtime.SnapshotStateKt__SnapshotFlowKt$snapshotFlow$1.invoke(SnapshotStateKt__SnapshotFlowKt.java)
  at kotlinx.coroutines.flow.SafeFlow.collectSafely(SafeFlow.java:61)
  at kotlinx.coroutines.flow.AbstractFlow.collect(AbstractFlow.java:230)
  at kotlinx.coroutines.flow.AbstractFlow.collect(AbstractFlow.java)
  at androidx.compose.material.SwipeableState$special$$inlined$filter$1$$InternalSyntheticOutline$447$59c0bf99bb25b350585f12eb864a44729ac0f62c0c24e04f449a730de7141dac$0.m(SwipeableState.java:2)
  at androidx.compose.material.SwipeableState$special$$inlined$filter$1.collect$bridge(SwipeableState.java)
  at kotlinx.coroutines.flow.FlowKt__LimitKt$take$$inlined$unsafeFlow$1.collect(FlowKt__LimitKt.java:115)
  at kotlinx.coroutines.flow.FlowKt__LimitKt$drop$$inlined$unsafeFlow$1.collect$bridge(FlowKt__LimitKt.java)
  at com.microsoft.fluentui.compose.SwipeableState.animateTo(SwipeableState.java:318)
  at com.microsoft.fluentui.tokenized.drawer.DrawerState.open(DrawerState.java:203)
  at com.microsoft.fluentui.tokenized.drawer.DrawerState$open$1.invokeSuspend(DrawerState.java:11)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:33)
  at kotlinx.coroutines.flow.internal.SafeCollector.invokeSuspend(SafeCollector.java:48)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:33)
  at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(ScopeCoroutine.java:32)
  at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.java:102)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:46)
  at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(ScopeCoroutine.java:32)
  at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.java:102)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:46)
  at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(ScopeCoroutine.java:32)
  at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.java:102)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:46)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.java:106)
  at androidx.compose.ui.platform.AndroidUiDispatcher.performTrampolineDispatch(AndroidUiDispatcher.java:81)
  at androidx.compose.ui.platform.AndroidUiDispatcher.access$performTrampolineDispatch(AndroidUiDispatcher.java:41)
  at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.run(AndroidUiDispatcher.java:57)
  at android.os.Handler.handleCallback(Handler.java:942)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at android.os.Looper.loopOnce(Looper.java:226)
  at android.os.Looper.loop(Looper.java:313)
  at android.app.ActivityThread.main(ActivityThread.java:8762)
  at java.lang.reflect.Method.invoke(Method.java:-2)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
`

### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
