### PR TITLE
v1 Date-time picker dailog orientation

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/DateTimePickerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/DateTimePickerActivity.kt
@@ -42,6 +42,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
 
         private const val DIALOG_DATE_TIME = "dialogDateTime"
         private const val DIALOG_MODE = "dialogMode"
+        private const val IS_DIALOG_SHOWING = "isDialogShowing"
     }
 
     enum class DatePickerType(
@@ -184,7 +185,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
             singleModeTag = it.getString(SINGLE_MODE_TAG)
             dialogMode = it.getSerializable(DIALOG_MODE) as? Mode
             dialogDateTime = it.getSerializable(DIALOG_DATE_TIME) as? ZonedDateTime
-            isDialogShowing = savedInstanceState.getBoolean("isDialogShowing")
+            isDialogShowing = savedInstanceState.getBoolean(IS_DIALOG_SHOWING)
         }
 
         // DateTimePickers
@@ -223,7 +224,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
         outState.putString(FRAGMENT_TAG, fragmentTag)
         outState.putSerializable(DIALOG_MODE, dialogMode)
         outState.putSerializable(DIALOG_DATE_TIME, dialogDateTime)
-        outState.putBoolean("isDialogShowing", dateTimePickerDialog?.isShowing ?: false)
+        outState.putBoolean(IS_DIALOG_SHOWING, dateTimePickerDialog?.isShowing ?: false)
     }
 
     override fun onDestroy() {

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/DateTimePickerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/DateTimePickerActivity.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.fluentuidemo.demos
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -79,6 +80,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
     }
 
     private var dateTimePickerDialog: DateTimePickerDialog? = null
+    private var isDialogShowing: Boolean = false
 
     private lateinit var dateTimeBinding: ActivityDateTimePickerBinding
 
@@ -183,6 +185,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
             singleModeTag = it.getString(SINGLE_MODE_TAG)
             dialogMode = it.getSerializable(DIALOG_MODE) as? Mode
             dialogDateTime = it.getSerializable(DIALOG_DATE_TIME) as? ZonedDateTime
+            isDialogShowing = savedInstanceState.getBoolean("isDialogShowing")
         }
 
         // DateTimePickers
@@ -202,7 +205,13 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
         accessibilityManager.addAccessibilityStateChangeListener {
             updateButtonsForAccessibility(it)
         }
+        if(isDialogShowing) {
+            dateTimePickerDialog?.dismiss()
+            createDateTimePickerDialog()
+        }
+
     }
+
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
@@ -215,6 +224,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
         outState.putString(FRAGMENT_TAG, fragmentTag)
         outState.putSerializable(DIALOG_MODE, dialogMode)
         outState.putSerializable(DIALOG_DATE_TIME, dialogDateTime)
+        outState.putBoolean("isDialogShowing", dateTimePickerDialog?.isShowing ?: false)
     }
 
     override fun onDestroy() {
@@ -251,6 +261,7 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
             getFragmentDateTime(),
             getFragmentDuration()
         )
+        dateTimePickerDialog?.onDateTimePickedListener = this
         dateTimePicker.show(supportFragmentManager, picker.tag)
     }
 
@@ -268,6 +279,13 @@ class DateTimePickerActivity : DemoActivity(), DateTimePickerDialog.OnDateTimePi
         dateTimePickerDialog?.onDateTimePickedListener =
             object : DateTimePickerDialog.OnDateTimePickedListener {
                 override fun onDateTimePicked(dateTime: ZonedDateTime, duration: Duration) {
+                    dialogMode = getDialogMode()
+                    dialogDateTime = dateTime
+                }
+            }
+        dateTimePickerDialog?.onDateTimeSelectedListener =
+            object : DateTimePickerDialog.OnDateTimeSelectedListener{
+                override fun onDateTimeSelected(dateTime: ZonedDateTime, duration: Duration) {
                     dialogMode = getDialogMode()
                     dialogDateTime = dateTime
                 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/DateTimePickerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/DateTimePickerActivity.kt
@@ -5,7 +5,6 @@
 
 package com.microsoft.fluentuidemo.demos
 
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View


### PR DESCRIPTION
### Problem 
The behavior of date-time picker dialog was not right on screen orientation change. In demo-app, it was closing the dialog.
### Root cause 
Dialog doesn't have a lifecycle like a fragment which can handle these changes on it's own.
### Fix
Recreation of date-time picker dialog on orientation change
and also making sure date-time is saved and maintained across the changes.

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots
Before

[time date picker dialog before.webm](https://github.com/user-attachments/assets/8bbb1958-c53b-49a5-8e80-e47d9d7a0a8b) 

After
[dateTimeDialog After.webm](https://github.com/user-attachments/assets/5fb0efd4-1845-44ef-9234-ad34e9dcbca2)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
