### PR TITLE
Fixed talkback announcement for Demo App

### DIFF
--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -443,9 +443,9 @@
     </plurals>
 
     <!--Persistent BottomSheet-->
-    <string name="expand_bottom_sheet_button">Expand Persistent BottomSheet</string>
-    <string name="collapse_persistent_sheet_button"> Hide Persistent BottomSheet</string>
-    <string name="show_persistent_sheet_button"> Show Persistent BottomSheet</string>
+    <string name="expand_bottom_sheet_button">Expand Persistent Bottom Sheet</string>
+    <string name="collapse_persistent_sheet_button"> Hide Persistent Bottom Sheet</string>
+    <string name="show_persistent_sheet_button"> Show Persistent Bottom Sheet</string>
     <string name="new_view">This is New View</string>
     <string name="toggle_sheet_content">Toggle Bottomsheet Content</string>
     <string name="switch_to_custom_content">Switch to custom Content</string>


### PR DESCRIPTION
### Problem 
Talkback on Android pronounces the word 'BOTTOMSHEET' letter by letter instead of the actual pronunciation 

### Root cause 
The issue may be due to a bug with talkback itself where whenever bottomsheet is writtten after persistent in a sentence, the pronunciation is letter by letter 

### Fix
Updated the strings to be pronounced correctly by talkback

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Talkback pronounced 'Bottomsheet' letter by letter | Talkback follows the correct pronunciation |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
