### PR TITLE
Adding an entry to the TabItemTokens to make the text adjustable in size

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -3,14 +3,21 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
-import com.microsoft.fluentui.theme.token.*
+import com.microsoft.fluentui.theme.token.ControlInfo
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentColor
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
+import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.IControlToken
+import com.microsoft.fluentui.theme.token.StateBrush
+import com.microsoft.fluentui.theme.token.StateColor
 import kotlinx.parcelize.Parcelize
 
 enum class TabTextAlignment {
@@ -73,7 +80,7 @@ open class TabItemTokens : IControlToken, Parcelable {
                 pressed = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value(
                     themeMode = FluentTheme.themeMode
                 ),
-                focused= FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                focused = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                     themeMode = FluentTheme.themeMode
                 ),
                 disabled = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
@@ -158,10 +165,15 @@ open class TabItemTokens : IControlToken, Parcelable {
 
     @Composable
     open fun padding(tabItemInfo: TabItemInfo): PaddingValues {
-        return when(tabItemInfo.tabTextAlignment){
+        return when (tabItemInfo.tabTextAlignment) {
             TabTextAlignment.HORIZONTAL -> PaddingValues(top = 8.dp, start = 4.dp, bottom = 4.dp, end = 8.dp)
             TabTextAlignment.VERTICAL -> PaddingValues(top = 8.dp, start = 8.dp, bottom = 4.dp, end = 8.dp)
             TabTextAlignment.NO_TEXT -> PaddingValues(top = 8.dp, start = 8.dp, bottom = 4.dp, end = 8.dp)
         }
+    }
+
+    @Composable
+    open fun textSize(tabItemInfo: TabItemInfo): TextUnit {
+        return TextUnit.Unspecified
     }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -78,6 +78,8 @@ fun TabItem(
             role = Role.Tab,
         )
 
+    val textSize = token.textSize(tabItemInfo)
+
     val widthModifier = if (fixedWidth) {
         Modifier.width(token.width(tabItemInfo = tabItemInfo))
     } else {
@@ -120,7 +122,7 @@ fun TabItem(
                         width = Dimension.preferredWrapContent
                     }
                     .padding(start = 8.dp),
-                style = TextStyle(color = textColor, textAlign = TextAlign.Center),
+                style = TextStyle(color = textColor, textAlign = TextAlign.Center, fontSize = textSize),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1
             )
@@ -206,7 +208,7 @@ fun TabItem(
                 Spacer(modifier = Modifier.height(2.dp))
                 BasicText(
                     text = title,
-                    style = TextStyle(color = textColor, textAlign = TextAlign.Center)
+                    style = TextStyle(color = textColor, textAlign = TextAlign.Center, fontSize = textSize)
                 )
             }
         }


### PR DESCRIPTION
### Problem 
Proposed change to address issue #662, adding a new entry in TabItemTokens so clients can change the Text Size

### Root cause 
There's no entry in TabItemTokens to change the font size

### Fix
Added an entry to TabItemTokens, using the same default as `TextStyle` which is the current option. With that, clients can change the text size for tab entries

### Validations

Validated change compile, does not affect existent overrides. 

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![image](https://github.com/microsoft/fluentui-android/assets/388868/fc492666-a54d-4f29-9bf9-870dd5c0103b) |![image](https://github.com/microsoft/fluentui-android/assets/388868/86363b4a-de92-4c72-8562-464ea7fe6548) Example with size = 8.sp |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] Automated Tests
- [x] Documentation and demo app examples
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and RTL layouts
- [x] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
