### PR TITLE
centering the bottomsheet on custom width

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -312,6 +312,7 @@ fun BottomSheet(
 
         Box(
             Modifier
+                .align(Alignment.Center)
                 .fillMaxWidth(
                     if(configuration.orientation == Configuration.ORIENTATION_LANDSCAPE)maxLandscapeWidth
                     else 1F


### PR DESCRIPTION
### Problem 
Bottomsheet on landscape mode with cusotme width is not centered
### Root cause 
Box is not aligned properly
### Fix
Adding Box alignment

### Validations

(how the change was tested, including both manual and automated tests)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
