### PR TITLE
fluent demo v1 not following app theme set by user

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/AppProperties.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/AppProperties.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
@@ -230,6 +231,7 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
                         AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Light
                         FluentTheme.updateThemeMode(ThemeMode.Light)
                         onThemeModeClick()
+                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
                     },
                 )
             },
@@ -242,6 +244,7 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
                 AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Dark
                 FluentTheme.updateThemeMode(ThemeMode.Dark)
                 onThemeModeClick()
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
             },
             leadingAccessoryContent = {
                 RadioButton(
@@ -250,6 +253,7 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
                         AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Dark
                         FluentTheme.updateThemeMode(ThemeMode.Dark)
                         onThemeModeClick()
+                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
                     },
                 )
             },

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/AppProperties.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/AppProperties.kt
@@ -199,19 +199,11 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
         val selectedThemeMode by AppThemeViewModel.selectedThemeMode_.observeAsState()
         ListItem.Item(
             text = stringResource(id = R.string.appearance_system_default),
-            onClick = {
-                AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Auto
-                FluentTheme.updateThemeMode(ThemeMode.Auto)
-                onThemeModeClick()
-            },
+            onClick = { appThemeToggle(ThemeMode.Auto, onThemeModeClick ) },
             leadingAccessoryContent = {
                 RadioButton(
                     selected = selectedThemeMode == ThemeMode.Auto,
-                    onClick = {
-                        AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Auto
-                        FluentTheme.updateThemeMode(ThemeMode.Auto)
-                        onThemeModeClick()
-                    },
+                    onClick = { appThemeToggle(ThemeMode.Auto, onThemeModeClick ) },
                 )
             },
             listItemTokens = CustomizedTokens.listItemTokens
@@ -219,20 +211,11 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
 
         ListItem.Item(
             text = stringResource(id = R.string.appearance_light),
-            onClick = {
-                AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Light
-                FluentTheme.updateThemeMode(ThemeMode.Light)
-                onThemeModeClick()
-            },
+            onClick = { appThemeToggle(ThemeMode.Light, onThemeModeClick ) },
             leadingAccessoryContent = {
                 RadioButton(
                     selected = selectedThemeMode == ThemeMode.Light,
-                    onClick = {
-                        AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Light
-                        FluentTheme.updateThemeMode(ThemeMode.Light)
-                        onThemeModeClick()
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-                    },
+                    onClick = { appThemeToggle(ThemeMode.Light, onThemeModeClick ) },
                 )
             },
             listItemTokens = CustomizedTokens.listItemTokens
@@ -240,21 +223,11 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
 
         ListItem.Item(
             text = stringResource(id = R.string.appearance_dark),
-            onClick = {
-                AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Dark
-                FluentTheme.updateThemeMode(ThemeMode.Dark)
-                onThemeModeClick()
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-            },
+            onClick = { appThemeToggle(ThemeMode.Dark, onThemeModeClick) },
             leadingAccessoryContent = {
                 RadioButton(
                     selected = selectedThemeMode == ThemeMode.Dark,
-                    onClick = {
-                        AppThemeViewModel.selectedThemeMode_.value = ThemeMode.Dark
-                        FluentTheme.updateThemeMode(ThemeMode.Dark)
-                        onThemeModeClick()
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-                    },
+                    onClick = { appThemeToggle(ThemeMode.Dark, onThemeModeClick) },
                 )
             },
             listItemTokens = CustomizedTokens.listItemTokens
@@ -262,6 +235,16 @@ fun SetAppThemeMode(onThemeModeClick: () -> Unit) {
     }
 }
 
+fun appThemeToggle(appThemeMode: ThemeMode, onThemeModeClick: () -> Unit) {
+    AppThemeViewModel.selectedThemeMode_.value = appThemeMode
+    FluentTheme.updateThemeMode(appThemeMode)
+    onThemeModeClick()
+    when(appThemeMode){
+        ThemeMode.Auto -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+        ThemeMode.Light -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+        ThemeMode.Dark -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+    }
+}
 @Composable
 fun SetAppTheme() {
     val selectedThemeIndex by AppThemeViewModel.selectedThemeIndex_.observeAsState()


### PR DESCRIPTION
### Problem 
V1 Activities in fluent demo app were not respecting Dark theme set by user.

### Root cause 
Fluent theme composable isn't used by v1 (xml based)
### Fix
Using AppDelegate.setDefaultNightMode so night mode can be communicated to the v1 components.

### Validations

[Fluent demo app v1 themes.webm](https://github.com/user-attachments/assets/9dac8ccf-a7b3-4537-a363-2d40960916e1)


### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
