### PR TITLE
Collapsed/Expanded Talkback for drawer and bottomsheet

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -5,8 +5,11 @@
 
 package com.microsoft.fluentui.tokenized.bottomsheet
 
+import android.content.Context
 import android.content.res.Configuration
 import android.view.*
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.*
 import androidx.compose.foundation.gestures.Orientation
@@ -428,6 +431,9 @@ fun BottomSheet(
                             )
                             .testTag(BOTTOMSHEET_HANDLE_TAG)
                     ) {
+                        val collapsed = LocalContext.current.resources.getString(R.string.collapsed)
+                        val expanded = LocalContext.current.resources.getString(R.string.expanded)
+                        val accessibilityManager  = LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
                         Icon(
                             painterResource(id = R.drawable.ic_drawer_handle),
                             contentDescription =
@@ -453,10 +459,22 @@ fun BottomSheet(
                                     if (sheetState.currentValue == BottomSheetValue.Expanded) {
                                         if (sheetState.confirmStateChange(BottomSheetValue.Shown)) {
                                             scope.launch { sheetState.show() }
+                                            accessibilityManager?.let { manager ->
+                                                val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                    text.add(collapsed)
+                                                }
+                                                manager.sendAccessibilityEvent(event)
+                                            }
                                         }
                                     } else if (sheetState.hasExpandedState) {
                                         if (sheetState.confirmStateChange(BottomSheetValue.Expanded)) {
                                             scope.launch { sheetState.expand() }
+                                            accessibilityManager?.let { manager ->
+                                                val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                    text.add(expanded)
+                                                }
+                                                manager.sendAccessibilityEvent(event)
+                                            }
                                         }
                                     }
                                 }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -1,5 +1,8 @@
 package com.microsoft.fluentui.tokenized.drawer
 
+import android.content.Context
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -977,6 +980,9 @@ private fun BottomDrawer(
                             )
                             .testTag(DRAWER_HANDLE_TAG)
                     ) {
+                        val collapsed = LocalContext.current.resources.getString(R.string.collapsed)
+                        val expanded = LocalContext.current.resources.getString(R.string.expanded)
+                        val accessibilityManager  = LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
                         Icon(
                             painterResource(id = R.drawable.ic_drawer_handle),
                             contentDescription = LocalContext.current.resources.getString(R.string.drag_handle),
@@ -1000,10 +1006,23 @@ private fun BottomDrawer(
                                             )
                                         ) {
                                             scope.launch { drawerState.open() }
+                                            accessibilityManager?.let { manager ->
+                                                val event = AccessibilityEvent.obtain(
+                                                    AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                    text.add(collapsed)
+                                                }
+                                                manager.sendAccessibilityEvent(event)
+                                            }
                                         }
                                     } else if (drawerState.hasExpandedState) {
                                         if (drawerState.confirmStateChange(DrawerValue.Expanded)) {
                                             scope.launch { drawerState.expand() }
+                                            accessibilityManager?.let { manager ->
+                                                val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                    text.add(expanded)
+                                                }
+                                                manager.sendAccessibilityEvent(event)
+                                            }
                                         }
                                     }
                                 }

--- a/fluentui_drawer/src/main/res/values/strings.xml
+++ b/fluentui_drawer/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="drag_handle">Drag Handle</string>
     <!-- onClick Label for bottomsheet to expand -->
     <string name="expand">expand</string>
+    <string name="expanded">expanded</string>
     <!-- onClick Label for bottomsheet to collapse -->
     <string name="collapse">collapse</string>
+    <string name="collapsed">collapsed</string>
 </resources>


### PR DESCRIPTION
### Problem 
Bottomsheet and Drawer does not announce when they are expanded or collapsed
### Root cause 
There is no accessibility event sent when action is performed on sheet
### Fix
Adding accesiiblity event when handle is clicked

### Validations
Manual testing
(how the change was tested, including both manual and automated tests)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
