### PR TITLE
adding accessibility on/off check

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -461,20 +461,24 @@ fun BottomSheet(
                                         if (sheetState.confirmStateChange(BottomSheetValue.Shown)) {
                                             scope.launch { sheetState.show() }
                                             accessibilityManager?.let { manager ->
-                                                val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
-                                                    text.add(collapsed)
+                                                if(manager.isEnabled){
+                                                    val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                        text.add(collapsed)
+                                                    }
+                                                    manager.sendAccessibilityEvent(event)
                                                 }
-                                                manager.sendAccessibilityEvent(event)
                                             }
                                         }
                                     } else if (sheetState.hasExpandedState) {
                                         if (sheetState.confirmStateChange(BottomSheetValue.Expanded)) {
                                             scope.launch { sheetState.expand() }
                                             accessibilityManager?.let { manager ->
-                                                val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
-                                                    text.add(expanded)
+                                                if(manager.isEnabled){
+                                                    val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                        text.add(expanded)
+                                                    }
+                                                    manager.sendAccessibilityEvent(event)
                                                 }
-                                                manager.sendAccessibilityEvent(event)
                                             }
                                         }
                                     }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -312,7 +312,7 @@ fun BottomSheet(
 
         Box(
             Modifier
-                .align(Alignment.Center)
+                .align(Alignment.TopCenter)
                 .fillMaxWidth(
                     if(configuration.orientation == Configuration.ORIENTATION_LANDSCAPE)maxLandscapeWidth
                     else 1F

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -1007,21 +1007,26 @@ private fun BottomDrawer(
                                         ) {
                                             scope.launch { drawerState.open() }
                                             accessibilityManager?.let { manager ->
-                                                val event = AccessibilityEvent.obtain(
-                                                    AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
-                                                    text.add(collapsed)
+                                                if(manager.isEnabled){
+                                                    val event = AccessibilityEvent.obtain(
+                                                        AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                        text.add(collapsed)
+                                                    }
+                                                    manager.sendAccessibilityEvent(event)
                                                 }
-                                                manager.sendAccessibilityEvent(event)
                                             }
                                         }
                                     } else if (drawerState.hasExpandedState) {
                                         if (drawerState.confirmStateChange(DrawerValue.Expanded)) {
                                             scope.launch { drawerState.expand() }
                                             accessibilityManager?.let { manager ->
-                                                val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
-                                                    text.add(expanded)
+                                                if(manager.isEnabled){
+                                                    val event = AccessibilityEvent.obtain(
+                                                        AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                        text.add(expanded)
+                                                    }
+                                                    manager.sendAccessibilityEvent(event)
                                                 }
-                                                manager.sendAccessibilityEvent(event)
                                             }
                                         }
                                     }


### PR DESCRIPTION
### Problem 
Bottomsheet crashes when the handle is clicked
### Root cause 
when accessibility is turned off, the handle onclick call the accessibility manager which is null causing crash
### Fix
Adding a check that will verify if manager is enabled

### Validations
manual testing
