### PR TITLE
v2 People Picker: Adding Customization support for Persona Chip

### DIFF
--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -84,7 +84,6 @@ import com.microsoft.fluentui.tokenized.persona.PersonaChip
  * acts as dismiss icon.
  * @param peoplePickerContentDescription String which acts as content description for the PeoplePicker. Add content description for accessibility description.
  * @param peoplePickerTokens Customization options for the PeoplePicker.
- * @param personaChipSize Size of the PersonaChip. See [PersonaChipSize]
  * @param personaChipTokens Customization options for the PersonaChip.
  */
 @OptIn(ExperimentalLayoutApi::class)
@@ -111,7 +110,6 @@ fun PeoplePicker(
     ),
     peoplePickerContentDescription: String? = null,
     peoplePickerTokens: PeoplePickerTokens? = null,
-    personaChipSize: PersonaChipSize? = null,
     personaChipTokens: PersonaChipTokens? = null
 ) {
     val themeID =
@@ -174,7 +172,6 @@ fun PeoplePicker(
                             PersonaChip(
                                 modifier = Modifier.padding(bottom = chipVerticalSpacing),
                                 person = it.person, selected = it.selected.value,
-                                size = personaChipSize ?: PersonaChipSize.Medium,
                                 onCloseClick = if (onChipCloseClick != null) {
                                     {
                                         onChipCloseClick.invoke(it)

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -45,7 +45,9 @@ import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.PeoplePickerInfo
 import com.microsoft.fluentui.theme.token.controlTokens.PeoplePickerTokens
+import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipSize
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipStyle
+import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipTokens
 import com.microsoft.fluentui.tokenized.controls.TextField
 import com.microsoft.fluentui.tokenized.persona.Person
 import com.microsoft.fluentui.tokenized.persona.PersonaChip
@@ -82,11 +84,10 @@ import com.microsoft.fluentui.tokenized.persona.PersonaChip
  * acts as dismiss icon.
  * @param peoplePickerContentDescription String which acts as content description for the PeoplePicker. Add content description for accessibility description.
  * @param peoplePickerTokens Customization options for the PeoplePicker.
+ * @param personaChipSize Size of the PersonaChip. See [PersonaChipSize]
+ * @param personaChipTokens Customization options for the PersonaChip.
  */
-@OptIn(
-    ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class,
-    ExperimentalLayoutApi::class
-)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun PeoplePicker(
     selectedPeopleList: MutableList<PeoplePickerItemData> = mutableStateListOf(),
@@ -109,7 +110,9 @@ fun PeoplePicker(
         contentDescription = LocalContext.current.resources.getString(R.string.fluentui_clear_text)
     ),
     peoplePickerContentDescription: String? = null,
-    peoplePickerTokens: PeoplePickerTokens? = null
+    peoplePickerTokens: PeoplePickerTokens? = null,
+    personaChipSize: PersonaChipSize? = null,
+    personaChipTokens: PersonaChipTokens? = null
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -171,6 +174,7 @@ fun PeoplePicker(
                             PersonaChip(
                                 modifier = Modifier.padding(bottom = chipVerticalSpacing),
                                 person = it.person, selected = it.selected.value,
+                                size = personaChipSize ?: PersonaChipSize.Medium,
                                 onCloseClick = if (onChipCloseClick != null) {
                                     {
                                         onChipCloseClick.invoke(it)
@@ -183,7 +187,8 @@ fun PeoplePicker(
                                     onChipClick?.invoke(it)
                                     onValueChange(queryText, selectedPeopleList)
                                 },
-                                style = chipValidation(it.person)
+                                style = chipValidation(it.person),
+                                personaChipTokens = personaChipTokens
                             )
                             Spacer(modifier = Modifier.width(chipHorizontalSpacing))
                         }

--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/tokenized/peoplepicker/PeoplePicker.kt
@@ -1,7 +1,6 @@
 package com.microsoft.fluentui.tokenized.peoplepicker
 
 import android.graphics.Bitmap
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -17,25 +16,19 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.LayoutDirection
 import com.microsoft.fluentui.icons.SearchBarIcons
 import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
 import com.microsoft.fluentui.peoplepicker.R
@@ -45,7 +38,6 @@ import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.PeoplePickerInfo
 import com.microsoft.fluentui.theme.token.controlTokens.PeoplePickerTokens
-import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipSize
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipStyle
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipTokens
 import com.microsoft.fluentui.tokenized.controls.TextField


### PR DESCRIPTION
### Problem 
There wasn't an option for modifying the Personal Chip Tokens which is used by People Picker

### Root cause 
By design
### Fix
Exposing the param

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After     Vertical Padding = 4dp   (Overriding Token)                             |
|----------------------------------------------|--------------------------------------------|
|![image](https://github.com/microsoft/fluentui-android/assets/68989156/d18c52df-f4c9-45d9-ad10-386bb89a8562)|![image](https://github.com/microsoft/fluentui-android/assets/68989156/3dc3146b-3054-4708-a62c-178b7baef162)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
