### PR TITLE
v2 Tab Bar: Implementing automatic text adjustment to prevent overflow or multiline issues and removing padding on smaller devices.

### DIFF
--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -21,12 +21,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ChainStyle
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.TabItemInfo
@@ -206,8 +207,14 @@ fun TabItem(
                 .then(widthModifier)
         ) {
             badgeWithIcon()
-            var fontSize = remember { mutableStateOf(14.sp) }
-            var textStyle by remember(textColor) { mutableStateOf(TextStyle(color = textColor, textAlign = TextAlign.Center, fontSize = fontSize.value)) }
+
+            val fontStyle = FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Caption2]
+            var fontSize = remember { mutableStateOf(fontStyle.fontSize) }
+            var textStyle by remember(textColor) {
+                mutableStateOf(
+                    fontStyle.merge(TextStyle(color = textColor, fontSize = fontSize.value))
+                )
+            }
 
             if (textAlignment == TabTextAlignment.VERTICAL) {
                 Spacer(modifier = Modifier.height(2.dp))
@@ -218,6 +225,7 @@ fun TabItem(
                     overflow = TextOverflow.Ellipsis,
                     onTextLayout = { textLayoutResult ->
                         if (textLayoutResult.didOverflowHeight) {
+                            textStyle.fontSize
                             fontSize.value *= 0.9
                             textStyle = textStyle.copy(fontSize = fontSize.value)
                         }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
@@ -18,6 +23,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ChainStyle
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
@@ -202,11 +208,22 @@ fun TabItem(
                 .then(widthModifier)
         ) {
             badgeWithIcon()
+            var fontSize = remember { mutableStateOf(14.sp) }
+            var textStyle by remember(textColor) { mutableStateOf(TextStyle(color = textColor, textAlign = TextAlign.Center, fontSize = fontSize.value)) }
+
             if (textAlignment == TabTextAlignment.VERTICAL) {
                 Spacer(modifier = Modifier.height(2.dp))
-                BasicText(
+                Text(
                     text = title,
-                    style = TextStyle(color = textColor, textAlign = TextAlign.Center)
+                    style = textStyle,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    onTextLayout = { textLayoutResult ->
+                        if (textLayoutResult.didOverflowHeight) {
+                            fontSize.value *= 0.9
+                            textStyle = textStyle.copy(fontSize = fontSize.value)
+                        }
+                    }
                 )
             }
         }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -14,7 +13,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
@@ -213,7 +211,7 @@ fun TabItem(
 
             if (textAlignment == TabTextAlignment.VERTICAL) {
                 Spacer(modifier = Modifier.height(2.dp))
-                Text(
+                BasicText(
                     text = title,
                     style = textStyle,
                     maxLines = 1,

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
@@ -59,9 +59,7 @@ fun TabBar(
                 .background(color = token.topBorderColor(tabBarInfo = TabBarInfo()))
         )
         Row(
-            modifier = Modifier
-                .padding(horizontal = if(LocalConfiguration.current.screenWidthDp.dp > 360.dp )16.dp else 1.dp)       // For small phones we don't want the text overflowing, hence removing padding
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
         ) {
             tabDataList.forEachIndexed { index, tabData ->
                 tabData.selected = index == selectedIndex

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
@@ -59,7 +60,7 @@ fun TabBar(
         )
         Row(
             modifier = Modifier
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = if(LocalConfiguration.current.screenWidthDp.dp > 360.dp )16.dp else 1.dp)       // For small phones we don't want the text overflowing, hence removing padding
                 .fillMaxWidth()
         ) {
             tabDataList.forEachIndexed { index, tabData ->


### PR DESCRIPTION
### Problem 
The text was overflowing and being present in multiple lines for tab items in tab bar. 
Requirement is for text to remain in one line. 

There are 2 things we can do here:
For any screen width smaller than 360dp, the side padding (16dp on either sides) will reduce proportionately to accommodate text. 

 
2. We can reduce text size in accordance to fit in one line. What we do on Title bar currently.
### Root cause 

By design

### Fix

1.  we are detecting text overflow using the onTextLayout callback. This allows us to recursively reduce text size untill it fits in the avaibale one line width
2. For small devices have removed the 16.dp padding

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| small phone                          | big phone                                   |
|----------------------------------------------|--------------------------------------------|
|![image](https://github.com/microsoft/fluentui-android/assets/68989156/121dc507-3604-48ee-8d6b-5052b5ec967e)| ![image](https://github.com/microsoft/fluentui-android/assets/68989156/26bcb787-3818-4594-86b8-377f7467b8fd) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
