### PR TITLE
Theming fixes for Calendar view

### DIFF
--- a/FluentUI/src/main/res/values-night/themes.xml
+++ b/FluentUI/src/main/res/values-night/themes.xml
@@ -51,14 +51,6 @@
         <item name="FluentuiButtonOutlinedStrokePressedColor">@color/fluentui_communication_tint_40</item>
         <item name="FluentuiButtonOutlinedStrokeDisabledColor">@color/fluentui_gray_800</item>
 
-        <!--CalendarView-->
-        <item name="fluentuiCalendarBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
-        <item name="fluentuiCalendarWeekHeadingBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
-        <item name="fluentuiCalendarOtherMonthBackgroundColor">@color/fluentui_gray_700</item>
-        <item name="fluentuiCalendarDayTodayBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
-        <item name="fluentuiCalendarDayTextActiveColor">?attr/fluentuiForegroundColor</item>
-        <item name="fluentuiCalendarWeekHeadingWeekendTextColor">@color/fluentui_gray_600</item>
-
         <!--ContextualCommandBar-->
         <item name="fluentuiContextualCommandBarBackgroundColor">@color/fluentui_gray_600</item>
         <item name="fluentuiContextualCommandBarBackgroundColorPressed">@color/fluentui_gray_900</item>

--- a/FluentUI/src/main/res/values/themes.xml
+++ b/FluentUI/src/main/res/values/themes.xml
@@ -95,18 +95,6 @@
         <item name="fluentuiCompoundButtonTintDefaultColor">?attr/fluentuiForegroundSecondaryIconColor</item>
         <item name="fluentuiCompoundButtonTintCheckedColor">?attr/fluentuiForegroundSelectedColor</item>
 
-        <!--CalendarView-->
-        <item name="fluentuiCalendarBackgroundColor">?attr/fluentuiBackgroundColor</item>
-        <item name="fluentuiCalendarWeekHeadingBackgroundColor">?attr/fluentuiBackgroundColor</item>
-        <item name="fluentuiCalendarWeekHeadingWeekDayTextColor">?attr/fluentuiForegroundSecondaryColor</item>
-        <item name="fluentuiCalendarWeekHeadingWeekendTextColor">@color/fluentui_gray_400</item>
-        <item name="fluentuiCalendarMonthOverlayBackgroundColor">?attr/fluentuiBackgroundColor</item>
-        <item name="fluentuiCalendarMonthOverlayTextColor">?attr/fluentuiForegroundColor</item>
-        <item name="fluentuiCalendarOtherMonthBackgroundColor">@color/fluentui_gray_25</item>
-        <item name="fluentuiCalendarSelectedColor">?attr/fluentuiForegroundSelectedColor</item>
-        <item name="fluentuiCalendarDayTodayBackgroundColor">?attr/fluentuiColorPrimaryLighter</item>
-        <item name="fluentuiCalendarDayKeyboardFocusTextColor">@color/fluentui_gray_600</item>
-
         <!--ContextualCommandBar-->
         <item name="fluentuiContextualCommandBarBackgroundColor">@color/fluentui_gray_50</item>
         <item name="fluentuiContextualCommandBarBackgroundColorPressed">@color/fluentui_gray_100</item>

--- a/fluentui_calendar/src/main/res/values-night/themes.xml
+++ b/fluentui_calendar/src/main/res/values-night/themes.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) Microsoft Corporation. All rights reserved.
+  ~ Licensed under the MIT License.
+  -->
+<resources>
+
+    <style name="Theme.FluentUI.Calendar" parent="Theme.FluentUI.Calendar.Base">
+     
+        <!--CalendarView-->
+        <item name="fluentuiCalendarBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
+        <item name="fluentuiCalendarWeekHeadingBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
+        <item name="fluentuiCalendarWeekHeadingWeekDayTextColor">@color/fluentui_gray_300</item>
+        <item name="fluentuiCalendarWeekHeadingWeekendTextColor">@color/fluentui_gray_400</item>
+        <item name="fluentuiCalendarOtherMonthBackgroundColor">@color/fluentui_gray_700</item>
+        <item name="fluentuiCalendarDayTodayBackgroundColor">?attr/fluentuiBackgroundSecondaryColor</item>
+        <item name="fluentuiCalendarDayTextActiveColor">?attr/fluentuiForegroundColor</item>
+        
+    </style>
+</resources>

--- a/fluentui_calendar/src/main/res/values/themes.xml
+++ b/fluentui_calendar/src/main/res/values/themes.xml
@@ -28,6 +28,7 @@
         <item name="fluentuiCalendarDayTextActiveCheckedColor">?attr/fluentuiForegroundOnPrimaryColor</item>
         <item name="fluentuiCalendarDayTextInactiveCheckedColor">?attr/fluentuiForegroundOnPrimaryColor</item>
         <item name="fluentuiCalendarDayTextDefaultColor">?attr/fluentuiForegroundSecondaryColor</item>
+        <item name="fluentuiCalendarDayKeyboardFocusTextColor">@color/fluentui_gray_600</item>
 
         <!--DateTimePicker-->
         <item name="fluentuiDateTimePickerToolbarTitleTextColor">?attr/colorPrimary</item>


### PR DESCRIPTION
### Problem 
Theming was not working properly for calendar view

### Root cause 
color tokens were not defined correctly for light and dark theme

### Fix
Added color tokens for dark theme, and updated some tokens for light theme

### Validations
Screenshots from Demo app

Dark theme
<img width="343" alt="image" src="https://github.com/user-attachments/assets/b1eda799-8d7b-4bcd-8009-8d298b1f0100">

Light theme
<img width="339" alt="image" src="https://github.com/user-attachments/assets/3f7e0c0c-e13a-44d7-97ee-0c2e298b88ae">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
