### PR TITLE
Fix - DrawerDialogs are not anchored to the bottom when Display Cutout Support is enabled 

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/drawer/DrawerDialog.kt
@@ -194,7 +194,11 @@ open class DrawerDialog @JvmOverloads constructor(context: Context, val behavior
 
         val displaySize: Point = context.displaySize
         val layoutParams: WindowManager.LayoutParams? = window?.attributes
-        layoutParams?.gravity = Gravity.TOP
+        if(behaviorType == BehaviorType.TOP) {
+            layoutParams?.gravity = Gravity.TOP
+        } else {
+            layoutParams?.gravity = Gravity.BOTTOM
+        }
         layoutParams?.y = topMargin
         layoutParams?.dimAmount = this.dimValue
         window?.attributes = layoutParams


### PR DESCRIPTION
### Problem 
DrawerDialogs are not anchored to the bottom when Display Cutout Support is enabled 

### Fix
Updated gravity to top for top sheets and Bottom for rest
Fixes issue #102 

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

Before
![image](https://github.com/user-attachments/assets/b20da176-362e-46cb-90b4-67954429d6be)
![image](https://github.com/user-attachments/assets/bbc39a95-61df-4821-8831-d1731b453a02)
![image](https://github.com/user-attachments/assets/6cc6e0ca-9721-4199-a6d2-075117d2ed31)


After
![image](https://github.com/user-attachments/assets/d5f89352-6088-40f8-b18d-e3dd63c7ab3e)
![image](https://github.com/user-attachments/assets/67143359-f23d-469d-aa45-c25c3ef17b6e)
![image](https://github.com/user-attachments/assets/85821971-7407-4f88-ac28-3b03f62e95aa)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
