### PR TITLE
removing the focus from textfield

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -126,16 +126,7 @@ fun TextField(
         textAvailable = value.isNotEmpty()
     )
 
-    val focusRequester = remember { FocusRequester() }
-
     Column(modifier = modifier
-        .onFocusChanged { focusState ->
-            when {
-                focusState.isFocused -> {
-                    focusRequester.requestFocus()
-                }
-            }
-        }
         .background(token.backgroundBrush(textFieldInfo))
         .padding(token.leftRightPadding(textFieldInfo))) {
         if (!label.isNullOrBlank()) {
@@ -185,7 +176,6 @@ fun TextField(
                             .testTag(TEXT_FIELD)
                             .padding(vertical = 12.dp)
                             .weight(1F)
-                            .focusRequester(focusRequester)
                             .onFocusChanged { state ->
                                 isFocused = false
                                 when {


### PR DESCRIPTION
### Problem 
n infinite loop occurs when focusing on the control
### Root cause 
focusRequester.requestFocus is causing the loop focus in newer compose versions
### Fix
Removnig the line, since it is not required specifically from design perspective

### Validations
Manual testing
(how the change was tested, including both manual and automated tests)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
