### PR TITLE
V2 Basic Card API changes

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
@@ -16,7 +16,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.CardType
 
 /**
  * Cards are flexible containers that group related content and actions together. They reveal more information upon interaction.
- * A Basic card is a card with an empty container and basic elevation and radius.
+ * A Basic card is a card with an empty container and with radius and basic elevation or outline depending on the cardType.
  *
  * @param modifier Modifier for the card
  * @param basicCardTokens Optional tokens for customizing the card

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
@@ -26,21 +26,22 @@ import com.microsoft.fluentui.theme.token.controlTokens.CardType
 fun BasicCard(
     modifier: Modifier = Modifier,
     basicCardTokens: BasicCardTokens? = null,
+    basicCardInfo: BasicCardInfo? = null,
     content: @Composable () -> Unit
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = basicCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BasicCardControlType] as BasicCardTokens
-    val basicCardInfo = BasicCardInfo(CardType.Elevated)
-    val cornerRadius = token.cornerRadius(basicCardInfo = basicCardInfo)
-    val backgroundBrush = token.backgroundBrush(basicCardInfo = basicCardInfo)
-    val elevation = token.elevation(basicCardInfo = basicCardInfo)
-    val borderColor = token.borderColor(basicCardInfo = basicCardInfo)
-    val borderStrokeWidth = token.borderStrokeWidth(basicCardInfo = basicCardInfo)
+    val cardInfo = basicCardInfo?: BasicCardInfo(CardType.Elevated)
+    val cornerRadius = token.cornerRadius(basicCardInfo = cardInfo)
+    val backgroundBrush = token.backgroundBrush(basicCardInfo = cardInfo)
+    val elevation = token.elevation(basicCardInfo = cardInfo)
+    val borderColor = token.borderColor(basicCardInfo = cardInfo)
+    val borderStrokeWidth = token.borderStrokeWidth(basicCardInfo = cardInfo)
     val shape = RoundedCornerShape(cornerRadius)
     Box(
-        modifier = modifier
+        modifier = Modifier
             .shadow(elevation, shape, false)
             .background(
                 backgroundBrush, shape
@@ -49,6 +50,7 @@ fun BasicCard(
                 borderStrokeWidth, borderColor, shape
             )
             .clip(shape)
+            .then(modifier)
     ) {
         content()
     }

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/BasicCard.kt
@@ -20,20 +20,21 @@ import com.microsoft.fluentui.theme.token.controlTokens.CardType
  *
  * @param modifier Modifier for the card
  * @param basicCardTokens Optional tokens for customizing the card
+ * @param cardType defines the card type, whether Elevated or Outlined
  * @param content Content for the card
  */
 @Composable
 fun BasicCard(
     modifier: Modifier = Modifier,
     basicCardTokens: BasicCardTokens? = null,
-    basicCardInfo: BasicCardInfo? = null,
+    cardType: CardType = CardType.Elevated,
     content: @Composable () -> Unit
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = basicCardTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.BasicCardControlType] as BasicCardTokens
-    val cardInfo = basicCardInfo?: BasicCardInfo(CardType.Elevated)
+    val cardInfo = BasicCardInfo(cardType)
     val cornerRadius = token.cornerRadius(basicCardInfo = cardInfo)
     val backgroundBrush = token.backgroundBrush(basicCardInfo = cardInfo)
     val elevation = token.elevation(basicCardInfo = cardInfo)


### PR DESCRIPTION
### Problem 
 1. User is not able to create Outlined Basic Card, default type is Elevated Card.
 2. modifiers passed as param may be overriden existing modifiers due to their order
### Root cause 
1. Deafult type ofCard has been defined inside composable, and i.e "Elevated"
2. Order of modifiers applied

### Fix
1. Let user pass BasicCardInfo
2. Change order of modifiers

### Validations

(how the change was tested, including both manual and automated tests)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
