### PR TITLE
V1 Calendar Accessibility: Added a way to leave focus when using Hardware Keyboard

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/CalendarViewActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/CalendarViewActivity.kt
@@ -6,7 +6,9 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.View
 import android.view.View.TEXT_ALIGNMENT_TEXT_START
 import com.microsoft.fluentui.calendar.OnDateSelectedListener
 import com.microsoft.fluentui.util.DateStringUtils
@@ -63,4 +65,22 @@ class CalendarViewActivity : DemoActivity() {
         calenderBinding.exampleDateTitle.text = DateStringUtils.formatDateWithWeekDay(this, date)
         calenderBinding.calendarView.setSelectedDateRange(date.toLocalDate(), Duration.ZERO, false)
     }
+
+    /**
+     * This function allows the user to leave the calendar focus by pressing the tab key.
+     * @param  keyCode The value in event.getKeyCode().
+     * @param  event The KeyEvent object.
+     */
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_TAB  && calenderBinding.calendarView.hasFocus()) {
+            // Find the currently focused view
+            val focusedView = currentFocus
+            // Remove focus from the currently focused view
+            focusedView?.clearFocus()
+
+            return true // Consume the event
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+
 }

--- a/fluentui_calendar/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
+++ b/fluentui_calendar/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
@@ -207,22 +207,6 @@ class CalendarView : LinearLayout, OnDateSelectedListener {
         val visibleDividersHeight = dividerHeight * visibleRows - 1
         return config.weekHeadingHeight + visibleRowsHeight + visibleDividersHeight
     }
-    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_SHIFT_LEFT || keyCode == KeyEvent.KEYCODE_SHIFT_RIGHT) {
-            // Find the currently focused view
-
-
-            // Remove focus from the currently focused view
-            this.clearFocus()
-
-            // Find another suitable view to focus on, for example, the root layout
-            val rootView = findViewById<View>(android.R.id.content)
-            rootView.requestFocus()
-
-            return true // Consume the event
-        }
-        return super.onKeyDown(keyCode, event)
-    }
 
     private fun canExpand(): Boolean {
         return displayMode != DisplayMode.FULL_MODE && displayMode != DisplayMode.LENGTHY_MODE && weeksView.isUserTouchOccurring

--- a/fluentui_calendar/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
+++ b/fluentui_calendar/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
@@ -14,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import android.util.AttributeSet
 import android.util.Property
+import android.view.KeyEvent
 import android.view.View
 import android.widget.LinearLayout
 import com.jakewharton.threetenabp.AndroidThreeTen
@@ -205,6 +206,22 @@ class CalendarView : LinearLayout, OnDateSelectedListener {
         val visibleRowsHeight = rowHeight * visibleRows
         val visibleDividersHeight = dividerHeight * visibleRows - 1
         return config.weekHeadingHeight + visibleRowsHeight + visibleDividersHeight
+    }
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_SHIFT_LEFT || keyCode == KeyEvent.KEYCODE_SHIFT_RIGHT) {
+            // Find the currently focused view
+
+
+            // Remove focus from the currently focused view
+            this.clearFocus()
+
+            // Find another suitable view to focus on, for example, the root layout
+            val rootView = findViewById<View>(android.R.id.content)
+            rootView.requestFocus()
+
+            return true // Consume the event
+        }
+        return super.onKeyDown(keyCode, event)
     }
 
     private fun canExpand(): Boolean {

--- a/fluentui_calendar/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
+++ b/fluentui_calendar/src/main/java/com/microsoft/fluentui/calendar/CalendarView.kt
@@ -14,7 +14,6 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import android.util.AttributeSet
 import android.util.Property
-import android.view.KeyEvent
 import android.view.View
 import android.widget.LinearLayout
 import com.jakewharton.threetenabp.AndroidThreeTen


### PR DESCRIPTION
### Problem 
There wasn't a way to leave focus of calendar using keyboard only.
### Root cause 

### Fix
Have overriden key press event to check if focus is inside calendar and key press is TAB, then clear focus


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
