### PR TITLE
Added ability to modify indicator color

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -159,6 +159,51 @@ open class TabItemTokens : IControlToken, Parcelable {
     }
 
     @Composable
+    open fun indicatorColor(tabItemInfo: TabItemInfo): StateBrush {
+        return when (tabItemInfo.fluentStyle) {
+            FluentStyle.Neutral -> StateBrush(
+                rest = SolidColor(FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground2].value(
+                    themeMode = FluentTheme.themeMode
+                )),
+                pressed = SolidColor(FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                    themeMode = FluentTheme.themeMode
+                )),
+                disabled = SolidColor(FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                    themeMode = FluentTheme.themeMode
+                ))
+            )
+
+            FluentStyle.Brand -> StateBrush(
+                rest = SolidColor(FluentColor(
+                    light = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                        ThemeMode.Light
+                    ),
+                    dark = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                        ThemeMode.Dark
+                    )
+                ).value(FluentTheme.themeMode)),
+                pressed = SolidColor(FluentColor(
+                    light = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
+                        ThemeMode.Light
+                    ),
+                    dark = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                        ThemeMode.Dark
+                    )
+                ).value(FluentTheme.themeMode)),
+                selected = SolidColor(FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value()),
+                disabled = SolidColor(FluentColor(
+                    light = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForegroundDisabled2].value(
+                        ThemeMode.Light
+                    ),
+                    dark = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                        ThemeMode.Dark
+                    )
+                ).value(FluentTheme.themeMode))
+            )
+        }
+    }
+
+    @Composable
     open fun padding(tabItemInfo: TabItemInfo): PaddingValues {
         return when(tabItemInfo.tabTextAlignment){
             TabTextAlignment.HORIZONTAL -> PaddingValues(top = 8.dp, start = 4.dp, bottom = 4.dp, end = 8.dp)

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
@@ -89,6 +90,11 @@ fun TabItem(
         ),
         animationSpec = tween(durationMillis = 300)
     )
+
+    val indicatorColor: Brush = token.indicatorColor(tabItemInfo = tabItemInfo).getBrushByState(
+        enabled = enabled, selected = selected, interactionSource = interactionSource
+    )
+
     val padding = token.padding(tabItemInfo = tabItemInfo)
     val backgroundColor = token.backgroundBrush(tabItemInfo = tabItemInfo).getBrushByState(
         enabled = enabled, selected = selected, interactionSource = interactionSource
@@ -277,7 +283,7 @@ fun TabItem(
                         modifier = Modifier
                             .height(3.dp)
                             .width(indicatorWidth)
-                            .background(shape = RoundedCornerShape(indicatorCornerRadiusSize), color = textColor)
+                            .background(shape = RoundedCornerShape(indicatorCornerRadiusSize), brush = indicatorColor)
                             .clip(RoundedCornerShape(indicatorCornerRadiusSize))
                     )
                 }


### PR DESCRIPTION
### Problem 
TabItem Indicator in Tab Bar had fixed color same as text color

### Root cause 
Indicator color was directly assigned as text color 

### Fix
Added function inside TabItemToken which can be overridden to assign indicator color 

### Screen recording

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [beforeIndicator.webm](https://github.com/user-attachments/assets/8af539d0-b4d6-4466-ba67-4596c3f3f987) | [afterIndicator.webm](https://github.com/user-attachments/assets/a1797c95-2ae5-4a81-a510-a627611a4180) |

Color Scheme Used in the After Video: 
![colorScheme](https://github.com/user-attachments/assets/ba1d6e51-901e-403e-81e0-1c3a1c64d0cc)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
