### PR TITLE
Added ability to initialize bottom drawers with initial state

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomDrawerActivity.kt
@@ -30,6 +30,8 @@ import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.tokenized.controls.RadioButton
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.drawer.BottomDrawer
+import com.microsoft.fluentui.tokenized.drawer.DrawerState
+import com.microsoft.fluentui.tokenized.drawer.DrawerValue
 import com.microsoft.fluentui.tokenized.drawer.rememberBottomDrawerState
 import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentuidemo.R
@@ -411,18 +413,22 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
     drawerContent: @Composable ((() -> Unit) -> Unit),
 ) {
     val scope = rememberCoroutineScope()
-
+    var initialState by remember { mutableStateOf(DrawerValue.Closed) }
     val drawerState = rememberBottomDrawerState(expandable = expandable, skipOpenState = skipOpenState)
 
     val open: () -> Unit = {
         scope.launch { drawerState.open() }
+        initialState = DrawerValue.Open
     }
     val expand: () -> Unit = {
         scope.launch { drawerState.expand() }
+        initialState = DrawerValue.Expanded
     }
     val close: () -> Unit = {
         scope.launch { drawerState.close() }
+        initialState = DrawerValue.Closed
     }
+
     Row {
         PrimarySurfaceContent(
             open,
@@ -443,7 +449,8 @@ private fun CreateDrawerWithButtonOnPrimarySurfaceToInvokeIt(
         showHandle = showHandle,
         enableSwipeDismiss = enableSwipeDismiss,
         maxLandscapeWidthFraction = maxLandscapeWidthFraction,
-        preventDismissalOnScrimClick = preventDismissalOnScrimClick
+        preventDismissalOnScrimClick = preventDismissalOnScrimClick,
+        initialValue = initialState
     )
 }
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -470,7 +470,9 @@ fun BottomDrawer(
     maxLandscapeWidthFraction: Float = 1F,
     preventDismissalOnScrimClick: Boolean = false,
     onScrimClick: () -> Unit = {},
+    initialValue: DrawerValue = DrawerValue.Closed
 ) {
+    var scope = rememberCoroutineScope()
     if (drawerState.enable) {
         val themeID =
             FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -522,5 +524,17 @@ fun BottomDrawer(
                 onScrimClick = onScrimClick
             )
         }
+    }
+    val open: () -> Unit = {
+        scope.launch { drawerState.open() }
+    }
+    val expand: () -> Unit = {
+        scope.launch { drawerState.expand() }
+    }
+    if(initialValue == DrawerValue.Open) {
+        open()
+    }
+    else if(initialValue == DrawerValue.Expanded) {
+        expand()
     }
 }


### PR DESCRIPTION
### Problem 
Bottom drawer always initializes with the closed state

### Root cause 


### Fix
Added initial state to bottom drawers to allow fine control

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Bottom Drawer always initialized with closed state | Bottom drawer can be initialized with closed, open or expanded state |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
