### PR TITLE
pipeline variable and readOnlyTest modified

### DIFF
--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -16,6 +16,7 @@ import com.microsoft.fluentui.tokenized.controls.TEXT_FIELD_ICON
 import com.microsoft.fluentui.tokenized.controls.TEXT_FIELD_LABEL
 import com.microsoft.fluentui.tokenized.controls.TEXT_FIELD_SECONDARY_TEXT
 import com.microsoft.fluentuidemo.BaseTest
+import junit.framework.AssertionFailedError
 import org.junit.Before
 import org.junit.Test
 
@@ -111,11 +112,14 @@ class V2TextFieldActivityUITest : BaseTest() {
         toggleControlToValue(control, true)
         component.performClick()
         component.assertIsFocused()
+        var testPass = false
         try {
             component.performTextInput("Test")
         } catch(e: Error){
+            testPass = true
             // expected Error as attempt to input text in read only mode throws error
         }
+        if(!testPass) throw AssertionError("Read only mode did not render properly")
     }
 
     @Test

--- a/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
+++ b/FluentUI.Demo/src/androidTest/java/com/microsoft/fluentuidemo/demos/V2TextFieldActivityUITest.kt
@@ -111,8 +111,11 @@ class V2TextFieldActivityUITest : BaseTest() {
         toggleControlToValue(control, true)
         component.performClick()
         component.assertIsFocused()
-        component.performTextInput("Test")
-        component.assertTextContains("")
+        try {
+            component.performTextInput("Test")
+        } catch(e: Error){
+            // expected Error as attempt to input text in read only mode throws error
+        }
     }
 
     @Test

--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -73,7 +73,7 @@ extends:
           inputs:
             testResultsFiles: "$(build.sourcesdirectory)/build/testResult/**/hydra_result_*.xml"
             testRunTitle: "Test-Result"
-            failTaskOnFailedTests: "$(failTaskOnFailedTests)"
+            failTaskOnFailedTests: $(failTaskOnFailedTests)
         - task: Gradle@2
           displayName: "generate artifacts and publish to feed"
           inputs:

--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -73,7 +73,7 @@ extends:
           inputs:
             testResultsFiles: "$(build.sourcesdirectory)/build/testResult/**/hydra_result_*.xml"
             testRunTitle: "Test-Result"
-            failTaskOnFailedTests: true
+            failTaskOnFailedTests: "$(failTaskOnFailedTests)"
         - task: Gradle@2
           displayName: "generate artifacts and publish to feed"
           inputs:


### PR DESCRIPTION
### Problem 
1. ReadOnlyTest() was failing
2. We wanted to have better control over hydra Task failure on test failure
### Root cause 
1. PerformTextInput() was throwing error for read only mode
### Fix
1. We have wrapped performTextInput() as we expect it to throw error when read-only mode is enabled
2. A new pipeline variable has been added which let's us control.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

![image](https://github.com/user-attachments/assets/d95cb450-a2a8-4a9e-bfac-0860dedb9251)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
