### PR TITLE
V2 BottomSheet Focus Accessibility: Auto Expansion for content focus in sliderOver 

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -456,7 +459,12 @@ fun BottomSheet(
                 }
                 Column(modifier = Modifier
                     .testTag(BOTTOMSHEET_CONTENT_TAG)
-                    .then(if (slideOver) Modifier else Modifier.fillMaxSize()),
+                    .then(if (slideOver) Modifier
+                        .onFocusChanged { focusState ->
+                            if (focusState.hasFocus && sheetState.currentValue != BottomSheetValue.Expanded) {        // this expands the sheet when the content is focused
+                                scope.launch { sheetState.expand() }
+                            }
+                        } else Modifier.fillMaxSize()),
                     content = { sheetContent() })
             }
         }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -22,8 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color


### PR DESCRIPTION
### Problem 
 
The sheetContent wasn't scrolling as the focus moved to next item which was below the visible region, making it inaccessible for physical keyboard users.

### Root cause 

The slideOver component is designed with a fixed height and relies on the expanded state to initiate scrolling. However, this design did not account for the dynamic focus changes occurring when users navigate the content with a keyboard.

### Fix

To enhance accessibility and ensure seamless keyboard navigation, we’ve introduced an auto-expansion feature for the sheet. This feature activates when any of the sheet’s contents gain focus, thereby enabling the content to scroll into view. This improvement has been thoroughly tested with slideOver = true and Expandable = false configurations, confirming that scrolling functions correctly in all scenarios.

[v2BottomSheet_auto_expand.webm](https://github.com/microsoft/fluentui-android/assets/68989156/86150df3-cdae-4c7b-9230-e4b713f9f5ba)
