### PR TITLE
Fixing order of clip & shadow in bottomsheet

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -354,8 +354,8 @@ fun BottomSheet(
                     peekHeight,
                     sheetState
                 )
-                .shadow(sheetElevation)
                 .clip(sheetShape)
+                .shadow(sheetElevation)
                 .background(sheetBackgroundColor)
                 .semantics(mergeDescendants = false) {
                     if (sheetState.isVisible) {


### PR DESCRIPTION
### Problem 
The default corner radius of bottom sheet is `12dp`, when we try to increase the radius to say `24dp` or `36dp` then the shadow (elevation) is showing up as a rectangular box behind the corners of bottom sheet. Its more evident when bottom sheet is in fully expanded state with background dim.

### Root cause 
Currently we are first applying shadow then clipping the corners. This is causing the problem.

### Fix
We just need to reverse the order i..e first clipping the corner then applying shadow.

### Validations
Created my own bottom sheet token to override the corner radius for bottom sheet of `V2BottomSheetActivity`:
```
class MyBottomSheetToken : BottomSheetTokens() {
    @Composable
    override fun cornerRadius(bottomSheetInfo: BottomSheetInfo): Dp = 24.dp
}
```

### Screenshots
First screenshot with 12dp (default) corner radius, second screenshot with 24dp and third one with 36dp
| Before                                    | After                            |
|----------------------------------------------|--------------------------------------------|
| ![default_before](https://github.com/microsoft/fluentui-android/assets/25812641/21c23d3f-19c7-4e6a-84cd-25fa47bc6f42) | ![default_after](https://github.com/microsoft/fluentui-android/assets/25812641/85ec36af-990e-456d-95ce-c6adbcc4c498) |
| ![24dp_before](https://github.com/microsoft/fluentui-android/assets/25812641/fb7fbacb-8ace-4cdc-a092-97c7fc594af3) | ![24dp_after](https://github.com/microsoft/fluentui-android/assets/25812641/bec148d0-4940-45fb-ac13-fe272f52cd91) |
| ![36dp_before](https://github.com/microsoft/fluentui-android/assets/25812641/ef84e990-648b-41a5-b46d-6d2c2e16542f) | ![36dp_after](https://github.com/microsoft/fluentui-android/assets/25812641/a1d9399f-6063-4e7a-8ef6-08bbfeae3bd7) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and RTL layouts
- [x] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
