### PR TITLE
Added Logic To Remember Previous State on Recomposition

### DIFF
--- a/FluentUI.Demo/src/main/AndroidManifest.xml
+++ b/FluentUI.Demo/src/main/AndroidManifest.xml
@@ -32,8 +32,7 @@
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BannerActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BasicChipActivity" />
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BasicControlsActivity" />
-        <activity android:name="com.microsoft.fluentuidemo.demos.V2BottomDrawerActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"/>
+        <activity android:name="com.microsoft.fluentuidemo.demos.V2BottomDrawerActivity"/>
         <activity android:name="com.microsoft.fluentuidemo.demos.V2BottomSheetActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity android:name="com.microsoft.fluentuidemo.demos.V2CardActivity" />

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
@@ -13,9 +13,11 @@ import androidx.compose.material.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -412,17 +414,23 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
 ) {
     val scope = rememberCoroutineScope()
 
-    val drawerState = rememberBottomDrawerState(expandable = expandable, skipOpenState = skipOpenState)
+    var drawerState = rememberBottomDrawerState(expandable = expandable, skipOpenState = skipOpenState)
+
+    var drawerAppearanceValue by rememberSaveable { mutableIntStateOf(0) }
 
     val open: () -> Unit = {
         scope.launch { drawerState.open() }
+        drawerAppearanceValue = 1
     }
     val expand: () -> Unit = {
         scope.launch { drawerState.expand() }
+        drawerAppearanceValue = 2
     }
     val close: () -> Unit = {
         scope.launch { drawerState.close() }
+        drawerAppearanceValue = 0
     }
+
     Row {
         PrimarySurfaceContent(
             open,
@@ -445,6 +453,18 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         maxLandscapeWidthFraction = maxLandscapeWidthFraction,
         preventDismissalOnScrimClick = preventDismissalOnScrimClick
     )
+
+    when (drawerAppearanceValue) {
+        1 -> {
+            open()
+        }
+        2 -> {
+            expand()
+        }
+        else -> {
+            close()
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Problem 
After upgrading to anchor draggable, the issue of bottom drawer disappearing on rotation reemerged.

### Root cause 
Upon rotation, the UI recomposes leading the bottom drawer to start from closed state

### Fix
Added logic to remember last state of bottom drawer before recomposition. This will also allow bottom drawer to retain it's state if recomposition is triggered by some other android event such as Automatic OS Memory Optimizations, Locale Changes etc. 

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [beforeFix.webm](https://github.com/user-attachments/assets/c78e906e-c6de-48fd-acd8-6bf472f9a009)  | [afterFixRecording.webm](https://github.com/user-attachments/assets/8a2c942f-ed18-47c4-8f04-01bb4e521489) |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
