### PR TITLE
[Fluent V1][BottomSheet] Add a custom accessory view property to BottomSheetItem class

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/BottomSheetActivity.kt
@@ -7,6 +7,7 @@ package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.widget.Switch
 import android.widget.TextView
 import com.microsoft.fluentui.bottomsheet.BottomSheet
 import com.microsoft.fluentui.bottomsheet.BottomSheetDialog
@@ -67,6 +68,12 @@ class BottomSheetActivity : DemoActivity(), BottomSheetItem.OnClickListener {
                         R.id.bottom_sheet_item_delete,
                         R.drawable.ic_delete_24_regular,
                         getString(R.string.bottom_sheet_item_delete_title)
+                    ),
+                    BottomSheetItem(
+                        R.id.bottom_sheet_item_toggle,
+                        R.drawable.ic_fluent_toggle_multiple_24_regular,
+                        getString(R.string.bottom_sheet_item_toggle_title),
+                        customAccessoryView = Switch(this)
                     )
                 )
             )
@@ -218,6 +225,7 @@ class BottomSheetActivity : DemoActivity(), BottomSheetItem.OnClickListener {
             R.id.bottom_sheet_item_reply -> showSnackbar(resources.getString(R.string.bottom_sheet_item_reply_toast))
             R.id.bottom_sheet_item_forward -> showSnackbar(resources.getString(R.string.bottom_sheet_item_forward_toast))
             R.id.bottom_sheet_item_delete -> showSnackbar(resources.getString(R.string.bottom_sheet_item_delete_toast))
+            R.id.bottom_sheet_item_toggle -> showSnackbar(resources.getString(R.string.bottom_sheet_item_toggle_toast))
 
             // Double line items
             R.id.bottom_sheet_item_camera -> showSnackbar(resources.getString(R.string.bottom_sheet_item_camera_toast))

--- a/FluentUI.Demo/src/main/res/values/ids.xml
+++ b/FluentUI.Demo/src/main/res/values/ids.xml
@@ -18,6 +18,7 @@
     <item name="bottom_sheet_item_reply" type="id" />
     <item name="bottom_sheet_item_forward" type="id" />
     <item name="bottom_sheet_item_delete" type="id" />
+    <item name="bottom_sheet_item_toggle" type="id" />
     <item name="bottom_sheet_item_camera" type="id" />
     <item name="bottom_sheet_item_gallery" type="id" />
     <item name="bottom_sheet_item_videos" type="id" />

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -248,6 +248,10 @@
     <string name="bottom_sheet_item_delete_title">Delete</string>
     <!--UI Label for user action clicked on item delete-->
     <string name="bottom_sheet_item_delete_toast">Delete item clicked</string>
+    <!--UI Label for item toggle-->
+    <string name="bottom_sheet_item_toggle_title">Toggle</string>
+    <!--UI Label for user action clicked on item toggle-->
+    <string name="bottom_sheet_item_toggle_toast">Toggle item clicked</string>
     <!--UI Label for item avatar-->
     <string name="bottom_sheet_item_custom_image">Avatar</string>
     <!--Double line items-->

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
@@ -112,6 +112,9 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
             } else if (item.accessoryImageId != NO_ID) {
                 accessoryImageView = context.createImageView(item.accessoryImageId, item.getImageTint(context))
             }
+            if (accessoryView != null) {
+                accessoryView.isEnabled = !item.disabled
+            }
             if (accessoryImageView != null && item.disabled)
                 accessoryImageView.imageAlpha = ThemeUtil.getThemeAttrColor(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Drawer), R.attr.fluentuiBottomSheetDisabledIconColor)
             listItemView.customAccessoryView = accessoryView ?: accessoryImageView

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
@@ -114,9 +114,10 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
             }
             if (accessoryView != null) {
                 accessoryView.isEnabled = !item.disabled
+            } else if (accessoryImageView != null && item.disabled) {
+                accessoryImageView.imageAlpha =
+                    ThemeUtil.getThemeAttrColor(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Drawer), R.attr.fluentuiBottomSheetDisabledIconColor)
             }
-            if (accessoryImageView != null && item.disabled)
-                accessoryImageView.imageAlpha = ThemeUtil.getThemeAttrColor(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Drawer), R.attr.fluentuiBottomSheetDisabledIconColor)
             listItemView.customAccessoryView = accessoryView ?: accessoryImageView
 
             listItemView.setOnClickListener {

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetAdapter.kt
@@ -103,15 +103,18 @@ class BottomSheetAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 image.imageAlpha = ThemeUtil.getThemeAttrColor(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Drawer), R.attr.fluentuiBottomSheetDisabledIconColor)
             listItemView.customView = image
 
-            var accessoryImage: ImageView ?= null
-            if (item.accessoryBitmap != null) {
-                accessoryImage = context.createImageView(item.accessoryBitmap)
+            var accessoryView: View ?= null
+            var accessoryImageView: ImageView ?= null
+            if (item.customAccessoryView != null) {
+                accessoryView = item.customAccessoryView
+            } else if (item.accessoryBitmap != null) {
+                accessoryImageView = context.createImageView(item.accessoryBitmap)
             } else if (item.accessoryImageId != NO_ID) {
-                accessoryImage = context.createImageView(item.accessoryImageId, item.getImageTint(context))
+                accessoryImageView = context.createImageView(item.accessoryImageId, item.getImageTint(context))
             }
-            if (accessoryImage != null && item.disabled)
-                accessoryImage.imageAlpha = ThemeUtil.getThemeAttrColor(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Drawer), R.attr.fluentuiBottomSheetDisabledIconColor)
-            listItemView.customAccessoryView = accessoryImage
+            if (accessoryImageView != null && item.disabled)
+                accessoryImageView.imageAlpha = ThemeUtil.getThemeAttrColor(FluentUIContextThemeWrapper(context, R.style.Theme_FluentUI_Drawer), R.attr.fluentuiBottomSheetDisabledIconColor)
+            listItemView.customAccessoryView = accessoryView ?: accessoryImageView
 
             listItemView.setOnClickListener {
                 onBottomSheetItemClickListener?.onBottomSheetItemClick(item)

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/bottomsheet/BottomSheetItem.kt
@@ -44,6 +44,7 @@ class BottomSheetItem : Parcelable {
     val accessoryBitmap: Bitmap?
 
     val roleDescription: String
+    val customAccessoryView: View?
 
     @JvmOverloads
     constructor(
@@ -59,6 +60,7 @@ class BottomSheetItem : Parcelable {
         @DrawableRes accessoryImageId: Int = NO_ID,
         accessoryBitmap: Bitmap? = null,
         roleDescription: String = "",
+        customAccessoryView: View? = null
     ) {
         this.id = id
         this.imageId = imageId
@@ -72,6 +74,7 @@ class BottomSheetItem : Parcelable {
         this.accessoryImageId = accessoryImageId
         this.accessoryBitmap = accessoryBitmap
         this.roleDescription = roleDescription
+        this.customAccessoryView = customAccessoryView
     }
 
     private constructor(parcel: Parcel) : this(
@@ -123,6 +126,7 @@ class BottomSheetItem : Parcelable {
         if (accessoryImageId != other.accessoryImageId) return false
         if (accessoryBitmap != other.accessoryBitmap) return false
         if (roleDescription != other.roleDescription) return false
+        if (customAccessoryView != other.customAccessoryView) return false
 
         return true
     }
@@ -140,6 +144,7 @@ class BottomSheetItem : Parcelable {
         result = 31 * result + accessoryImageId.hashCode()
         result = 31 * result + (accessoryBitmap?.hashCode() ?: 0)
         result = 31 * result + roleDescription.hashCode()
+        result = 31 * result + (customAccessoryView?.hashCode() ?: 0)
         return result
     }
 


### PR DESCRIPTION
###  About this feature
Currently with V1 BottomSheet there is no way to add a custom accessory view. The list item view supports a custom view but bottom sheet item is not. So, exposing a property for hosts via BottomSheetItem to set a custom accessory view. 

As an example in the demo test application, I have added a toggle as a customAccessoryView.

The old logic of setting imageView is still intact. With the new logic if a host sets customAccessoryView then that will take precedence over the accessoryBitmap and accessoryImageId. This is because host is opting for customView rather than a Bitmap.

### Validations

### Screenshots
<img width="304" alt="light_mode" src="https://github.com/user-attachments/assets/8c37818f-ca55-4510-93b2-7f383d9fddf9">
<img width="305" alt="dark_mode" src="https://github.com/user-attachments/assets/4222d4ad-1d59-4a38-9980-ed467fb68df1">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] Automated Tests - No automated tests for V1
- [x] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
