### PR TITLE
V2 BottomDrawer: Max Landscape Width 

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
@@ -1,5 +1,6 @@
 package com.microsoft.fluentuidemo.demos
 
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,19 +8,25 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Slider
+import androidx.compose.material.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
+import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.tokenized.controls.RadioButton
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.drawer.BottomDrawer
@@ -61,7 +68,9 @@ private fun CreateActivityUI() {
     var slideOver by remember { mutableStateOf(false) }
     var showHandle by remember { mutableStateOf(true) }
     var enableSwipeDismiss by remember { mutableStateOf(true) }
+    var maxLandscapeWidthFraction by remember { mutableFloatStateOf(1F) }
     var preventDismissalOnScrimClick by remember { mutableStateOf(false) }
+    var isLandscapeOrientation: Boolean = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
             slideOver = slideOver,
@@ -71,6 +80,7 @@ private fun CreateActivityUI() {
             showHandle = showHandle,
             preventDismissalOnScrimClick = preventDismissalOnScrimClick,
             enableSwipeDismiss = enableSwipeDismiss,
+            maxLandscapeWidthFraction = maxLandscapeWidthFraction,
             drawerContent =
             if (listContent)
                 getAndroidViewAsContent(selectedContent)
@@ -253,6 +263,43 @@ private fun CreateActivityUI() {
                     }
                 )
             }
+
+            item {
+                val maxLandscapeWidthFractionText = stringResource(id = R.string.bottom_drawer_max_width_landscape)
+                ListItem.Header(title = maxLandscapeWidthFractionText + if(!isLandscapeOrientation) " (Rotate to landscape Mode to use this)" else "",
+                    titleMaxLines = 2,
+                    enabled = isLandscapeOrientation,
+                    modifier = Modifier
+                        .clearAndSetSemantics {
+                            this.contentDescription = maxLandscapeWidthFractionText
+                        },
+                )
+                Slider(
+                    value = maxLandscapeWidthFraction,
+                    onValueChange = { maxLandscapeWidthFraction = it },
+                    valueRange = 0F..1F,
+                    enabled = isLandscapeOrientation,
+                    colors = SliderDefaults.colors(
+                        thumbColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            FluentTheme.themeMode
+                        ),
+                        activeTrackColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color80],
+                        inactiveTrackColor = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                            FluentTheme.themeMode
+                        ),
+                        disabledThumbColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            FluentTheme.themeMode
+                        ),
+                        disabledActiveTrackColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            FluentTheme.themeMode
+                        ),
+                        disabledInactiveTrackColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            FluentTheme.themeMode
+                        )
+                    ),
+                    steps = 10
+                )
+            }
             item {
                 ListItem.Header(title = stringResource(id = R.string.drawer_select_drawer_content))
                 ListItem.Item(text = stringResource(id = R.string.drawer_full_screen_size_scrollable_content),
@@ -360,6 +407,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     showHandle: Boolean,
     preventDismissalOnScrimClick: Boolean,
     enableSwipeDismiss: Boolean,
+    maxLandscapeWidthFraction: Float,
     drawerContent: @Composable ((() -> Unit) -> Unit),
 ) {
     val scope = rememberCoroutineScope()
@@ -394,6 +442,7 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         slideOver = slideOver,
         showHandle = showHandle,
         enableSwipeDismiss = enableSwipeDismiss,
+        maxLandscapeWidthFraction = maxLandscapeWidthFraction,
         preventDismissalOnScrimClick = preventDismissalOnScrimClick
     )
 }

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -894,6 +894,7 @@
     <!-- UI Label for Show Handle -->
     <string name="drawer_show_handle">Show Handle</string>
     <string name="drawer_enable_swipe_dismiss">Enable Swipe Dismiss</string>
+    <string name="bottom_drawer_max_width_landscape">Max Landscape width</string>
 
     <!--V2 ToolTip-->
     <!-- UI Label for ToolTip Title-->

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
@@ -58,4 +58,7 @@ open class DrawerTokens : IControlToken, Parcelable {
 
     @Composable
     open fun scrimOpacity(drawerInfo: DrawerInfo): Float = 0.32F
+
+    @Composable
+    open fun maxLandscapeWidth (drawerInfo: DrawerInfo): Float = 0.6F
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/DrawerTokens.kt
@@ -58,7 +58,4 @@ open class DrawerTokens : IControlToken, Parcelable {
 
     @Composable
     open fun scrimOpacity(drawerInfo: DrawerInfo): Float = 0.32F
-
-    @Composable
-    open fun maxLandscapeWidth (drawerInfo: DrawerInfo): Float = 0.6F
 }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -1191,6 +1191,7 @@ fun Drawer(
  * @param windowInsetsType Type window insets to be passed to the bottom drawer window via PaddingValues params. The default value is WindowInsetsCompat.Type.systemBars()
  * @param drawerTokens tokens to provide appearance values. If not provided then drawer tokens will be picked from [FluentTheme]
  * @param drawerContent composable that represents content inside the drawer
+ * @param maxLandscapeWidthFraction max width of bottomDrawer wrt to screen width in landscape mode. The default value is 1F
  * @param preventDismissalOnScrimClick when true, the drawer will not be dismissed when the scrim is clicked
  * @param onScrimClick callback to be invoked when the scrim is clicked
  *
@@ -1208,6 +1209,7 @@ fun BottomDrawer(
     windowInsetsType: Int = WindowInsetsCompat.Type.systemBars(),
     drawerTokens: DrawerTokens? = null,
     drawerContent: @Composable () -> Unit,
+    maxLandscapeWidthFraction: Float = 1F,
     preventDismissalOnScrimClick: Boolean = false,
     onScrimClick: () -> Unit = {},
 ) {
@@ -1243,8 +1245,6 @@ fun BottomDrawer(
             val scrimOpacity: Float = tokens.scrimOpacity(drawerInfo)
             val scrimColor: Color =
                 tokens.scrimColor(drawerInfo).copy(alpha = scrimOpacity)
-            val maxLandscapeWidth :Float=
-                tokens.maxLandscapeWidth(drawerInfo = DrawerInfo(type = BehaviorType.BOTTOM))
             BottomDrawer(
                 modifier = modifier,
                 drawerState = drawerState,
@@ -1260,7 +1260,7 @@ fun BottomDrawer(
                 onDismiss = close,
                 drawerContent = drawerContent,
                 preventDismissalOnScrimClick = preventDismissalOnScrimClick,
-                maxLandscapeWidthFraction = maxLandscapeWidth,
+                maxLandscapeWidthFraction = maxLandscapeWidthFraction,
                 onScrimClick = onScrimClick
             )
         }


### PR DESCRIPTION
### Problem 
Maximum width for bottomDrawer is fixed and assumed to occupy the whole screen width available in landscape mode.
### Root cause 
by design
### Fix
Added a param to control fraction of bottomDrawer width in landscape mode
Reference : [https://github.com/microsoft/fluentui-android/pull/659](url)

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After            (when maxLandscapeWidth  = 0.5f)                          |  After (showing the slider in demo activity) | Slider in portrait mode |
|----------------------------------------------|--------------------------------------------|--| --|
| ![image](https://github.com/user-attachments/assets/32da7292-e627-4e47-be09-21beff6493a6)| ![image](https://github.com/user-attachments/assets/0ba9fc6b-6f4d-46b4-a545-7a1ee4514526) | ![image](https://github.com/user-attachments/assets/26697799-e906-4931-aa21-6b67cb989e32)| ![image](https://github.com/user-attachments/assets/f82cc480-c3d0-4b85-9ee0-a1c7ca9114f8)|


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
