### PR TITLE
@Suppress("ModifierFactoryUnreferencedReceiver") for false positives

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/AnchoredDraggable.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/AnchoredDraggable.kt
@@ -16,6 +16,7 @@
 
 package com.microsoft.fluentui.compose
 
+import android.annotation.SuppressLint
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.animate
 import androidx.compose.foundation.MutatePriority
@@ -158,6 +159,7 @@ fun <T : Any> DraggableAnchors(
  * @param interactionSource Optional [MutableInteractionSource] that will passed on to
  * the internal [Modifier.draggable].
  */
+@Suppress("ModifierFactoryUnreferencedReceiver")
 fun <T> Modifier.anchoredDraggable(
     state: AnchoredDraggableState<T>,
     orientation: Orientation,

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/Swipeable.kt
@@ -16,6 +16,7 @@
 
 package com.microsoft.fluentui.compose
 
+import android.annotation.SuppressLint
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.SpringSpec
@@ -544,6 +545,7 @@ internal fun <T : Any> rememberSwipeableStateFor(
  * @param velocityThreshold The threshold (in dp per second) that the end velocity has to exceed
  * in order to animate to the next state, even if the positional [thresholds] have not been reached.
  */
+@SuppressLint("ModifierFactoryUnreferencedReceiver")
 fun <T> Modifier.swipeable(
         state: SwipeableState<T>,
         anchors: Map<Float, T>,


### PR DESCRIPTION
### Problem 
ModifierFactoryUnreferencedReceiver is being thrown with compose foundation version 1.6.0

### Root cause 
Modifier factory functions are fluently chained to construct a chain of Modifier objects that will be applied to a layout. As a result, each factory function must use the receiver Modifier parameter, to ensure that the function is returning a chain that includes previous items in the chain. Make sure the returned chain either explicitly includes this, such as return this.then(MyModifier) or implicitly by returning a chain that starts with an implicit call to another factory function, such as return myModifier(), where myModifier is defined as fun Modifier.myModifier(): Modifier.

But in our case we are implicity calling another factory function (draggable in case of AnchoredDraggable, and compose in case of Swipeable. Still the error is getting reported

### Fix
Added lint supressions for false positives

### Validations
verified locally by running the lint command
