### PR TITLE
Feature to add CCB button Border when Selected

### DIFF
--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -63,6 +63,7 @@ enum class ActionButtonPosition {
  * @param scrollable Boolean value to specify if CCB has fixed or infinite width(Scrollable).
  *                      Use false to create a fixed non scrollable CCB. Command groups widths will adhere to the weights set in [CommandGroup] weight parameter.
  *                      Use true to have a scrollable CCB. [CommandGroup] weight parameter is ignored
+ * @param selectionStroke List of BorderStroke to be applied on selected button in CCB
  * @param contextualCommandBarToken Token to provide appearance values to Avatar
  */
 @OptIn(

--- a/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
+++ b/fluentui_ccb/src/main/java/com/microsoft/fluentui/tokenized/contextualcommandbar/ContextualCommandBar.kt
@@ -80,6 +80,7 @@ fun ContextualCommandBar(
         contentDescription = LocalContext.current.resources.getString(R.string.fluentui_dismiss)
     ),
     scrollable: Boolean = true,
+    selectionStroke: List<BorderStroke>? = null,
     contextualCommandBarToken: ContextualCommandBarTokens? = null
 ) {
 
@@ -111,7 +112,9 @@ fun ContextualCommandBar(
     val focusStroke = token.focusStroke(
         contextualCommandBarInfo
     )
+    val showSelectionBorderStroke = selectionStroke != null
     var focusedBorderModifier: Modifier = Modifier
+    var selectedBorderModifier: Modifier = Modifier
 
     val selectedString = LocalContext.current.resources.getString(R.string.fluentui_selected)
 
@@ -145,6 +148,7 @@ fun ContextualCommandBar(
                             )
                             end.linkTo(parent.end)
                         }
+
                         ActionButtonPosition.End -> {
                             start.linkTo(parent.start)
                             end.linkTo(
@@ -152,6 +156,7 @@ fun ContextualCommandBar(
                                 margin = contentPaddingWithActionButton
                             )
                         }
+
                         ActionButtonPosition.None -> {
                             start.linkTo(parent.start)
                             end.linkTo(parent.end)
@@ -193,6 +198,13 @@ fun ContextualCommandBar(
                             for (borderStroke in focusStroke) {
                                 focusedBorderModifier =
                                     focusedBorderModifier.border(borderStroke, shape)
+                            }
+                            selectedBorderModifier = Modifier
+                            if(showSelectionBorderStroke){
+                                for (borderStroke in selectionStroke!!) {
+                                    selectedBorderModifier =
+                                        selectedBorderModifier.border(borderStroke, shape)
+                                }
                             }
 
                             Row(
@@ -289,6 +301,7 @@ fun ContextualCommandBar(
                             )
                             end.linkTo(parent.end)
                         }
+
                         ActionButtonPosition.End -> {
                             start.linkTo(parent.start)
                             end.linkTo(
@@ -296,6 +309,7 @@ fun ContextualCommandBar(
                                 margin = contentPaddingWithActionButton
                             )
                         }
+
                         ActionButtonPosition.None -> {
                             start.linkTo(parent.start)
                             end.linkTo(parent.end)
@@ -335,6 +349,13 @@ fun ContextualCommandBar(
                             focusedBorderModifier =
                                 focusedBorderModifier.border(borderStroke, shape)
                         }
+                        selectedBorderModifier = Modifier
+                        if(showSelectionBorderStroke){
+                            for (borderStroke in selectionStroke!!) {
+                                selectedBorderModifier =
+                                    selectedBorderModifier.border(borderStroke, shape)
+                            }
+                        }
                         Row(
                             modifier = Modifier
                                 .height(IntrinsicSize.Min)
@@ -359,6 +380,11 @@ fun ContextualCommandBar(
                                     )
                                     .then(clickableModifier)
                                     .then(if (interactionSource.collectIsFocusedAsState().value || interactionSource.collectIsHoveredAsState().value) focusedBorderModifier else Modifier)
+                                    .then(
+                                        if (commandGroup.items[itemIndex].selected)
+                                            selectedBorderModifier
+                                        else Modifier
+                                    )
                                     .semantics {
                                         contentDescription =
                                             item.label + if (item.selected) selectedString else ""


### PR DESCRIPTION
### Problem 
We got an ask from partner team to let user show stroke on CCB buttons when button is in selected-focused state
### Root cause 
Customization Request, wasn't a part of design
### Fix
Adding a param selectionStroke, where user can pass a list of BorderStroke and it will be applied when CCB button is in selected state.

### Validations

```
and Mail button is in Selected state
selectionStroke = listOf(
                                                BorderStroke(
                                                    5.dp,
                                                    Color.Red
                                                ),
                                                BorderStroke(
                                                    6.dp,
                                                    Color.Green
                                                )
                                            )
```
![image](https://github.com/user-attachments/assets/721a87da-42d4-40d1-bff5-121aab1d5687)

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
