### PR TITLE
Added color scheme in horizontalListAdapter

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/PersistentBottomSheetActivity.kt
@@ -240,7 +240,7 @@ class PersistentBottomSheetActivity : DemoActivity(), SheetItem.OnClickListener,
                     ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint),
                     disabled = true
                 )
-            ), 0, marginBetweenView
+            ), 0, marginBetweenView, drawerTint = ContextCompat.getColor(this, R.color.bottomsheet_horizontal_icon_tint).toInt()
         )
         horizontalListAdapter.mOnSheetItemClickListener = this
         persistentSheetContentBinding.sheetHorizontalItemList3.layoutManager =

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/SheetHorizontalItemAdapter.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/persistentbottomsheet/SheetHorizontalItemAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.ColorInt
 import com.microsoft.fluentui.drawer.R
 import com.microsoft.fluentui.util.createImageView
 
@@ -18,7 +19,7 @@ import com.microsoft.fluentui.util.createImageView
 /**
  * [SheetHorizontalItemAdapter] is used for horizontal list in bottomSheet
  */
-class SheetHorizontalItemAdapter(private val context: Context, items: ArrayList<SheetItem>, @StyleRes private val themeId: Int = R.style.Theme_FluentUI_Drawer, private val marginBetweenView: Int = 0) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class SheetHorizontalItemAdapter(private val context: Context, items: ArrayList<SheetItem>, @StyleRes private val themeId: Int = R.style.Theme_FluentUI_Drawer, private val marginBetweenView: Int = 0, @ColorInt private val drawerTint: Int? = null) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     var mOnSheetItemClickListener: SheetItem.OnClickListener? = null
     private val mItems: ArrayList<SheetItem> = items
 
@@ -49,7 +50,7 @@ class SheetHorizontalItemAdapter(private val context: Context, items: ArrayList<
                 if (it != null) {
                     listItemView.update(item.title, context.createImageView(it), item.disabled)
                 } else {
-                    listItemView.update(item.title, context.createImageView(item.drawable), item.disabled)
+                    listItemView.update(item.title, context.createImageView(item.drawable, imageTint = drawerTint), item.disabled)
                 }
             }
             listItemView.setOnClickListener {


### PR DESCRIPTION
### Problem 
Icons were not properly visible in PersistentBottomSheet

### Root cause 
When passing the items to HorizontalListAdapter, it was passed without the required color tint leading to default value which was different from the rest of the bottomsheet items 

### Fix
Added ability to pass a color tint as a ColorInt variable, and aligned the color with the rest of the bottomsheet elements

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

##### Before fix in Light Mode: 
![image](https://github.com/user-attachments/assets/76178363-e5f7-4cda-8643-0dae492b63aa)

##### Before fix in Dark Mode: 
![image](https://github.com/user-attachments/assets/40353c02-c3a0-417e-95cb-23ccd3a3357c)

##### After fix in Light Mode: 
![image](https://github.com/user-attachments/assets/2e8511c5-f2c8-4657-a531-f4726dd4c26e)

##### After fix in Dark Mode: 
![image](https://github.com/user-attachments/assets/4af529fb-f20a-4f74-a864-1b0f308c8dd9)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
