### PR TITLE
adding trailing icon for v2button

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ButtonsActivity.kt
@@ -220,7 +220,8 @@ class V2ButtonsActivity : V2DemoActivity() {
                             Toast.makeText(context, toastText, Toast.LENGTH_SHORT).show()
                         },
                         icon = Icons.Filled.Email,
-                        modifier = Modifier.padding(16.dp)
+                        modifier = Modifier
+                            .padding(16.dp)
                             .testTag("FAB"),
                         text = fabText,
                     )
@@ -271,6 +272,7 @@ class V2ButtonsActivity : V2DemoActivity() {
                     buttonTokens = if (clicks < 3) buttonToken else ButtonTokens(),
                     onClick = onClickLambda,
                     icon = icon(toggleIcon),
+                    trailingIcon = icon(enabled = toggleIcon),
                     text = text
                 )
 
@@ -281,6 +283,7 @@ class V2ButtonsActivity : V2DemoActivity() {
                     buttonTokens = buttonToken,
                     onClick = onClickLambda,
                     icon = icon(toggleIcon),
+                    trailingIcon = icon(enabled = toggleIcon),
                     text = "Long text displayed on this button. This Is long text."
                 )
 
@@ -291,6 +294,7 @@ class V2ButtonsActivity : V2DemoActivity() {
                     buttonTokens = buttonToken,
                     onClick = onClickLambda,
                     icon = icon(toggleIcon),
+                    trailingIcon = icon(enabled = toggleIcon),
                     text = "Outlined $text"
                 )
                 Button(
@@ -300,6 +304,7 @@ class V2ButtonsActivity : V2DemoActivity() {
                     buttonTokens = buttonToken,
                     onClick = onClickLambda,
                     icon = icon(clicks % 2 == 0),
+                    trailingIcon = icon( clicks %2 != 0 ),
                     text = "Text $text"
                 )
             }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/Button.kt
@@ -38,6 +38,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.ButtonTokens
  * @param enabled Boolean for enabling/disabling button. Default: [true]
  * @param interactionSource Interaction Source to handle user interactions
  * @param icon ImageVector for Icon Content on buttton. Default: [null]
+ * @param trailingIcon ImageVector for trailing Icon Content on buttton. Default: [null]
  * @param text String to be displayed as text on button. Default: [null]
  * @param contentDescription Content Description for Icon. Default: [null]
  * @param buttonTokens Tokens to customize appearance of button. Default: [null]
@@ -51,6 +52,7 @@ fun Button(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     icon: ImageVector? = null,
+    trailingIcon: ImageVector? = null,
     text: String? = null,
     contentDescription: String? = null,
     buttonTokens: ButtonTokens? = null
@@ -134,7 +136,7 @@ fun Button(
             if (text != null)
                 BasicText(
                     text = text,
-                    modifier = Modifier.clearAndSetSemantics { },
+                    modifier = Modifier.weight(1f, fill = false).clearAndSetSemantics { },
                     style = token.typography(buttonInfo).merge(
                         TextStyle(
                             color = token.textColor(buttonInfo = buttonInfo)
@@ -148,6 +150,23 @@ fun Button(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
+
+            if(trailingIcon != null){
+                Icon(
+                    imageVector = trailingIcon,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(
+                            token.iconSize(buttonInfo = buttonInfo)
+                        ),
+                    tint = token.iconColor(buttonInfo = buttonInfo)
+                        .getColorByState(
+                            enabled = enabled,
+                            selected = false,
+                            interactionSource = interactionSource
+                        )
+                )
+            }
         }
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ButtonTokens.kt
@@ -82,6 +82,49 @@ open class ButtonTokens : IControlToken, Parcelable {
     }
 
     @Composable
+    open fun trailingIconColor(buttonInfo: ButtonInfo): StateColor {
+        return when (buttonInfo.style) {
+            ButtonStyle.Button ->
+                StateColor(
+                    rest = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    pressed = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    selected = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    focused = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
+                        themeMode = themeMode
+                    ),
+                    disabled = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        themeMode = themeMode
+                    )
+                )
+
+            ButtonStyle.OutlinedButton, ButtonStyle.TextButton ->
+                StateColor(
+                    rest = aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        themeMode = themeMode
+                    ),
+                    pressed = aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                        themeMode = themeMode
+                    ),
+                    selected = aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1Selected].value(
+                        themeMode = themeMode
+                    ),
+                    focused = aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        themeMode = themeMode
+                    ),
+                    disabled = aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        themeMode = themeMode
+                    )
+                )
+        }
+    }
+
+    @Composable
     open fun textColor(buttonInfo: ButtonInfo): StateColor {
         return when (buttonInfo.style) {
             ButtonStyle.Button -> StateColor(
@@ -232,6 +275,18 @@ open class ButtonTokens : IControlToken, Parcelable {
 
     @Composable
     open fun iconSize(buttonInfo: ButtonInfo): Dp {
+        return when (buttonInfo.style) {
+            ButtonStyle.Button, ButtonStyle.TextButton, ButtonStyle.OutlinedButton ->
+                when (buttonInfo.size) {
+                    ButtonSize.Small -> FluentGlobalTokens.IconSizeTokens.IconSize160.value
+                    ButtonSize.Medium -> FluentGlobalTokens.IconSizeTokens.IconSize200.value
+                    ButtonSize.Large -> FluentGlobalTokens.IconSizeTokens.IconSize200.value
+                }
+        }
+    }
+
+    @Composable
+    open fun trailingIconSize(buttonInfo: ButtonInfo): Dp {
         return when (buttonInfo.style) {
             ButtonStyle.Button, ButtonStyle.TextButton, ButtonStyle.OutlinedButton ->
                 when (buttonInfo.size) {


### PR DESCRIPTION
### Problem 
Trailing icon cannot be created in v2button
### Root cause 
No trailing icon provided in the api
### Fix
Added trailing icon param to the api

### Validations

(how the change was tested, including both manual and automated tests)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
