### PR TITLE
[v1 Snackbar] Update with correct event on snackbar action dismiss

### DIFF
--- a/fluentui_transients/src/main/java/com/microsoft/fluentui/snackbar/Snackbar.kt
+++ b/fluentui_transients/src/main/java/com/microsoft/fluentui/snackbar/Snackbar.kt
@@ -216,7 +216,8 @@ class Snackbar : BaseTransientBottomBar<Snackbar> {
         actionButtonView.visibility = View.VISIBLE
         actionButtonView.setOnClickListener { view ->
             listener.onClick(view)
-            dismiss()
+            // dismiss the Snackbar
+            dispatchDismiss(BaseCallback.DISMISS_EVENT_ACTION)
         }
 
         updateStyle()


### PR DESCRIPTION
### Problem 
When we click the action button on a Snackbar it incorrectly calls dismiss().
https://github.com/microsoft/fluentui-android/blob/master/fluentui_transients/src/main/java/com/microsoft/fluentui/snackbar/Snackbar.kt#L212
This calls dispatchDismiss(BaseCallback.DISMISS_EVENT_MANUAL) in BaseTransientBottomBar.

Instead it should directly call  dispatchDismiss(BaseCallback.DISMISS_EVENT_ACTION)

### Fix
DISMISS_EVENT_ACTION indicates that the snackbar was dismissed via an action click
DISMISS_EVENT_MANUAL indicates that the snackbar was dismissed via a call to dismiss()

Since here the snackbar is being dismissed via action click, the correct event should be DISMISS_EVENT_ACTION
Fixes issue #101 

### Validations
Validated in Fluent demo app, snackbar is getting dismissed with the correct event

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
