### PR TITLE
Prevented Bottom Drawer V2 Recomposition on rotate in Demo App

### DIFF
--- a/FluentUI.Demo/src/main/AndroidManifest.xml
+++ b/FluentUI.Demo/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BannerActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BasicChipActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BasicControlsActivity" />
-        <activity android:name="com.microsoft.fluentuidemo.demos.V2BottomDrawerActivity" />
+        <activity android:name="com.microsoft.fluentuidemo.demos.V2BottomDrawerActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BottomSheetActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity android:name="com.microsoft.fluentuidemo.demos.V2CardActivity" />


### PR DESCRIPTION
### Problem 
Bottom Drawer disappears on rotate 

### Root cause 
Bottom Drawer V2 initializes with closed state and has to be opened. When the bottom drawer is open and we rotate the screen, the UI is recomposed, causing the bottom drawer to initialize again with closed state. 

### Fix
To avoid this, we prevent the recomposition of bottom drawer on rotate, similar to what has been implemented in bottom sheet V2.

### Validations
Manually validated in the demo app
(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Bottom Drawer would disappear on rotate | Bottom Drawer stays even after rotating |

### Screen Recording
[BottomDrawerRotationFix.webm](https://github.com/user-attachments/assets/721c1a8c-7347-4ea0-af99-02816c57e5bf)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] Automated Tests
- [x] Documentation and demo app examples
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and RTL layouts
- [x] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
