### PR TITLE
Revert drawer changes

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerUITest.kt
@@ -24,6 +24,7 @@ import com.microsoft.fluentui.tokenized.drawer.DRAWER_SCRIM_TAG
 import com.microsoft.fluentui.util.statusBarHeight
 import com.microsoft.fluentuidemo.BaseTest
 import com.microsoft.fluentuidemo.R
+import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -67,7 +68,7 @@ class V2BottomDrawerUITest : BaseTest() {
         val drawerHandleY = (drawerHandle.fetchSemanticsNode().positionInRoot.y / context.resources.displayMetrics.density).dp
         val topHandlePadding = 8.dp
         val statusBarHeight = (context.statusBarHeight / context.resources.displayMetrics.density).dp
-        assert(drawerHandleY == topHandlePadding + statusBarHeight) //if drawerHandle is below status bar, then it's in Expanded state
+        assertEquals(drawerHandleY.value.toDouble(), topHandlePadding.value.toDouble() + statusBarHeight.value.toDouble(), 1.0) //if drawerHandle is below status bar, then it's in Expanded state
     }
 
     private fun dpToPx(value: Dp) = (value * Resources

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2DrawerActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2DrawerActivityUITest.kt
@@ -5,10 +5,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeRight
@@ -309,7 +312,7 @@ class V2DrawerActivityUITest : BaseTest() {
 
     @Test
     fun testPreventDrawerDismissalOnScrimClick(){
-        composeTestRule.onNodeWithText(getString(R.string.prevent_scrim_click_dismissal), useUnmergedTree = true).performClick()
+        composeTestRule.onNodeWithContentDescription(getString(R.string.prevent_scrim_click_dismissal), useUnmergedTree = true, ignoreCase = true).performClick()
         composeTestRule.onNodeWithText("Open Drawer").performClick()
         openCheckForVerticalDrawer()
         drawerScrim.performTouchInput {
@@ -317,5 +320,4 @@ class V2DrawerActivityUITest : BaseTest() {
         }
         openCheckForVerticalDrawer()
     }
-
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ListItemUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ListItemUITest.kt
@@ -273,7 +273,8 @@ class V2ListItemUITest {
                 accessoryTextTitle = ACTION_TEXT,
                 accessoryTextOnClick = {})
         }
-        val actionButton = composeTestRule.onNodeWithText(ACTION_TEXT)
+        composeTestRule.onRoot().printToLog("listTestTag")
+        val actionButton = composeTestRule.onNodeWithContentDescription(ACTION_TEXT)
         actionButton.assertExists()
         actionButton.assertIsDisplayed()
         actionButton.assertHasClickAction()

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2PersonaListActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2PersonaListActivityUITest.kt
@@ -25,7 +25,6 @@ class V2PersonaListActivityUITest : BaseTest() {
         personaList.assertExists()
         personaList.assertIsDisplayed()
         personaList.assert(hasScrollAction())
-        personaList.onChildAt(0).assertHasClickAction()
     }
 
 }

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2ToolTipActivityUITest.kt
@@ -22,6 +22,7 @@ import com.microsoft.fluentui.tokenized.notification.rememberTooltipState
 import com.microsoft.fluentui.util.dpToPx
 import com.microsoft.fluentuidemo.BaseTest
 import com.microsoft.fluentuidemo.R
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.launch
 import org.junit.Before
 import org.junit.Rule
@@ -85,11 +86,8 @@ class V2ToolTipActivityUITest : BaseTest() {
         composeTestRule.waitForIdle()
         //find the Tip
         val tip: UiObject2 = device.findObject(By.res(TOOLTIP_TIP_TEST_TAG))
-
-        val isBottomAligned =
-            composeTestRule.onNodeWithTag(context.resources.getString(R.string.tooltip_top_start))
-                .fetchSemanticsNode().boundsInWindow.bottom >= tip.visibleBounds.top
-        assert(isBottomAligned)
+        assertEquals(composeTestRule.onNodeWithTag(context.resources.getString(R.string.tooltip_top_start))
+            .fetchSemanticsNode().boundsInWindow.bottom.toDouble(), tip.visibleBounds.top.toDouble(), 2.0)
     }
 
     //Test to check top align tooltip

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -188,24 +188,6 @@ private fun CreateActivityUI() {
                     )
                 }
                 item {
-                    val scrimVisibleText = stringResource(id = R.string.drawer_scrim_visible)
-                    ListItem.Header(title = scrimVisibleText, modifier = Modifier
-                        .toggleable(
-                            value = scrimVisible,
-                            role = Role.Switch,
-                            onValueChange = { scrimVisible = !scrimVisible }
-                        )
-                        .clearAndSetSemantics {
-                            this.contentDescription = scrimVisibleText
-                        }, trailingAccessoryContent = {
-                        ToggleSwitch(
-                            onValueChange = { scrimVisible = !scrimVisible },
-                            checkedState = scrimVisible
-                        )
-                    }
-                    )
-                }
-                item {
                     val preventDismissalOnScrimClickText =
                         stringResource(id = R.string.prevent_scrim_click_dismissal)
                     ListItem.Header(title = preventDismissalOnScrimClickText,
@@ -228,6 +210,24 @@ private fun CreateActivityUI() {
                                 checkedState = preventDismissalOnScrimClick
                             )
                         }
+                    )
+                }
+                item {
+                    val scrimVisibleText = stringResource(id = R.string.drawer_scrim_visible)
+                    ListItem.Header(title = scrimVisibleText, modifier = Modifier
+                        .toggleable(
+                            value = scrimVisible,
+                            role = Role.Switch,
+                            onValueChange = { scrimVisible = !scrimVisible }
+                        )
+                        .clearAndSetSemantics {
+                            this.contentDescription = scrimVisibleText
+                        }, trailingAccessoryContent = {
+                        ToggleSwitch(
+                            onValueChange = { scrimVisible = !scrimVisible },
+                            checkedState = scrimVisible
+                        )
+                    }
                     )
                 }
                 item {

--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -91,7 +91,7 @@ extends:
           inputs:
             testResultsFiles: "$(build.sourcesdirectory)/build/testResult/**/hydra_result_*.xml"
             testRunTitle: "Test-Result"
-            failTaskOnFailedTests: false
+            failTaskOnFailedTests: true
         - task: Gradle@2
           displayName: "generate artifacts and publish to feed"
           inputs:

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
@@ -332,30 +332,6 @@ open class SwipeableState<T>(
             }
         }
     }
-    /**
-     * Set the state to the target value by starting an animation.
-     *
-     * @param targetValue The new value to animate to.
-     * @param anim The animation that will be used to animate to the new value.
-     */
-    suspend fun faultTolerantAnimateTo(targetValue: Int, anim: AnimationSpec<Float> = animationSpec) {
-        latestNonEmptyAnchorsFlow.collect { anchors ->
-            try {
-                val targetOffset = anchors.getFaultTolerantOffset(targetValue)
-                requireNotNull(targetOffset) {
-                    "The target value must have an associated anchor."
-                }
-                animateInternalToOffset(targetOffset, anim)
-            } finally {
-                val endOffset = absoluteOffset.value
-                val endValue = anchors
-                    // fighting rounding error once again, anchor should be as close as 0.5 pixels
-                    .filterKeys { anchorOffset -> abs(anchorOffset - endOffset) < 0.5f }
-                    .values.firstOrNull() ?: currentValue
-                currentValue = endValue
-            }
-        }
-    }
 
     /**
      * Perform fling with settling to one of the anchors which is determined by the given
@@ -802,22 +778,6 @@ private fun computeTarget(
 private fun <T> Map<Float, T>.getOffset(state: T): Float? {
     return entries.firstOrNull { it.value == state }?.key
 }
-
-/**
- * This functions return the most probable offset for the given state if exact match isn't found
- * @param state Int value of the state
- * @return Float value of the offset
-
- */
-private fun <T> Map<Float, T>.getFaultTolerantOffset(state: Int): Float? {
-    return entries.firstOrNull { it.value == state }?.key ?: when (state) {
-        1 -> keys.minOrNull()
-        2 -> keys.sorted().getOrNull(1)?:keys.minOrNull()
-        3 -> keys.maxOrNull()
-        else -> null
-    }
-}
-
 
 /**
  * Contains useful defaults for [swipeable] and [SwipeableState].

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -195,14 +195,14 @@ class DrawerState(
         }
         if (targetValue != currentValue) {
             try {
-                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
+                animateTo(targetValue = targetValue, AnimationSpec)
 
             } catch (e: Exception) {
                 //TODO: When previous instance of drawer changes its content & closed then on
                 // re-triggering the same drawer, it open but stuck to end of screen due to
                 // JobCancellationException thrown with message "ScopeCoroutine was cancelled".
                 // Hence re-triggering "animateTo". Check for better sol
-                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
+                animateTo(targetValue = targetValue, AnimationSpec)
             } finally {
                 animationInProgress = false
             }
@@ -221,9 +221,9 @@ class DrawerState(
     suspend fun close() {
         animationInProgress = true
         try {
-            faultTolerantAnimateTo(DrawerValue.Closed.ordinal, AnimationSpec)
+            animateTo(DrawerValue.Closed, AnimationSpec)
         } catch (e: Exception) {
-            faultTolerantAnimateTo(DrawerValue.Closed.ordinal, AnimationSpec)
+            animateTo(DrawerValue.Closed, AnimationSpec)
         } finally {
             animationInProgress = false
             enable = false
@@ -255,9 +255,9 @@ class DrawerState(
         }
         if (targetValue != currentValue) {
             try {
-                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
+                animateTo(targetValue = targetValue, AnimationSpec)
             } catch (e: Exception) {
-                faultTolerantAnimateTo(targetValue = targetValue.ordinal, AnimationSpec)
+                animateTo(targetValue = targetValue, AnimationSpec)
             } finally {
                 animationInProgress = false
             }


### PR DESCRIPTION
### Problem 
Drawer changes in previous release causes crashes. So reverting
Modifying the hydralab test to fail on test failure
modified ui tests


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
