### PR TITLE
Added ability to use gradients in Tab Bar Icons

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/TabItemTokens.kt
@@ -66,49 +66,53 @@ open class TabItemTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun iconColor(tabItemInfo: TabItemInfo): StateColor {
+    open fun iconColor(tabItemInfo: TabItemInfo): StateBrush {
         return when (tabItemInfo.fluentStyle) {
-            FluentStyle.Neutral -> StateColor(
-                rest = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value(
+            FluentStyle.Neutral -> StateBrush(
+                rest = SolidColor( FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value(
                     themeMode = FluentTheme.themeMode
+                )
                 ),
-                pressed = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
+                pressed = SolidColor( FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
                     themeMode = FluentTheme.themeMode
+                )
                 ),
-                focused= FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                focused= SolidColor( FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                     themeMode = FluentTheme.themeMode
+                )
                 ),
-                disabled = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                disabled = SolidColor( FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
                     themeMode = FluentTheme.themeMode
+                )
                 )
             )
 
-            FluentStyle.Brand -> StateColor(
-                rest = FluentColor(
+            FluentStyle.Brand -> StateBrush(
+                rest = SolidColor( FluentColor(
                     light = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(
                         ThemeMode.Light
                     ),
                     dark = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                         ThemeMode.Dark
                     )
-                ).value(FluentTheme.themeMode),
-                pressed = FluentColor(
+                ).value(FluentTheme.themeMode)),
+                pressed = SolidColor( FluentColor(
                     light = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1Pressed].value(
                         ThemeMode.Light
                     ),
                     dark = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                         ThemeMode.Dark
                     )
-                ).value(FluentTheme.themeMode),
-                selected = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value(),
-                disabled = FluentColor(
+                ).value(FluentTheme.themeMode)),
+                selected = SolidColor( FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForeground1].value()),
+                disabled = SolidColor( FluentColor(
                     light = FluentTheme.aliasTokens.brandForegroundColor[FluentAliasTokens.BrandForegroundColorTokens.BrandForegroundDisabled2].value(
                         ThemeMode.Light
                     ),
                     dark = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
                         ThemeMode.Dark
                     )
-                ).value(FluentTheme.themeMode)
+                ).value(FluentTheme.themeMode))
             )
         }
     }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -29,6 +29,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
@@ -81,13 +86,10 @@ fun TabItem(
         ),
         animationSpec = tween(durationMillis = 300)
     )
-    val iconColor by animateColorAsState (
-        targetValue = token.iconColor(tabItemInfo = tabItemInfo).getColorByState(
-            enabled = enabled,
-            selected = selected,
-            interactionSource = interactionSource
-        ),
-        animationSpec = tween(durationMillis = 300)
+    val iconColorBrush: Brush = token.iconColor(tabItemInfo = tabItemInfo).getBrushByState(
+        enabled = enabled,
+        selected = selected,
+        interactionSource = interactionSource
     )
     val padding = token.padding(tabItemInfo = tabItemInfo)
     val backgroundColor = token.backgroundBrush(tabItemInfo = tabItemInfo).getBrushByState(
@@ -112,9 +114,15 @@ fun TabItem(
     val iconContent: @Composable () -> Unit = {
         Icon(
             imageVector = icon,
-            modifier = Modifier.size(if (textAlignment == TabTextAlignment.NO_TEXT) 28.dp else 24.dp),
+            modifier = Modifier.size(if (textAlignment == TabTextAlignment.NO_TEXT) 28.dp else 24.dp)
+                        .graphicsLayer(alpha = 0.99f)
+                        .drawWithCache {
+                            onDrawWithContent {
+                                drawContent()
+                                drawRect(brush = iconColorBrush, blendMode = BlendMode.SrcAtop)
+                            }
+                        },
             contentDescription = if (textAlignment == TabTextAlignment.NO_TEXT) title else null,
-            tint = iconColor
         )
     }
 


### PR DESCRIPTION
### Problem 
Gradient was not supported in Icons previously 

### Root cause 
Icons accept a color tint in Compose 

### Fix
Added a graphic layer over the icon to allow the use of a Brush in the Icon Colors 

### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
