### PR TITLE
removing disabled automatic component creation from gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 android.jetifier.ignorelist=bcprov-jdk18on
-android.disableAutomaticComponentCreation=true
 org.gradle.jvmargs=-XX\:MaxHeapSize\=256m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -Xmx2048M


### PR DESCRIPTION
### Problem 
generate artifacts and publish to feed task is failing
* What went wrong:
Execution failed for task ':fluentui_icons:publishFluentUIPublicationToFeedRepository'.
> Failed to publish publication 'FluentUI' to repository 'feed'
   > Could not PUT 'https://pkgs.dev.azure.com/microsoftdesign/fluentui-native/_packaging/fluentui-android/maven/v1/com/microsoft/fluentui/fluentui_icons/0.2.1/fluentui_icons-0.2.1.aar'. Received status code 401 from server: Unauthorized


### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
