### PR TITLE
Upgrade tp targetSdk 34

### DIFF
--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -17,15 +17,7 @@ android {
         versionName '0.2.10'
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
+ 
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId 'com.microsoft.fluentuidemo'
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 34
         versionCode 1010
         versionName '0.2.10'
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/FluentUI.Demo/build.gradle
+++ b/FluentUI.Demo/build.gradle
@@ -16,8 +16,6 @@ android {
         versionCode 1010
         versionName '0.2.10'
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
- 
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/FluentUI/build.gradle
+++ b/FluentUI/build.gradle
@@ -18,15 +18,6 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
 
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/azure-pipelines-fork-build-push.yml
+++ b/azure-pipelines-fork-build-push.yml
@@ -39,7 +39,7 @@ jobs:
           tasks: "testDevelopmentDebugUnitTest"
           publishJUnitResults: false
           javaHomeOption: "JDKVersion"
-          jdkVersionOption: "$(jdkVersion)"
+          jdkVersionOption: "17"
           sonarQubeRunAnalysis: false
           spotBugsAnalysis: false
 

--- a/azure-pipelines-fork-build-push.yml
+++ b/azure-pipelines-fork-build-push.yml
@@ -24,7 +24,7 @@ jobs:
           sonarQubeRunAnalysis: false
           spotBugsAnalysis: false
 
-      - task: Gradle@2
+      - task: Gradle@3
         displayName: "gradlew build"
         inputs:
           gradleWrapperFile: "gradlew"
@@ -32,7 +32,7 @@ jobs:
           javaHomeOption: "JDKVersion"
           jdkVersionOption: "$(jdkVersion)"
 
-      - task: Gradle@2
+      - task: Gradle@3
         displayName: Unit tests
         inputs:
           gradleWrapperFile: "gradlew"
@@ -43,7 +43,7 @@ jobs:
           sonarQubeRunAnalysis: false
           spotBugsAnalysis: false
 
-      - task: Gradle@2
+      - task: Gradle@3
         displayName: Generate testApk
         inputs:
           gradleWrapperFile: "gradlew"
@@ -54,7 +54,7 @@ jobs:
           sonarQubeRunAnalysis: false
           spotBugsAnalysis: false
 
-      - task: Gradle@2
+      - task: Gradle@3
         displayName: Hydra Lab UI test
         inputs:
           gradleWrapperFile: "gradlew"
@@ -63,7 +63,7 @@ jobs:
           jdkVersionOption: "$(jdkVersion)"
           publishJUnitResults: true
 
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: "Publish Test Results"
         inputs:
           testResultsFiles: "$(build.sourcesdirectory)/build/testResult/**/hydra_result_*.xml"

--- a/azure-pipelines-fork-build-push.yml
+++ b/azure-pipelines-fork-build-push.yml
@@ -63,7 +63,7 @@ jobs:
           jdkVersionOption: "$(jdkVersion)"
           publishJUnitResults: true
 
-      - task: PublishTestResults@3
+      - task: PublishTestResults@2
         displayName: "Publish Test Results"
         inputs:
           testResultsFiles: "$(build.sourcesdirectory)/build/testResult/**/hydra_result_*.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
         constants = [
                 minSdkVersion: 21,
                 targetSdkVersion: 34,
-                compileSdkVersion: 33
+                compileSdkVersion: 34
         ]
 
         androidxRunner            =    '1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
         materialVersion           =    '1.9.0'
         mockitoVersion            =    '1.10.19'
         recyclerViewVersion       =    '1.3.0'
-        robolectric               =    '4.10.3'
+        robolectric               =    '4.13'
         uiautomatorVersion        =    '2.2.0'
         supportVersion            =    '28.0.0'
         tokenautocompleteVersion  =    '2.0.8'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     project.ext {
         constants = [
                 minSdkVersion: 21,
-                targetSdkVersion: 33,
+                targetSdkVersion: 34,
                 compileSdkVersion: 33
         ]
 

--- a/fluentui_calendar/build.gradle
+++ b/fluentui_calendar/build.gradle
@@ -18,16 +18,6 @@ android {
         versionName project.ext.fluentui_calendar_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildFeatures {
         viewBinding true

--- a/fluentui_ccb/build.gradle
+++ b/fluentui_ccb/build.gradle
@@ -17,16 +17,6 @@ android {
         versionName project.ext.fluentui_ccb_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_controls/build.gradle
+++ b/fluentui_controls/build.gradle
@@ -12,16 +12,6 @@ android {
         versionCode project.ext.fluentui_controls_version_code
         versionName project.ext.fluentui_controls_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_core/build.gradle
+++ b/fluentui_core/build.gradle
@@ -19,16 +19,6 @@ android {
         versionName project.ext.fluentui_core_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_drawer/build.gradle
+++ b/fluentui_drawer/build.gradle
@@ -21,16 +21,6 @@ android {
         versionName project.ext.fluentui_drawer_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_icons/build.gradle
+++ b/fluentui_icons/build.gradle
@@ -12,16 +12,6 @@ android {
         versionCode project.ext.fluentui_icons_version_code
         versionName project.ext.fluentui_icons_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_listitem/build.gradle
+++ b/fluentui_listitem/build.gradle
@@ -17,16 +17,6 @@ android {
         versionName project.ext.fluentui_listitem_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_menus/build.gradle
+++ b/fluentui_menus/build.gradle
@@ -17,16 +17,6 @@ android {
         versionName project.ext.fluentui_menus_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_notification/build.gradle
+++ b/fluentui_notification/build.gradle
@@ -12,16 +12,6 @@ android {
         versionCode project.ext.fluentui_notification_version_code
         versionName project.ext.fluentui_notification_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_others/build.gradle
+++ b/fluentui_others/build.gradle
@@ -17,16 +17,6 @@ android {
         versionCode project.ext.fluentui_others_version_code
         versionName project.ext.fluentui_others_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     lintOptions {
         abortOnError false

--- a/fluentui_peoplepicker/build.gradle
+++ b/fluentui_peoplepicker/build.gradle
@@ -18,16 +18,6 @@ android {
         versionName project.ext.fluentui_peoplepicker_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildFeatures {
         viewBinding true

--- a/fluentui_persona/build.gradle
+++ b/fluentui_persona/build.gradle
@@ -22,16 +22,6 @@ android {
         versionName project.ext.fluentui_persona_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_progress/build.gradle
+++ b/fluentui_progress/build.gradle
@@ -24,16 +24,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         consumerProguardFiles "consumer-rules.pro"
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_tablayout/build.gradle
+++ b/fluentui_tablayout/build.gradle
@@ -17,16 +17,6 @@ android {
         versionName project.ext.fluentui_tablayout_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_topappbars/build.gradle
+++ b/fluentui_topappbars/build.gradle
@@ -22,16 +22,6 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
         vectorDrawables.useSupportLibrary = true
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/fluentui_transients/build.gradle
+++ b/fluentui_transients/build.gradle
@@ -20,16 +20,6 @@ android {
         versionName project.ext.fluentui_transients_versionid
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
-
-//      Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update.
-//      https://issuetracker.google.com/issues/295457468
-//      Remove once we plan to move to Android 34
-        configurations.all {
-            resolutionStrategy {
-                force("androidx.emoji2:emoji2-views-helper:1.3.0")
-                force("androidx.emoji2:emoji2:1.3.0")
-            }
-        }
     }
     buildTypes {
         release {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,5 @@
 #Thu Mar 18 21:49:01 IST 2021
 android.enableJetifier=true
 android.useAndroidX=true
+android.disableAutomaticComponentCreation=true
 org.gradle.jvmargs=-XX\:MaxHeapSize\=256m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -Xmx2048M

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,6 @@
 #Thu Mar 18 21:49:01 IST 2021
 android.enableJetifier=true
 android.useAndroidX=true
+android.jetifier.ignorelist=bcprov-jdk18on
 android.disableAutomaticComponentCreation=true
 org.gradle.jvmargs=-XX\:MaxHeapSize\=256m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -Xmx2048M


### PR DESCRIPTION
### Problem 
1. New apps and app updates must target Android 14 (API level 34) or higher to be submitted to Google Play
2. Code Cleanup : Forcing emoji2 version as a workaround for not moving to Android 34 during BOM update. [https://issuetracker.google.com/issues/295457468](url)
3. Robolectric testing framework Upgrade
### Root cause 

### Fix
Upgrading the targetSdk version to 34
Code Cleanup
Robolectric upgrade to v 4.13 and using jdk 17

### Validations
![image](https://github.com/user-attachments/assets/0cff5107-78ab-4115-961f-e29516210de0)


(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
