### PR TITLE
adding readonly talkback

### DIFF
--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/TextField.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -172,7 +174,13 @@ fun TextField(
                         value = value,
                         onValueChange = onValueChange,
                         modifier = Modifier
-                            .semantics { contentDescription = textFieldContentDescription ?: "" }
+                            .semantics {
+                                contentDescription = textFieldContentDescription ?: ""
+                                if(readOnly){
+                                    this.stateDescription = "Read-only."
+                                    this.disabled()
+                                }
+                            }
                             .testTag(TEXT_FIELD)
                             .padding(vertical = 12.dp)
                             .weight(1F)


### PR DESCRIPTION
### Problem 
Textfield in readonly mode is announcing to double click which is actually disabled
### Root cause 
Readonly specific accessibiltiy is not specified
### Fix
Added readonly specific semantics

### Validations
Manual testting

