### PR TITLE
v2 Basic Card and Pill Button Token Changes

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SegmentedControlActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SegmentedControlActivity.kt
@@ -104,6 +104,15 @@ class V2SegmentedControlActivity : V2DemoActivity() {
                                     enabled = enabled,
                                 )
                             )
+                            PillButton(
+                                modifier = Modifier.testTag(SEGMENTED_CONTROL_PILL_BUTTON_COMPONENT),
+                                pillMetaData = PillMetaData(
+                                    onClick = { selectedIcon = !selectedIcon },
+                                    icon = AvatarIcons.Icon.Anonymous.Xxlarge,
+                                    selected = selectedIcon,
+                                    enabled = enabled,
+                                )
+                            )
                         },
                         brandContent = {
                             PillButton(
@@ -119,6 +128,16 @@ class V2SegmentedControlActivity : V2DemoActivity() {
                                 PillMetaData(
                                     "Brand",
                                     { selectedBrandIcon = !selectedBrandIcon },
+                                    icon = AvatarIcons.Icon.Anonymous.Xxlarge,
+                                    selected = selectedBrandIcon,
+                                    enabled = enabled,
+                                    notificationDot = true
+                                ),
+                                style = FluentStyle.Brand,
+                            )
+                            PillButton(
+                                PillMetaData(
+                                    onClick = { selectedBrandIcon = !selectedBrandIcon },
                                     icon = AvatarIcons.Icon.Anonymous.Xxlarge,
                                     selected = selectedBrandIcon,
                                     enabled = enabled,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SegmentedControlActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SegmentedControlActivity.kt
@@ -105,7 +105,6 @@ class V2SegmentedControlActivity : V2DemoActivity() {
                                 )
                             )
                             PillButton(
-                                modifier = Modifier.testTag(SEGMENTED_CONTROL_PILL_BUTTON_COMPONENT),
                                 pillMetaData = PillMetaData(
                                     onClick = { selectedIcon = !selectedIcon },
                                     icon = AvatarIcons.Icon.Anonymous.Xxlarge,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SegmentedControlActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SegmentedControlActivity.kt
@@ -110,6 +110,7 @@ class V2SegmentedControlActivity : V2DemoActivity() {
                                     icon = AvatarIcons.Icon.Anonymous.Xxlarge,
                                     selected = selectedIcon,
                                     enabled = enabled,
+                                    semanticContentName = "anonymous"
                                 )
                             )
                         },
@@ -140,7 +141,8 @@ class V2SegmentedControlActivity : V2DemoActivity() {
                                     icon = AvatarIcons.Icon.Anonymous.Xxlarge,
                                     selected = selectedBrandIcon,
                                     enabled = enabled,
-                                    notificationDot = true
+                                    notificationDot = true,
+                                    semanticContentName = "anonymous"
                                 ),
                                 style = FluentStyle.Brand,
                             )

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/AnnouncementCard.kt
@@ -83,7 +83,7 @@ fun AnnouncementCard(
         }
 
         @Composable
-        override fun borderColor(basicCardInfo: BasicCardInfo): Color {
+        override fun borderColor(basicCardInfo: BasicCardInfo): Brush {
             return token.borderColor(announcementCardInfo = announcementCardInfo)
         }
 

--- a/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
+++ b/fluentui_controls/src/main/java/com/microsoft/fluentui/tokenized/controls/FileCard.kt
@@ -99,7 +99,7 @@ fun FileCard(
         }
 
         @Composable
-        override fun borderColor(basicCardInfo: BasicCardInfo): Color {
+        override fun borderColor(basicCardInfo: BasicCardInfo): Brush {
             return token.borderColor(fileCardInfo = fileCardInfo)
         }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AnnouncementCardTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AnnouncementCardTokens.kt
@@ -100,9 +100,11 @@ open class AnnouncementCardTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun borderColor(announcementCardInfo: AnnouncementCardInfo): Color {
-        return FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke1].value(
-            themeMode = FluentTheme.themeMode
+    open fun borderColor(announcementCardInfo: AnnouncementCardInfo): Brush {
+        return SolidColor(
+            FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke1].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BasicCardTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/BasicCardTokens.kt
@@ -48,9 +48,11 @@ open class BasicCardTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun borderColor(basicCardInfo: BasicCardInfo): Color {
-        return FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke1].value(
-            themeMode = FluentTheme.themeMode
+    open fun borderColor(basicCardInfo: BasicCardInfo): Brush {
+        return SolidColor(
+            FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke1].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FileCardTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/FileCardTokens.kt
@@ -46,9 +46,11 @@ open class FileCardTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun borderColor(fileCardInfo: FileCardInfo): Color {
-        return FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke1].value(
-            themeMode = FluentTheme.themeMode
+    open fun borderColor(fileCardInfo: FileCardInfo): Brush {
+        return SolidColor(
+            FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke1].value(
+                themeMode = FluentTheme.themeMode
+            )
         )
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
@@ -458,4 +458,15 @@ open class PillButtonTokens : IControlToken, Parcelable {
             )
         }
     }
+
+    @Composable
+    open fun iconSpace(pillButtonInfo: PillButtonInfo): Dp {
+        return FluentGlobalTokens.SizeTokens.Size20.value
+    }
+
+    @Composable
+    open fun horizontalMargin(pillButtonInfo: PillButtonInfo): Dp {
+        return FluentGlobalTokens.SizeTokens.Size160.value
+    }
+
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
@@ -458,20 +458,4 @@ open class PillButtonTokens : IControlToken, Parcelable {
             )
         }
     }
-
-    @Composable
-    open fun startMarginBeforeIcon(pillButtonInfo: PillButtonInfo): Dp {
-        return FluentGlobalTokens.SizeTokens.Size180.value
-    }
-
-    @Composable
-    open fun startMarginBeforText(pillButtonInfo: PillButtonInfo): Dp {
-        return FluentGlobalTokens.SizeTokens.Size160.value
-    }
-
-    @Composable
-    open fun endMargin(pillButtonInfo: PillButtonInfo): Dp {
-        return FluentGlobalTokens.SizeTokens.Size160.value
-    }
-
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillButtonTokens.kt
@@ -458,4 +458,20 @@ open class PillButtonTokens : IControlToken, Parcelable {
             )
         }
     }
+
+    @Composable
+    open fun startMarginBeforeIcon(pillButtonInfo: PillButtonInfo): Dp {
+        return FluentGlobalTokens.SizeTokens.Size180.value
+    }
+
+    @Composable
+    open fun startMarginBeforText(pillButtonInfo: PillButtonInfo): Dp {
+        return FluentGlobalTokens.SizeTokens.Size160.value
+    }
+
+    @Composable
+    open fun endMargin(pillButtonInfo: PillButtonInfo): Dp {
+        return FluentGlobalTokens.SizeTokens.Size160.value
+    }
+
 }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -176,7 +176,7 @@ fun PillButton(
     ) {
         Row(Modifier.width(IntrinsicSize.Max)) {
             if (pillMetaData.icon != null) {
-                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size180.value))
+                Spacer(Modifier.requiredWidth(token.startMarginBeforeIcon(pillButtonInfo = pillButtonInfo)))
                 Icon(
                     pillMetaData.icon!!,
                     pillMetaData.text,
@@ -186,7 +186,7 @@ fun PillButton(
                     tint = iconColor
                 )
             } else {
-                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size160.value))
+                Spacer(Modifier.requiredWidth(token.startMarginBeforText(pillButtonInfo = pillButtonInfo)))
                 BasicText(
                     pillMetaData.text,
                     modifier = Modifier
@@ -223,7 +223,7 @@ fun PillButton(
                 else
                     Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size80.value))
             } else {
-                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size160.value))
+                Spacer(Modifier.requiredWidth(token.endMargin(pillButtonInfo = pillButtonInfo)))
             }
         }
     }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -176,7 +176,7 @@ fun PillButton(
     ) {
         Row(Modifier.width(IntrinsicSize.Max)) {
             if (pillMetaData.icon != null) {
-                Spacer(Modifier.requiredWidth(token.startMarginBeforeIcon(pillButtonInfo = pillButtonInfo)))
+                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size180.value))
                 Icon(
                     pillMetaData.icon!!,
                     pillMetaData.text,
@@ -186,7 +186,7 @@ fun PillButton(
                     tint = iconColor
                 )
             } else {
-                Spacer(Modifier.requiredWidth(token.startMarginBeforText(pillButtonInfo = pillButtonInfo)))
+                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size160.value))
                 BasicText(
                     pillMetaData.text,
                     modifier = Modifier
@@ -223,7 +223,7 @@ fun PillButton(
                 else
                     Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size80.value))
             } else {
-                Spacer(Modifier.requiredWidth(token.endMargin(pillButtonInfo = pillButtonInfo)))
+                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size160.value))
             }
         }
     }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -192,7 +192,6 @@ fun PillButton(
 
             }
 
-
             if(pillMetaData.text != null){
 
                 BasicText(
@@ -208,7 +207,6 @@ fun PillButton(
                 )
 
             }
-
             if (pillMetaData.notificationDot) {
                 val notificationDotColor: Color =
                     token.notificationDotColor(pillButtonInfo)

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -50,6 +50,16 @@ import com.microsoft.fluentui.util.dpToPx
 import kotlinx.coroutines.launch
 import kotlin.math.max
 
+/**
+ * Pill Meta Data defines meta data for  a pill.
+ * @param text: the text that's displayed on the Pill
+ * @param onClick: onClick callback for defining the click action on the pill
+ * @param icon: icon that's displayed on the Pill.
+ * @param enabled: to make pill disabled or enabled for click interactions
+ * @param notificationDot: boolean which defines whether to show a notification dot or not on the pill.
+ * @param calloutSelectionState: boolean which let's the user define if "selected" or "not selected" state of pill must be announced for the accessibility purposes
+ * @param semanticContentName: Pill name that must be announced for accessibility purposes, if it's null then @param text is used for accessibility announcement
+ */
 data class PillMetaData(
     var text: String? = null,
     var onClick: (() -> Unit),

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.max
 
 data class PillMetaData(
-    var text: String,
+    var text: String? = null,
     var onClick: (() -> Unit),
     var icon: ImageVector? = null,
     var enabled: Boolean = true,
@@ -175,8 +175,9 @@ fun PillButton(
         contentAlignment = Alignment.Center
     ) {
         Row(Modifier.width(IntrinsicSize.Max)) {
+            Spacer(Modifier.requiredWidth(token.horizontalMargin(pillButtonInfo = pillButtonInfo)))
             if (pillMetaData.icon != null) {
-                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size180.value))
+                Spacer(Modifier.requiredWidth(token.iconSpace(pillButtonInfo = pillButtonInfo)))
                 Icon(
                     pillMetaData.icon!!,
                     pillMetaData.text,
@@ -185,10 +186,17 @@ fun PillButton(
                         .clearAndSetSemantics { },
                     tint = iconColor
                 )
-            } else {
-                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size160.value))
+                if(pillMetaData.text != null){
+                    Spacer(Modifier.requiredWidth(token.iconSpace(pillButtonInfo = pillButtonInfo)))
+                }
+
+            }
+
+
+            if(pillMetaData.text != null){
+
                 BasicText(
-                    pillMetaData.text,
+                    pillMetaData.text!!,
                     modifier = Modifier
                         .weight(1F)
                         .clearAndSetSemantics { },
@@ -198,6 +206,7 @@ fun PillButton(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
+
             }
 
             if (pillMetaData.notificationDot) {
@@ -223,7 +232,7 @@ fun PillButton(
                 else
                     Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size80.value))
             } else {
-                Spacer(Modifier.requiredWidth(FluentGlobalTokens.SizeTokens.Size160.value))
+                Spacer(Modifier.requiredWidth(token.horizontalMargin(pillButtonInfo = pillButtonInfo)))
             }
         }
     }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -189,9 +189,7 @@ fun PillButton(
                 if(pillMetaData.text != null){
                     Spacer(Modifier.requiredWidth(token.iconSpace(pillButtonInfo = pillButtonInfo)))
                 }
-
             }
-
             if(pillMetaData.text != null){
 
                 BasicText(
@@ -205,7 +203,6 @@ fun PillButton(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-
             }
             if (pillMetaData.notificationDot) {
                 val notificationDotColor: Color =

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/Pill.kt
@@ -58,6 +58,7 @@ data class PillMetaData(
     var selected: Boolean = false,
     var notificationDot: Boolean = false,
     var calloutSelectionState: Boolean = true,
+    var semanticContentName: String? = null,
 )
 
 /**
@@ -168,9 +169,8 @@ fun PillButton(
             .padding(vertical = token.verticalPadding(pillButtonInfo))
             .semantics(true) {
                 contentDescription =
-                    if (pillMetaData.enabled) "${pillMetaData.text} $selectedString"
-                    else "${pillMetaData.text} $enabledString"
-
+                    if (pillMetaData.enabled) "${pillMetaData.semanticContentName ?: pillMetaData.text ?:  ""} $selectedString"
+                    else "${pillMetaData.semanticContentName ?: pillMetaData.text ?: ""} $enabledString"
             },
         contentAlignment = Alignment.Center
     ) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
 android.jetifier.ignorelist=bcprov-jdk18on
+android.disableAutomaticComponentCreation=true
 org.gradle.jvmargs=-XX\:MaxHeapSize\=256m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -Xmx2048M

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 android.jetifier.ignorelist=bcprov-jdk18on
-android.disableAutomaticComponentCreation=true
 org.gradle.jvmargs=-XX\:MaxHeapSize\=256m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -Xmx2048M


### PR DESCRIPTION
### Problem 
1. Border Color token of Basic Card is of type Color, so it cannot support gradient brush
2. Pill  Button ignores the text, if it has an icon
3. Margin related tokens added in Pill Button Tokens
### Root cause 
1. by design
2. Bug
3. by design
### Fix
1. Have convertedBorder Color to Brush type
2. Fixed by allowing text and icon to co-exist
3. Added tokens


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![image](https://github.com/user-attachments/assets/b2c3c581-065f-404d-8c10-05d588ba5e85)|  ![image](https://github.com/user-attachments/assets/afcfc849-53f4-4f89-926c-bfa2d4664cbb) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
