### PR TITLE
release-version-0.2.5

### DIFF
--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId 'com.microsoft.fluentuidemo'
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 1004
-        versionName '0.2.4'
+        versionCode 1005
+        versionName '0.2.5'
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
 //      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.

--- a/FluentUI.Demo/src/main/assets/dogfood-release-notes.txt
+++ b/FluentUI.Demo/src/main/assets/dogfood-release-notes.txt
@@ -1,13 +1,11 @@
-Release Version 0.2.4:
+Release Version 0.2.5:
 
 What's New:
 
 Fluent V2:
         Fix/Enhancement:
             
-            1. Addressed an issue with the shadow in Bottomsheet.
-            2. Included a new parameter, minmaxLines, in the AvatarCarousel to adjust text and subtext.
-            3. Updated the Button component to include a trailing icon.
-            4. Resolved crashes related to the Bottomsheet anchor.
+            1. You can specify the card type as outlined or elevated in the Card component's params.
+            2. You can adjust the tip's position relative to the tooltip box using the tipOffset parameter.
 
 Note: Fluent version 0.1.x (from 0.1.48) supports compose version 0.1.43 (BOM 2023.06.01). Fluent versions 0.2.x will support compose version 1.5.1 (BOM 2023.09.00)

--- a/config.gradle
+++ b/config.gradle
@@ -12,7 +12,7 @@
  * fluentui_drawer and FluentUI should increment their respective version ids
   */
 project.ext.fluentui_calendar_versionid = '0.2.0'
-project.ext.fluentui_controls_versionid = '0.2.2'
+project.ext.fluentui_controls_versionid = '0.2.3'
 project.ext.fluentui_core_versionid = '0.2.4'
 project.ext.fluentui_listitem_versionid = '0.2.1'
 project.ext.fluentui_tablayout_versionid = '0.2.0'
@@ -26,10 +26,10 @@ project.ext.fluentui_peoplepicker_versionid = '0.2.0'
 project.ext.fluentui_persona_versionid = '0.2.1'
 project.ext.fluentui_progress_versionid = '0.2.0'
 project.ext.fluentui_icons_versionid = '0.2.0'
-project.ext.fluentui_notification_versionid = '0.2.1'
-project.ext.FluentUI_versionid = '0.2.4'
+project.ext.fluentui_notification_versionid = '0.2.2'
+project.ext.FluentUI_versionid = '0.2.5'
 project.ext.fluentui_calendar_version_code = 1000
-project.ext.fluentui_controls_version_code = 1002
+project.ext.fluentui_controls_version_code = 1003
 project.ext.fluentui_core_version_code = 1004
 project.ext.fluentui_listitem_version_code = 1001
 project.ext.fluentui_tablayout_version_code = 1000
@@ -43,8 +43,8 @@ project.ext.fluentui_peoplepicker_version_code = 1000
 project.ext.fluentui_persona_version_code = 1001
 project.ext.fluentui_progress_version_code = 1000
 project.ext.fluentui_icons_version_code = 1000
-project.ext.fluentui_notification_version_code = 1001
-project.ext.FluentUI_version_code = 1004
+project.ext.fluentui_notification_version_code = 1002
+project.ext.FluentUI_version_code = 1005
 project.ext.license_type = 'MIT License'
 project.ext.license_url = 'https://github.com/microsoft/fluentui-android/blob/master/LICENSE'
 project.ext.github_url = 'https://github.com/microsoft/fluentui-android'

--- a/fluentui-office-build-universal-publish-1espt.yml
+++ b/fluentui-office-build-universal-publish-1espt.yml
@@ -62,6 +62,6 @@ extends:
             vstsFeedPublish: 'Office'
             vstsFeedPackagePublish: 'fluentuiandroid'
             versionOption: 'custom'
-            versionPublish: '0.2.4'
+            versionPublish: '0.2.5'
             packagePublishDescription: 'Fluent Universal Package'
             publishedPackageVar: 'fluent package'


### PR DESCRIPTION
Release Version 0.2.5:

What's New:

Fluent V2:
        Fix/Enhancement:
            
            1. You can specify the card type as outlined or elevated in the Card component's params.
            2. You can adjust the tip's position relative to the tooltip box using the tipOffset parameter.

Note: Fluent version 0.1.x (from 0.1.48) supports compose version 0.1.43 (BOM 2023.06.01). Fluent versions 0.2.x will support compose version 1.5.1 (BOM 2023.09.00)