### PR TITLE
Allowed use of gradient in tabItem Indicator

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TabBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2TabBarActivity.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -20,9 +22,11 @@ import androidx.lifecycle.MutableLiveData
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.StateBrush
 import com.microsoft.fluentui.theme.token.controlTokens.BadgeType
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonSize
 import com.microsoft.fluentui.theme.token.controlTokens.ButtonStyle
+import com.microsoft.fluentui.theme.token.controlTokens.TabItemInfo
 import com.microsoft.fluentui.theme.token.controlTokens.TabTextAlignment
 import com.microsoft.fluentui.tokenized.controls.Button
 import com.microsoft.fluentui.tokenized.controls.RadioButton
@@ -195,6 +199,12 @@ class V2TabBarActivity : V2DemoActivity() {
             val tabItemsCount = _tabItemsCount.observeAsState(initial = 5)
             val showIndicator = _tabShowIndicator.observeAsState(initial = false)
 
+            val indicatorColor = StateBrush(
+                rest = Brush.sweepGradient(listOf(Color.Blue, Color.Green)),
+                pressed = Brush.linearGradient(listOf(Color.Blue, Color.Black)),
+                selected = Brush.radialGradient(listOf(Color.Blue, Color.Red)),
+            )
+
             val tabDataList = arrayListOf(
                 TabData(
                     title = resources.getString(R.string.tabBar_home),
@@ -253,7 +263,8 @@ class V2TabBarActivity : V2DemoActivity() {
                 tabDataList = tabDataList.take(tabItemsCount.value),
                 selectedIndex = selectedIndex,
                 tabTextAlignment = tabTextAlignment.value,
-                showIndicator = showIndicator.value
+                showIndicator = showIndicator.value,
+                indicatorStyle = indicatorColor,
             )
         }
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -3,6 +3,7 @@ package com.microsoft.fluentui.theme.token.controlTokens
 import android.os.Parcelable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
@@ -23,7 +24,8 @@ enum class TabTextAlignment {
 
 open class TabItemInfo(
     val tabTextAlignment: TabTextAlignment = TabTextAlignment.VERTICAL,
-    val fluentStyle: FluentStyle = FluentStyle.Neutral
+    val fluentStyle: FluentStyle = FluentStyle.Neutral,
+    val indicatorColor: StateBrush? = null
 ) : ControlInfo
 
 @Parcelize
@@ -170,5 +172,10 @@ open class TabItemTokens : IControlToken, Parcelable {
     @Composable
     open fun textTypography(tabItemInfo: TabItemInfo): TextStyle {
         return FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Caption2]
+    }
+
+    @Composable
+    open fun indicatorColor(tabItemInfo: TabItemInfo): StateBrush? {
+        return tabItemInfo.indicatorColor
     }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -2,6 +2,7 @@ package com.microsoft.fluentui.tokenized.tabItem
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateValueAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
@@ -22,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +31,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
@@ -46,6 +50,7 @@ import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.Icon
+import com.microsoft.fluentui.theme.token.StateBrush
 import com.microsoft.fluentui.theme.token.controlTokens.TabItemInfo
 import com.microsoft.fluentui.theme.token.controlTokens.TabItemTokens
 import com.microsoft.fluentui.theme.token.controlTokens.TabTextAlignment
@@ -59,6 +64,7 @@ fun TabItem(
     modifier: Modifier = Modifier,
     style: FluentStyle = FluentStyle.Neutral,
     textAlignment: TabTextAlignment = TabTextAlignment.VERTICAL,
+    indicatorStyle: StateBrush? = null,
     enabled: Boolean = true,
     selected: Boolean = false,
     fixedWidth: Boolean = false,
@@ -72,7 +78,7 @@ fun TabItem(
         tabItemTokens
             ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabItemControlType] as TabItemTokens
 
-    val tabItemInfo = TabItemInfo(textAlignment, style)
+    val tabItemInfo = TabItemInfo(textAlignment, style, indicatorColor = indicatorStyle)
     val textColor by animateColorAsState(
         token.textColor(tabItemInfo = tabItemInfo).getColorByState(
             enabled = enabled,
@@ -94,6 +100,9 @@ fun TabItem(
         enabled = enabled, selected = selected, interactionSource = interactionSource
     )
     val rippleColor = token.rippleColor(tabItemInfo = tabItemInfo)
+    val indicatorColor: Brush? = token.indicatorColor(tabItemInfo = tabItemInfo)?.getBrushByState(
+        enabled = enabled, selected = selected, interactionSource = interactionSource
+    )
     val clickableModifier = Modifier
         .clickable(
             interactionSource = interactionSource,
@@ -274,11 +283,19 @@ fun TabItem(
                 )
                 {
                     Box(
-                        modifier = Modifier
+                        modifier = if(indicatorColor != null) {
+                            Modifier
                             .height(3.dp)
                             .width(indicatorWidth)
-                            .background(shape = RoundedCornerShape(indicatorCornerRadiusSize), color = textColor)
+                            .background(shape = RoundedCornerShape(indicatorCornerRadiusSize), brush = indicatorColor)
                             .clip(RoundedCornerShape(indicatorCornerRadiusSize))
+                        } else {
+                            Modifier
+                                .height(3.dp)
+                                .width(indicatorWidth)
+                                .background(shape = RoundedCornerShape(indicatorCornerRadiusSize), color = textColor)
+                                .clip(RoundedCornerShape(indicatorCornerRadiusSize))
+                        }
                     )
                 }
             }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/navigation/TabBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.StateBrush
 import com.microsoft.fluentui.theme.token.controlTokens.TabBarInfo
 import com.microsoft.fluentui.theme.token.controlTokens.TabBarTokens
 import com.microsoft.fluentui.theme.token.controlTokens.TabItemTokens
@@ -45,6 +46,7 @@ fun TabBar(
     selectedIndex: Int = 0,
     tabTextAlignment: TabTextAlignment = TabTextAlignment.VERTICAL,
     showIndicator: Boolean = false,
+    indicatorStyle: StateBrush? = null,
     tabItemTokens: TabItemTokens? = null,
     tabBarTokens: TabBarTokens? = null
 ) {
@@ -76,6 +78,7 @@ fun TabBar(
                     onClick = tabData.onClick,
                     accessory = tabData.badge,
                     showIndicator = showIndicator,
+                    indicatorStyle = indicatorStyle,
                     tabItemTokens = tabItemTokens
                         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.TabItemControlType] as TabItemTokens,
                     style = if (tabData.selected) FluentStyle.Brand else FluentStyle.Neutral


### PR DESCRIPTION
### Problem 
TabItem Indicator in Tab Bar had fixed color drawn from text, modified it to accept custom colors and gradients

### Root cause 
Indicator color was directly assigned as text color 

### Fix
Added arguments to assign indicator color 

### Screen recording

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [beforeIndicator.webm](https://github.com/user-attachments/assets/8af539d0-b4d6-4466-ba67-4596c3f3f987) | [afterIndicator.webm](https://github.com/user-attachments/assets/a1797c95-2ae5-4a81-a510-a627611a4180) |

Color Scheme Used in the After Video: 
![image](https://github.com/user-attachments/assets/263b1714-a109-4ff5-ad64-bd95368fc18e)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
