### PR TITLE
adding keycorrction to not duplicate the offset keys

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -481,23 +481,24 @@ private fun Modifier.bottomSheetSwipeable(
 
 ): Modifier {
     var peekHeightPx = min(dpToPx(peekHeight), fullHeight * BottomSheetOpenFraction)
+    val keyCorrection = 0.05f
     val modifier = if (slideOver) {
         if (sheetHeight != null && sheetHeight != 0f) {
             val anchors = if (!expandable) {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,
-                    fullHeight - min(sheetHeight, peekHeightPx) to BottomSheetValue.Shown
+                    (fullHeight - min(sheetHeight, peekHeightPx))+keyCorrection to BottomSheetValue.Shown
                 )
             } else if (sheetHeight <= peekHeightPx) {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,
-                    fullHeight - sheetHeight to BottomSheetValue.Shown
+                    (fullHeight - sheetHeight)+keyCorrection to BottomSheetValue.Shown
                 )
             } else {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,
-                    fullHeight - peekHeightPx to BottomSheetValue.Shown,
-                    max(0f, fullHeight - sheetHeight) to BottomSheetValue.Expanded
+                    (fullHeight - peekHeightPx)+keyCorrection to BottomSheetValue.Shown,
+                    (max(0f, fullHeight - sheetHeight))+(keyCorrection*2) to BottomSheetValue.Expanded
                 )
             }
             if (sheetState.initialValue == BottomSheetValue.Expanded


### PR DESCRIPTION
### Problem 
bottomsheet anchor map replaces statevalues when the keys are same in some scenarios
### Root cause 
Map used for anchors use Float as Key. These key values can be same in some scenarios
### Fix
Added a very small value for key that will prevent from key duplication while also not causing any issues wrt to dp

### Validations
Manual Testing

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
