### PR TITLE
[Fluent v2] Allow text style confirguration for Tab bar items 

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -5,7 +5,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
@@ -162,5 +165,10 @@ open class TabItemTokens : IControlToken, Parcelable {
             TabTextAlignment.VERTICAL -> PaddingValues(top = 8.dp, start = 8.dp, bottom = 4.dp, end = 8.dp)
             TabTextAlignment.NO_TEXT -> PaddingValues(top = 8.dp, start = 8.dp, bottom = 4.dp, end = 8.dp)
         }
+    }
+
+    @Composable
+    open fun textTypography(tabItemInfo: TabItemInfo): TextStyle {
+        return FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Body1]
     }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -241,11 +241,11 @@ fun TabItem(
         ) {
             badgeWithIcon()
 
-            val fontStyle = FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Caption2]
-            var fontSize = remember { mutableStateOf(fontStyle.fontSize) }
+            val textTypography = token.textTypography(tabItemInfo = tabItemInfo)
+            var fontSize = remember { mutableStateOf(textTypography.fontSize) }
             var textStyle by remember(textColor) {
                 mutableStateOf(
-                    fontStyle.merge(TextStyle(color = textColor, fontSize = fontSize.value))
+                    textTypography.merge(TextStyle(color = textColor, fontSize = fontSize.value))
                 )
             }
 


### PR DESCRIPTION
### Problem 
currently, there is no option to configure text style in tab bar item

### Root cause 

### Fix


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
