### PR TITLE
fix positional substitutions in position string

### DIFF
--- a/fluentui_tablayout/src/main/res/values/strings.xml
+++ b/fluentui_tablayout/src/main/res/values/strings.xml
@@ -4,5 +4,5 @@
     <string name="tab_content_description">\u0020 tab %1$d of %2$d</string>
 
     <!-- Describes the Numbering of Pill Butons Inside PillBar -->
-    <string name="position_string">Item %d in list of %d</string>
+    <string name="position_string">Item %1$d in list of %2$d</string>
 </resources>


### PR DESCRIPTION
### Problem 
Multiple substitutions specified in non-positional format of string resource

### Fix
Added positioned arguments (%1$d, %2$d) to position_string
Fixes #588 

### Validations
Tested in fluent demo app

### Pull request checklist
This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
