### PR TITLE
Scrim functionality fixes & other enhancements for v2 bottom sheet

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -114,7 +114,7 @@ private fun CreateActivityUI() {
 
     var hidden by remember { mutableStateOf(true) }
 
-    val bottomSheetState = rememberBottomSheetState(BottomSheetValue.Shown)
+    val bottomSheetState = rememberBottomSheetState(BottomSheetValue.Hidden)
 
     val scope = rememberCoroutineScope()
 

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -94,6 +95,8 @@ class V2BottomSheetActivity : V2DemoActivity() {
 
 @Composable
 private fun CreateActivityUI() {
+    var scrimVisible by rememberSaveable { mutableStateOf(true) }
+
     var enableSwipeDismiss by remember { mutableStateOf(true) }
 
     var showHandleState by remember { mutableStateOf(true) }
@@ -103,6 +106,8 @@ private fun CreateActivityUI() {
     var slideOverState by remember { mutableStateOf(true) }
 
     var peekHeightState by remember { mutableStateOf(110.dp) }
+
+    var preventDismissalOnScrimClick by rememberSaveable { mutableStateOf(false) }
 
     var stickyThresholdUpwardDrag: Float by remember { mutableStateOf(56f) }
     var stickyThresholdDownwardDrag: Float by remember { mutableStateOf(56f) }
@@ -147,10 +152,12 @@ private fun CreateActivityUI() {
         sheetContent = sheetContentState,
         expandable = expandableState,
         peekHeight = peekHeightState,
+        scrimVisible = scrimVisible,
         showHandle = showHandleState,
         sheetState = bottomSheetState,
         slideOver = slideOverState,
         enableSwipeDismiss = enableSwipeDismiss,
+        preventDismissalOnScrimClick = preventDismissalOnScrimClick,
         stickyThresholdUpward = stickyThresholdUpwardDrag,
         stickyThresholdDownward = stickyThresholdDownwardDrag
     ) {
@@ -300,6 +307,44 @@ private fun CreateActivityUI() {
                     onValueChange = { enableSwipeDismiss = it }
                 )
             }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(30.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BasicText(
+                    text = "Scrim Visible",
+                    modifier = Modifier.weight(1F),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+                ToggleSwitch(checkedState = scrimVisible,
+                    onValueChange = { scrimVisible = it }
+                )
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(30.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BasicText(
+                    text = "Prevent Dismissal On Scrim Click",
+                    modifier = Modifier.weight(1F),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+                ToggleSwitch(checkedState = preventDismissalOnScrimClick,
+                    onValueChange = { preventDismissalOnScrimClick = it }
+                )
+            }
+
             // New Row for Sticky Threshold Downward Drag
             Row(
                 horizontalArrangement = Arrangement.spacedBy(30.dp),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -203,28 +203,13 @@ private fun CreateActivityUI() {
                         }
                     }
                 )
-            }
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Button(
-                    style = ButtonStyle.OutlinedButton,
-                    size = ButtonSize.Medium,
-                    text = "Hide",
-                    enabled = !hidden,
-                    onClick = {
-                        hidden = true
-                        scope.launch { bottomSheetState.hide() }
-                    }
-                )
+
 
                 Button(
                     style = ButtonStyle.OutlinedButton,
                     size = ButtonSize.Medium,
                     text = "Expand",
-                    enabled = !hidden && expandableState,
+                    enabled = expandableState,
                     onClick = {
                         scope.launch { bottomSheetState.expand() }
                     }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -76,13 +76,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 const val BOTTOM_SHEET_ENABLE_SWIPE_DISMISS_TEST_TAG = "enableSwipeDismiss"
+
 class V2BottomSheetActivity : V2DemoActivity() {
     init {
         setupActivity(this)
     }
 
     override val paramsUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#params-10"
-    override val controlTokensUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-10"
+    override val controlTokensUrl =
+        "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-10"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -204,7 +206,6 @@ private fun CreateActivityUI() {
                     }
                 )
 
-
                 Button(
                     style = ButtonStyle.OutlinedButton,
                     size = ButtonSize.Medium,
@@ -278,7 +279,7 @@ private fun CreateActivityUI() {
                 modifier = Modifier.fillMaxWidth()
             ) {
                 BasicText(
-                    text = stringResource(id =R.string.bottom_sheet_text_enable_swipe_dismiss),
+                    text = stringResource(id = R.string.bottom_sheet_text_enable_swipe_dismiss),
                     modifier = Modifier.weight(1F),
                     style = TextStyle(
                         color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
@@ -346,11 +347,15 @@ private fun CreateActivityUI() {
                     )
                 )
                 Slider(
-                    modifier = Modifier.width(100.dp).height(50.dp).padding(0.dp, 0.dp, 0.dp, 0.dp),
+                    modifier = Modifier
+                        .width(100.dp)
+                        .height(50.dp)
+                        .padding(0.dp, 0.dp, 0.dp, 0.dp),
                     value = stickyThresholdUpwardDrag,
-                    onValueChange = { stickyThresholdUpwardDrag = it
-                                    peekHeightState+=0.0001.dp
-                                    },
+                    onValueChange = {
+                        stickyThresholdUpwardDrag = it
+                        peekHeightState += 0.0001.dp
+                    },
                     valueRange = 0f..500f,
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],
@@ -382,11 +387,15 @@ private fun CreateActivityUI() {
                     )
                 )
                 Slider(
-                    modifier = Modifier.width(100.dp).height(50.dp).padding(0.dp, 0.dp, 0.dp, 0.dp),
+                    modifier = Modifier
+                        .width(100.dp)
+                        .height(50.dp)
+                        .padding(0.dp, 0.dp, 0.dp, 0.dp),
                     value = stickyThresholdDownwardDrag,
-                    onValueChange = { stickyThresholdDownwardDrag = it
-                                    peekHeightState+=0.0001.dp
-                                    },
+                    onValueChange = {
+                        stickyThresholdDownwardDrag = it
+                        peekHeightState += 0.0001.dp
+                    },
                     valueRange = 0f..500f,
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color100],

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/Utils.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/Utils.kt
@@ -1,4 +1,47 @@
 package com.microsoft.fluentui.tokenized
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+
 internal fun calculateFraction(a: Float, b: Float, pos: Float) =
     ((pos - a) / (b - a)).coerceIn(0f, 1f)
+
+@Composable
+internal fun Scrim(
+    open: Boolean,
+    color: Color,
+    onClose: () -> Unit,
+    fraction: () -> Float,
+    preventDismissalOnScrimClick: Boolean = false,
+    onScrimClick: () -> Unit = {},
+    tag: String
+) {
+    val dismissDrawer = if (open) {
+        Modifier.pointerInput(onClose) {
+            detectTapGestures {
+                if (!preventDismissalOnScrimClick) {
+                    onClose()
+                }
+                onScrimClick() //this function runs post onClose() so that the drawer is closed before the callback is invoked
+            }
+        }
+    } else {
+        Modifier
+    }
+
+    Canvas(
+        Modifier
+            .fillMaxSize()
+            .then(dismissDrawer)
+            .testTag(tag)
+
+    ) {
+        drawRect(color = color, alpha = fraction())
+    }
+}

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -242,7 +242,7 @@ fun BottomSheet(
     stickyThresholdUpward: Float = 56f,
     stickyThresholdDownward: Float = 56f,
     bottomSheetTokens: BottomSheetTokens? = null,
-    onScrimClick: () -> Unit = {},
+    onDismiss: () -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val themeID =
@@ -318,7 +318,7 @@ fun BottomSheet(
                     }
                 },
                 open = sheetState.isVisible,
-                onScrimClick = onScrimClick,
+                onScrimClick = onDismiss,
                 preventDismissalOnScrimClick = preventDismissalOnScrimClick,
                 tag = BOTTOMSHEET_SCRIM_TAG
             )
@@ -391,6 +391,7 @@ fun BottomSheet(
                                 if (sheetState.confirmStateChange(BottomSheetValue.Hidden)) {
                                     scope.launch { sheetState.hide() }
                                 }
+                                onDismiss()
                                 true
                             }
                         }
@@ -438,6 +439,7 @@ fun BottomSheet(
                                         if (!sheetState.isVisible) {
                                             if (enableSwipeDismiss) {
                                                 scope.launch { sheetState.hide() }
+                                                onDismiss()
                                             } else {
                                                 scope.launch { sheetState.show() }
                                             }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -263,7 +263,7 @@ fun BottomSheet(
         tokens.scrimColor(bottomSheetInfo).copy(alpha = scrimOpacity)
 
     val scope = rememberCoroutineScope()
-    val maxLandscapeWidth :Float= tokens.maxLandscapeWidth(bottomSheetInfo)
+    val maxLandscapeWidth: Float = tokens.maxLandscapeWidth(bottomSheetInfo)
 
     BoxWithConstraints(modifier) {
         val fullHeight = constraints.maxHeight.toFloat()
@@ -287,41 +287,41 @@ fun BottomSheet(
         ) {
             content()
             Scrim(
-                    color = if (scrimVisible) scrimColor else Color.Transparent,
-                    onClose = {
-                        if (sheetState.confirmStateChange(BottomSheetValue.Hidden)) {
-                            scope.launch { sheetState.hide() }
-                        }
-                    },
-                    fraction = {
-                        if (sheetState.anchors.isEmpty()
-                            || (sheetHeightState.value != null && sheetHeightState.value == 0f)
-                        ) {
-                            0.toFloat()
-                        } else {
-                            val targetValue: BottomSheetValue = if(slideOver) {
-                                if(sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded } != null) {
-                                    BottomSheetValue.Expanded
-                                } else if(sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Shown } != null) {
-                                    BottomSheetValue.Shown
-                                } else {
-                                    BottomSheetValue.Hidden
-                                }
-                            } else {
+                color = if (scrimVisible) scrimColor else Color.Transparent,
+                onClose = {
+                    if (sheetState.confirmStateChange(BottomSheetValue.Hidden)) {
+                        scope.launch { sheetState.hide() }
+                    }
+                },
+                fraction = {
+                    if (sheetState.anchors.isEmpty()
+                        || (sheetHeightState.value != null && sheetHeightState.value == 0f)
+                    ) {
+                        0.toFloat()
+                    } else {
+                        val targetValue: BottomSheetValue = if (slideOver) {
+                            if (sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded } != null) {
+                                BottomSheetValue.Expanded
+                            } else if (sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Shown } != null) {
                                 BottomSheetValue.Shown
+                            } else {
+                                BottomSheetValue.Hidden
                             }
-                            calculateFraction(
-                                sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Hidden }?.key!!,
-                                sheetState.anchors.entries.firstOrNull { it.value == targetValue }?.key!!,
-                                sheetState.offset.value
-                            )
+                        } else {
+                            BottomSheetValue.Shown
                         }
-                    },
-                    open = sheetState.isVisible,
-                    onScrimClick = onScrimClick,
-                    preventDismissalOnScrimClick = preventDismissalOnScrimClick,
-                    tag = BOTTOMSHEET_SCRIM_TAG
-                )
+                        calculateFraction(
+                            sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Hidden }?.key!!,
+                            sheetState.anchors.entries.firstOrNull { it.value == targetValue }?.key!!,
+                            sheetState.offset.value
+                        )
+                    }
+                },
+                open = sheetState.isVisible,
+                onScrimClick = onScrimClick,
+                preventDismissalOnScrimClick = preventDismissalOnScrimClick,
+                tag = BOTTOMSHEET_SCRIM_TAG
+            )
         }
         val configuration = LocalConfiguration.current
 
@@ -329,7 +329,7 @@ fun BottomSheet(
             Modifier
                 .align(Alignment.TopCenter)
                 .fillMaxWidth(
-                    if(configuration.orientation == Configuration.ORIENTATION_LANDSCAPE)maxLandscapeWidth
+                    if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) maxLandscapeWidth
                     else 1F
                 )
                 .nestedScroll(
@@ -449,7 +449,8 @@ fun BottomSheet(
                     ) {
                         val collapsed = LocalContext.current.resources.getString(R.string.collapsed)
                         val expanded = LocalContext.current.resources.getString(R.string.expanded)
-                        val accessibilityManager  = LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+                        val accessibilityManager =
+                            LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
                         Icon(
                             painterResource(id = R.drawable.ic_drawer_handle),
                             contentDescription =
@@ -476,10 +477,12 @@ fun BottomSheet(
                                         if (sheetState.confirmStateChange(BottomSheetValue.Shown)) {
                                             scope.launch { sheetState.show() }
                                             accessibilityManager?.let { manager ->
-                                                if(manager.isEnabled){
-                                                    val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
-                                                        text.add(collapsed)
-                                                    }
+                                                if (manager.isEnabled) {
+                                                    val event =
+                                                        AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT)
+                                                            .apply {
+                                                                text.add(collapsed)
+                                                            }
                                                     manager.sendAccessibilityEvent(event)
                                                 }
                                             }
@@ -488,10 +491,12 @@ fun BottomSheet(
                                         if (sheetState.confirmStateChange(BottomSheetValue.Expanded)) {
                                             scope.launch { sheetState.expand() }
                                             accessibilityManager?.let { manager ->
-                                                if(manager.isEnabled){
-                                                    val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
-                                                        text.add(expanded)
-                                                    }
+                                                if (manager.isEnabled) {
+                                                    val event =
+                                                        AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT)
+                                                            .apply {
+                                                                text.add(expanded)
+                                                            }
                                                     manager.sendAccessibilityEvent(event)
                                                 }
                                             }
@@ -533,18 +538,24 @@ private fun Modifier.bottomSheetSwipeable(
             val anchors = if (!expandable) {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,
-                    (fullHeight - min(sheetHeight, peekHeightPx))+keyCorrection to BottomSheetValue.Shown
+                    (fullHeight - min(
+                        sheetHeight,
+                        peekHeightPx
+                    )) + keyCorrection to BottomSheetValue.Shown
                 )
             } else if (sheetHeight <= peekHeightPx) {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,
-                    (fullHeight - sheetHeight)+keyCorrection to BottomSheetValue.Shown
+                    (fullHeight - sheetHeight) + keyCorrection to BottomSheetValue.Shown
                 )
             } else {
                 mapOf(
                     fullHeight to BottomSheetValue.Hidden,
-                    (fullHeight - peekHeightPx)+keyCorrection to BottomSheetValue.Shown,
-                    (max(0f, fullHeight - sheetHeight))+(keyCorrection*2) to BottomSheetValue.Expanded
+                    (fullHeight - peekHeightPx) + keyCorrection to BottomSheetValue.Shown,
+                    (max(
+                        0f,
+                        fullHeight - sheetHeight
+                    )) + (keyCorrection * 2) to BottomSheetValue.Expanded
                 )
             }
             if (sheetState.initialValue == BottomSheetValue.Expanded
@@ -564,9 +575,15 @@ private fun Modifier.bottomSheetSwipeable(
                     val fromKey = anchors.entries.firstOrNull { it.value == from }?.key
                     val toKey = anchors.entries.firstOrNull { it.value == to }?.key
 
-                    if(fromKey == null || toKey == null) { FixedThreshold(56.dp) } //in case of null defaulting to 56.dp threshold
-                    else if (fromKey < toKey) { FixedThreshold(stickyThresholdDownward.dp) } // Threshold for drag down
-                    else{ FixedThreshold(stickyThresholdUpward.dp) } // Threshold for drag up
+                    if (fromKey == null || toKey == null) {
+                        FixedThreshold(56.dp)
+                    } //in case of null defaulting to 56.dp threshold
+                    else if (fromKey < toKey) {
+                        FixedThreshold(stickyThresholdDownward.dp)
+                    } // Threshold for drag down
+                    else {
+                        FixedThreshold(stickyThresholdUpward.dp)
+                    } // Threshold for drag up
                 },
                 resistance = null
             )
@@ -597,9 +614,15 @@ private fun Modifier.bottomSheetSwipeable(
                 val fromKey = anchors.entries.firstOrNull { it.value == from }?.key
                 val toKey = anchors.entries.firstOrNull { it.value == to }?.key
 
-                if(fromKey == null || toKey == null) { FixedThreshold(56.dp) } //in case of null defaulting to 56 as a fallback
-                else if (fromKey < toKey) { FixedThreshold(stickyThresholdDownward.dp) } // Threshold for drag down
-                else{ FixedThreshold(stickyThresholdUpward.dp) } // Threshold for drag up
+                if (fromKey == null || toKey == null) {
+                    FixedThreshold(56.dp)
+                } //in case of null defaulting to 56 as a fallback
+                else if (fromKey < toKey) {
+                    FixedThreshold(stickyThresholdDownward.dp)
+                } // Threshold for drag down
+                else {
+                    FixedThreshold(stickyThresholdUpward.dp)
+                } // Threshold for drag up
             },
             resistance = null
         )

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -286,7 +286,6 @@ fun BottomSheet(
                 }
         ) {
             content()
-            if (slideOver) {
             Scrim(
                     color = if (scrimVisible) scrimColor else Color.Transparent,
                     onClose = {
@@ -296,14 +295,24 @@ fun BottomSheet(
                     },
                     fraction = {
                         if (sheetState.anchors.isEmpty()
-                            || !sheetState.anchors.containsValue(BottomSheetValue.Expanded)
                             || (sheetHeightState.value != null && sheetHeightState.value == 0f)
                         ) {
                             0.toFloat()
                         } else {
+                            val targetValue: BottomSheetValue = if(slideOver) {
+                                if(sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded } != null) {
+                                    BottomSheetValue.Expanded
+                                } else if(sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Shown } != null) {
+                                    BottomSheetValue.Shown
+                                } else {
+                                    BottomSheetValue.Hidden
+                                }
+                            } else {
+                                BottomSheetValue.Shown
+                            }
                             calculateFraction(
-                                sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Shown }?.key!!,
-                                sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded }?.key!!,
+                                sheetState.anchors.entries.firstOrNull { it.value == BottomSheetValue.Hidden }?.key!!,
+                                sheetState.anchors.entries.firstOrNull { it.value == targetValue }?.key!!,
                                 sheetState.offset.value
                             )
                         }
@@ -313,7 +322,6 @@ fun BottomSheet(
                     preventDismissalOnScrimClick = preventDismissalOnScrimClick,
                     tag = BOTTOMSHEET_SCRIM_TAG
                 )
-            }
         }
         val configuration = LocalConfiguration.current
 

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -147,18 +147,14 @@ class BottomSheetState(
          * The default [Saver] implementation for [BottomSheetState].
          */
         fun Saver(
-            animationSpec: AnimationSpec<Float>,
-            confirmStateChange: (BottomSheetValue) -> Boolean
-        ): Saver<BottomSheetState, *> = Saver(
-            save = { it.currentValue },
-            restore = {
-                BottomSheetState(
-                    initialValue = it,
-                    animationSpec = animationSpec,
-                    confirmStateChange = confirmStateChange
-                )
-            }
-        )
+            animationSpec: AnimationSpec<Float>, confirmStateChange: (BottomSheetValue) -> Boolean
+        ): Saver<BottomSheetState, *> = Saver(save = { it.currentValue }, restore = {
+            BottomSheetState(
+                initialValue = it,
+                animationSpec = animationSpec,
+                confirmStateChange = confirmStateChange
+            )
+        })
     }
 }
 
@@ -176,10 +172,8 @@ fun rememberBottomSheetState(
     confirmStateChange: (BottomSheetValue) -> Boolean = { true }
 ): BottomSheetState {
     return rememberSaveable(
-        initialValue, animationSpec, confirmStateChange,
-        saver = BottomSheetState.Saver(
-            animationSpec = animationSpec,
-            confirmStateChange = confirmStateChange
+        initialValue, animationSpec, confirmStateChange, saver = BottomSheetState.Saver(
+            animationSpec = animationSpec, confirmStateChange = confirmStateChange
         )
     ) {
         BottomSheetState(
@@ -238,11 +232,11 @@ fun BottomSheet(
     showHandle: Boolean = true,
     slideOver: Boolean = true,
     enableSwipeDismiss: Boolean = false,
-    preventDismissalOnScrimClick: Boolean = false,
+    preventDismissalOnScrimClick: Boolean = false,  // if true, the sheet will not be dismissed when the scrim is clicked
     stickyThresholdUpward: Float = 56f,
     stickyThresholdDownward: Float = 56f,
     bottomSheetTokens: BottomSheetTokens? = null,
-    onDismiss: () -> Unit = {},
+    onDismiss: () -> Unit = {}, // callback to be invoked after the sheet is closed
     content: @Composable () -> Unit
 ) {
     val themeID =
@@ -259,16 +253,14 @@ fun BottomSheet(
     val sheetBackgroundColor: Brush = tokens.backgroundBrush(bottomSheetInfo)
     val sheetHandleColor: Color = tokens.handleColor(bottomSheetInfo)
     val scrimOpacity: Float = tokens.scrimOpacity(bottomSheetInfo)
-    val scrimColor: Color =
-        tokens.scrimColor(bottomSheetInfo).copy(alpha = scrimOpacity)
+    val scrimColor: Color = tokens.scrimColor(bottomSheetInfo).copy(alpha = scrimOpacity)
 
     val scope = rememberCoroutineScope()
     val maxLandscapeWidth: Float = tokens.maxLandscapeWidth(bottomSheetInfo)
 
     BoxWithConstraints(modifier) {
         val fullHeight = constraints.maxHeight.toFloat()
-        val sheetHeightState =
-            remember(sheetContent.hashCode()) { mutableStateOf<Float?>(null) }
+        val sheetHeightState = remember(sheetContent.hashCode()) { mutableStateOf<Float?>(null) }
 
         Box(
             Modifier
@@ -283,20 +275,16 @@ fun BottomSheet(
                             true
                         }
                     }
-                }
-        ) {
+                }) {
             content()
-            Scrim(
-                color = if (scrimVisible) scrimColor else Color.Transparent,
+            Scrim(color = if (scrimVisible) scrimColor else Color.Transparent,
                 onClose = {
                     if (sheetState.confirmStateChange(BottomSheetValue.Hidden)) {
                         scope.launch { sheetState.hide() }
                     }
                 },
                 fraction = {
-                    if (sheetState.anchors.isEmpty()
-                        || (sheetHeightState.value != null && sheetHeightState.value == 0f)
-                    ) {
+                    if (sheetState.anchors.isEmpty() || (sheetHeightState.value != null && sheetHeightState.value == 0f)) {
                         0.toFloat()
                     } else {
                         val targetValue: BottomSheetValue = if (slideOver) {
@@ -336,8 +324,7 @@ fun BottomSheet(
                     if (!enableSwipeDismiss && sheetState.offset.value >= (fullHeight - dpToPx(
                             peekHeight
                         ))
-                    )
-                        sheetState.NonDismissiblePostDownNestedScrollConnection
+                    ) sheetState.NonDismissiblePostDownNestedScrollConnection
                     else if (slideOver) sheetState.PreUpPostDownNestedScrollConnection
                     else sheetState.PostDownNestedScrollConnection
                 )
@@ -375,11 +362,7 @@ fun BottomSheet(
                     }
                 }
                 .sheetHeight(
-                    expandable,
-                    slideOver,
-                    fullHeight,
-                    peekHeight,
-                    sheetState
+                    expandable, slideOver, fullHeight, peekHeight, sheetState
                 )
                 .clip(sheetShape)
                 .shadow(sheetElevation)
@@ -453,21 +436,17 @@ fun BottomSheet(
                         val expanded = LocalContext.current.resources.getString(R.string.expanded)
                         val accessibilityManager =
                             LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
-                        Icon(
-                            painterResource(id = R.drawable.ic_drawer_handle),
-                            contentDescription =
-                            if (sheetState.currentValue == BottomSheetValue.Expanded || (sheetState.hasExpandedState && sheetState.isVisible)) {
+                        Icon(painterResource(id = R.drawable.ic_drawer_handle),
+                            contentDescription = if (sheetState.currentValue == BottomSheetValue.Expanded || (sheetState.hasExpandedState && sheetState.isVisible)) {
                                 LocalContext.current.resources.getString(R.string.drag_handle)
                             } else {
                                 null
                             },
                             tint = sheetHandleColor,
-                            modifier = Modifier
-                                .clickable(
+                            modifier = Modifier.clickable(
                                     enabled = sheetState.hasExpandedState,
                                     role = Role.Button,
-                                    onClickLabel =
-                                    if (sheetState.currentValue == BottomSheetValue.Expanded) {
+                                    onClickLabel = if (sheetState.currentValue == BottomSheetValue.Expanded) {
                                         LocalContext.current.resources.getString(R.string.collapse)
                                     } else {
                                         if (sheetState.hasExpandedState && sheetState.isVisible) LocalContext.current.resources.getString(
@@ -504,19 +483,16 @@ fun BottomSheet(
                                             }
                                         }
                                     }
-                                }
-                        )
+                                })
                     }
                 }
                 Column(modifier = Modifier
                     .testTag(BOTTOMSHEET_CONTENT_TAG)
-                    .then(if (slideOver) Modifier
-                        .onFocusChanged { focusState ->
-                            if (focusState.hasFocus && sheetState.currentValue != BottomSheetValue.Expanded) {        // this expands the sheet when the content is focused
-                                scope.launch { sheetState.expand() }
-                            }
-                        } else Modifier.fillMaxSize()),
-                    content = { sheetContent() })
+                    .then(if (slideOver) Modifier.onFocusChanged { focusState ->
+                        if (focusState.hasFocus && sheetState.currentValue != BottomSheetValue.Expanded) {        // this expands the sheet when the content is focused
+                            scope.launch { sheetState.expand() }
+                        }
+                    } else Modifier.fillMaxSize()), content = { sheetContent() })
             }
         }
     }
@@ -539,10 +515,8 @@ private fun Modifier.bottomSheetSwipeable(
         if (sheetHeight != null && sheetHeight != 0f) {
             val anchors = if (!expandable) {
                 mapOf(
-                    fullHeight to BottomSheetValue.Hidden,
-                    (fullHeight - min(
-                        sheetHeight,
-                        peekHeightPx
+                    fullHeight to BottomSheetValue.Hidden, (fullHeight - min(
+                        sheetHeight, peekHeightPx
                     )) + keyCorrection to BottomSheetValue.Shown
                 )
             } else if (sheetHeight <= peekHeightPx) {
@@ -555,17 +529,13 @@ private fun Modifier.bottomSheetSwipeable(
                     fullHeight to BottomSheetValue.Hidden,
                     (fullHeight - peekHeightPx) + keyCorrection to BottomSheetValue.Shown,
                     (max(
-                        0f,
-                        fullHeight - sheetHeight
+                        0f, fullHeight - sheetHeight
                     )) + (keyCorrection * 2) to BottomSheetValue.Expanded
                 )
             }
-            if (sheetState.initialValue == BottomSheetValue.Expanded
-                && anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded } == null
-            ) {
+            if (sheetState.initialValue == BottomSheetValue.Expanded && anchors.entries.firstOrNull { it.value == BottomSheetValue.Expanded } == null) {
                 throw IllegalArgumentException(
-                    "BottomSheet initial value must not be set to Expanded " +
-                            "if the whole content is visible in Shown state itself"
+                    "BottomSheet initial value must not be set to Expanded " + "if the whole content is visible in Shown state itself"
                 )
             }
             Modifier.swipeable(
@@ -641,18 +611,16 @@ private fun Modifier.sheetHeight(
     peekHeight: Dp,
     sheetState: BottomSheetState
 ): Modifier {
-    val modifier =
-        if (slideOver) {
-            if (expandable) {
-                Modifier
-            } else {
-                Modifier.heightIn(
-                    0.dp,
-                    pxToDp(min(fullHeight * BottomSheetOpenFraction, dpToPx(peekHeight)))
-                )
-            }
+    val modifier = if (slideOver) {
+        if (expandable) {
+            Modifier
         } else {
-            Modifier.heightIn(0.dp, pxToDp(fullHeight - sheetState.offset.value))
+            Modifier.heightIn(
+                0.dp, pxToDp(min(fullHeight * BottomSheetOpenFraction, dpToPx(peekHeight)))
+            )
         }
+    } else {
+        Modifier.heightIn(0.dp, pxToDp(fullHeight - sheetState.offset.value))
+    }
     return this.then(modifier)
 }

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/BottomDrawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/BottomDrawer.kt
@@ -61,18 +61,14 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 private fun Modifier.drawerHeight(
-    slideOver: Boolean,
-    fixedHeight: Float,
-    fullHeight: Float,
-    drawerState: DrawerState
+    slideOver: Boolean, fixedHeight: Float, fullHeight: Float, drawerState: DrawerState
 ): Modifier {
     val modifier = if (slideOver) {
         if (drawerState.expandable) {
             Modifier
         } else {
             Modifier.heightIn(
-                0.dp,
-                pxToDp(fixedHeight)
+                0.dp, pxToDp(fixedHeight)
             )
         }
     } else {
@@ -97,21 +93,18 @@ fun BottomDrawer(
     showHandle: Boolean,
     onDismiss: () -> Unit,
     drawerContent: @Composable () -> Unit,
-    maxLandscapeWidthFraction : Float = 1F,
+    maxLandscapeWidthFraction: Float = 1F,
     preventDismissalOnScrimClick: Boolean = false,
     onScrimClick: () -> Unit = {}
 ) {
     BoxWithConstraints(modifier.fillMaxSize()) {
         val fullHeight = constraints.maxHeight.toFloat()
-        val drawerHeight =
-            remember(drawerContent.hashCode()) { mutableStateOf<Float?>(null) }
+        val drawerHeight = remember(drawerContent.hashCode()) { mutableStateOf<Float?>(null) }
         val maxOpenHeight = fullHeight * DrawerOpenFraction
 
         val drawerConstraints = with(LocalDensity.current) {
-            Modifier
-                .sizeIn(
-                    maxWidth = constraints.maxWidth.toDp(),
-                    maxHeight = constraints.maxHeight.toDp()
+            Modifier.sizeIn(
+                    maxWidth = constraints.maxWidth.toDp(), maxHeight = constraints.maxHeight.toDp()
                 )
         }
         val scope = rememberCoroutineScope()
@@ -129,7 +122,10 @@ fun BottomDrawer(
                         drawerStateAnchors.let {
                             if (drawerState.anchoredDraggableState.anchors.hasAnchorFor(DrawerValue.Expanded)) {
                                 DrawerValue.Expanded
-                            } else if (drawerState.anchoredDraggableState.anchors.hasAnchorFor(DrawerValue.Open)) {
+                            } else if (drawerState.anchoredDraggableState.anchors.hasAnchorFor(
+                                    DrawerValue.Open
+                                )
+                            ) {
                                 DrawerValue.Open
                             } else {
                                 DrawerValue.Closed
@@ -160,8 +156,7 @@ fun BottomDrawer(
                     else 1F
                 )
                 .nestedScroll(
-                    if (!enableSwipeDismiss && drawerStateOffset >= maxOpenHeight) drawerState.anchoredDraggableState.NonDismissiblePreUpPostDownNestedScrollConnection else
-                        if (slideOver) drawerState.nestedScrollConnection else drawerState.anchoredDraggableState.PostDownNestedScrollConnection
+                    if (!enableSwipeDismiss && drawerStateOffset >= maxOpenHeight) drawerState.anchoredDraggableState.NonDismissiblePreUpPostDownNestedScrollConnection else if (slideOver) drawerState.nestedScrollConnection else drawerState.anchoredDraggableState.PostDownNestedScrollConnection
                 )
                 .offset {
                     val y = if (drawerStateAnchors.size == 0) {
@@ -172,16 +167,13 @@ fun BottomDrawer(
                     IntOffset(x = 0, y = y)
                 }
                 .then(
-                    if (maxLandscapeWidthFraction != 1F
-                        && configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-                    ) Modifier.align(Alignment.TopCenter)
+                    if (maxLandscapeWidthFraction != 1F && configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) Modifier.align(
+                        Alignment.TopCenter
+                    )
                     else Modifier
                 )
                 .onGloballyPositioned { layoutCoordinates ->
-                    if (!drawerState.animationInProgress
-                        && drawerState.anchoredDraggableState.currentValue == DrawerValue.Closed
-                        && drawerState.anchoredDraggableState.targetValue == DrawerValue.Closed
-                    ) {
+                    if (!drawerState.animationInProgress && drawerState.anchoredDraggableState.currentValue == DrawerValue.Closed && drawerState.anchoredDraggableState.targetValue == DrawerValue.Closed) {
                         onDismiss()
                     }
 
@@ -191,24 +183,16 @@ fun BottomDrawer(
                             originalSize
                         } else {
                             min(
-                                originalSize,
-                                maxOpenHeight
+                                originalSize, maxOpenHeight
                             )
                         }
                     }
                 }
                 .bottomDrawerAnchoredDraggable(
-                    drawerState,
-                    slideOver,
-                    maxOpenHeight,
-                    fullHeight,
-                    drawerHeight.value
+                    drawerState, slideOver, maxOpenHeight, fullHeight, drawerHeight.value
                 )
                 .drawerHeight(
-                    slideOver,
-                    maxOpenHeight,
-                    fullHeight,
-                    drawerState
+                    slideOver, maxOpenHeight, fullHeight, drawerState
                 )
                 .shadow(drawerElevation)
                 .clip(drawerShape)
@@ -250,7 +234,9 @@ fun BottomDrawer(
                                 state = rememberDraggableState { delta ->
                                     if (!enableSwipeDismiss && drawerStateOffset >= maxOpenHeight) {
                                         if (delta < 0) {
-                                            drawerState.anchoredDraggableState.dispatchRawDelta(delta)
+                                            drawerState.anchoredDraggableState.dispatchRawDelta(
+                                                delta
+                                            )
                                         }
                                     } else {
                                         drawerState.anchoredDraggableState.dispatchRawDelta(delta)
@@ -262,10 +248,8 @@ fun BottomDrawer(
                                             velocity
                                         )
                                         if (drawerState.isClosed) {
-                                            if (enableSwipeDismiss)
-                                                onDismiss()
-                                            else
-                                                scope.launch { drawerState.open() }
+                                            if (enableSwipeDismiss) onDismiss()
+                                            else scope.launch { drawerState.open() }
                                         }
                                     }
                                 },
@@ -274,17 +258,15 @@ fun BottomDrawer(
                     ) {
                         val collapsed = LocalContext.current.resources.getString(R.string.collapsed)
                         val expanded = LocalContext.current.resources.getString(R.string.expanded)
-                        val accessibilityManager  = LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
-                        Icon(
-                            painterResource(id = R.drawable.ic_drawer_handle),
+                        val accessibilityManager =
+                            LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+                        Icon(painterResource(id = R.drawable.ic_drawer_handle),
                             contentDescription = LocalContext.current.resources.getString(R.string.drag_handle),
                             tint = drawerHandleColor,
-                            modifier = Modifier
-                                .clickable(
+                            modifier = Modifier.clickable(
                                     enabled = drawerState.hasExpandedState,
                                     role = Role.Button,
-                                    onClickLabel =
-                                    if (drawerState.anchoredDraggableState.currentValue == DrawerValue.Expanded) {
+                                    onClickLabel = if (drawerState.anchoredDraggableState.currentValue == DrawerValue.Expanded) {
                                         LocalContext.current.resources.getString(R.string.collapse)
                                     } else {
                                         if (drawerState.hasExpandedState && !drawerState.isClosed) LocalContext.current.resources.getString(
@@ -299,9 +281,10 @@ fun BottomDrawer(
                                         ) {
                                             scope.launch { drawerState.open() }
                                             accessibilityManager?.let { manager ->
-                                                if(manager.isEnabled){
+                                                if (manager.isEnabled) {
                                                     val event = AccessibilityEvent.obtain(
-                                                        AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                        AccessibilityEvent.TYPE_ANNOUNCEMENT
+                                                    ).apply {
                                                         text.add(collapsed)
                                                     }
                                                     manager.sendAccessibilityEvent(event)
@@ -312,9 +295,10 @@ fun BottomDrawer(
                                         if (drawerState.confirmValueChange(DrawerValue.Expanded)) {
                                             scope.launch { drawerState.expand() }
                                             accessibilityManager?.let { manager ->
-                                                if(manager.isEnabled){
+                                                if (manager.isEnabled) {
                                                     val event = AccessibilityEvent.obtain(
-                                                        AccessibilityEvent.TYPE_ANNOUNCEMENT).apply {
+                                                        AccessibilityEvent.TYPE_ANNOUNCEMENT
+                                                    ).apply {
                                                         text.add(expanded)
                                                     }
                                                     manager.sendAccessibilityEvent(event)
@@ -322,12 +306,12 @@ fun BottomDrawer(
                                             }
                                         }
                                     }
-                                }
-                        )
+                                })
                     }
                 }
-                Column(modifier = Modifier
-                    .testTag(DRAWER_CONTENT_TAG), content = { drawerContent() })
+                Column(
+                    modifier = Modifier.testTag(DRAWER_CONTENT_TAG),
+                    content = { drawerContent() })
             }
         }
     }
@@ -348,8 +332,7 @@ private fun Modifier.bottomDrawerAnchoredDraggable(
             val drawerStateAnchors = drawerState.anchoredDraggableState.anchors
             val anchors: DraggableAnchors<DrawerValue> =
                 if (drawerHeight <= maxOpenHeight) {  // when contentHeight is less than maxOpenHeight
-                    if (drawerStateAnchors.hasAnchorFor(DrawerValue.Expanded)) {
-                        /*
+                    if (drawerStateAnchors.hasAnchorFor(DrawerValue.Expanded)) {/*
                         *For dynamic content when drawerHeight was previously greater than maxOpenHeight and now less than maxOpenHEight
                         *The old anchors won't have Open state, so we need to continue with Expanded state.
                         */
@@ -366,8 +349,7 @@ private fun Modifier.bottomDrawerAnchoredDraggable(
                 } else {
                     if (drawerState.expandable) {
                         if (drawerState.skipOpenState) {
-                            if (drawerStateAnchors.hasAnchorFor(DrawerValue.Open)) {
-                                /*
+                            if (drawerStateAnchors.hasAnchorFor(DrawerValue.Open)) {/*
                                 *For dynamic content when drawerHeight was previously less than maxOpenHeight and now greater than maxOpenHEight
                                 *The old anchors won't have Expanded state, so we need to continue with Open state.
                                 */

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/BottomDrawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/BottomDrawer.kt
@@ -52,6 +52,7 @@ import com.microsoft.fluentui.compose.PostDownNestedScrollConnection
 import com.microsoft.fluentui.compose.anchoredDraggable
 import com.microsoft.fluentui.drawer.R
 import com.microsoft.fluentui.theme.token.Icon
+import com.microsoft.fluentui.tokenized.Scrim
 import com.microsoft.fluentui.tokenized.calculateFraction
 import com.microsoft.fluentui.util.pxToDp
 import kotlinx.coroutines.launch
@@ -148,7 +149,8 @@ fun BottomDrawer(
             },
             color = if (scrimVisible) scrimColor else Color.Transparent,
             preventDismissalOnScrimClick = preventDismissalOnScrimClick,
-            onScrimClick = onScrimClick
+            onScrimClick = onScrimClick,
+            tag = DRAWER_SCRIM_TAG
         )
         val configuration = LocalConfiguration.current
         Box(

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -286,38 +286,6 @@ class DrawerPositionProvider(val offset: IntOffset?) : PopupPositionProvider {
     }
 }
 
-@Composable
-fun Scrim(
-    open: Boolean,
-    onClose: () -> Unit,
-    fraction: () -> Float,
-    color: Color,
-    preventDismissalOnScrimClick: Boolean = false,
-    onScrimClick: () -> Unit = {},
-) {
-    val dismissDrawer = if (open) {
-        Modifier.pointerInput(onClose) {
-            detectTapGestures {
-                if (!preventDismissalOnScrimClick) {
-                    onClose()
-                }
-                onScrimClick() //this function runs post onClose() so that the drawer is closed before the callback is invoked
-            }
-        }
-    } else {
-        Modifier
-    }
-
-    Canvas(
-        Modifier
-            .fillMaxSize()
-            .then(dismissDrawer)
-            .testTag(DRAWER_SCRIM_TAG)
-    ) {
-        drawRect(color, alpha = fraction())
-    }
-}
-
 /**
  *
  * Drawer block interaction with the rest of an app’s content with a scrim.

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/Drawer.kt
@@ -64,20 +64,20 @@ class DrawerState(
     internal var velocityThreshold: () -> Float = { VelocityThreshold }
     internal var positionalThreshold: (Float) -> Float = { PositionalThreshold }
 
-    internal val anchoredDraggableState: AnchoredDraggableState<DrawerValue> = AnchoredDraggableState(
-        initialValue,
-        anchors = DraggableAnchors {},
-        positionalThreshold,
-        velocityThreshold,
-        animationSpec = AnimationSpec,
-        confirmValueChange = confirmValueChange
-    )
+    internal val anchoredDraggableState: AnchoredDraggableState<DrawerValue> =
+        AnchoredDraggableState(
+            initialValue,
+            anchors = DraggableAnchors {},
+            positionalThreshold,
+            velocityThreshold,
+            animationSpec = AnimationSpec,
+            confirmValueChange = confirmValueChange
+        )
 
     init {
         if (skipOpenState) {
             require(anchoredDraggableState.currentValue != DrawerValue.Open) {
-                "The initial value must not be set to Open if skipOpenState is set to" +
-                        " true."
+                "The initial value must not be set to Open if skipOpenState is set to" + " true."
             }
             require(expandable) {
                 "Invalid state: expandable = false & skipOpenState = true"
@@ -85,8 +85,7 @@ class DrawerState(
         }
         if (!expandable) {
             require(initialValue != DrawerValue.Expanded) {
-                "The initial value must not be set to Expanded if expandable is set to" +
-                        " false."
+                "The initial value must not be set to Expanded if expandable is set to" + " false."
             }
         }
     }
@@ -131,8 +130,7 @@ class DrawerState(
         animationInProgress = true
         do {
             delay(50)
-        } while (!anchoredDraggableState.anchorsFilled)
-        /*
+        } while (!anchoredDraggableState.anchorsFilled)/*
        * first try to open the drawer
        * if not possible then try to expand the drawer
         */
@@ -144,11 +142,10 @@ class DrawerState(
         if (targetValue != anchoredDraggableState.currentValue) {
             try {
                 anchoredDraggableState.animateTo(targetValue, velocityThreshold())
-            } catch(e: Exception) {
+            } catch (e: Exception) {
                 anchoredDraggableState.animateTo(targetValue = targetValue, VelocityThreshold)
-            }
-            finally {
-                    animationInProgress = false
+            } finally {
+                animationInProgress = false
             }
         } else {
             animationInProgress = false
@@ -187,8 +184,7 @@ class DrawerState(
         animationInProgress = true
         do {
             delay(50)
-        } while (!anchoredDraggableState.anchorsFilled)
-        /*
+        } while (!anchoredDraggableState.anchorsFilled)/*
         * first try to expand the drawer
         * if not possible then try to open the drawer
          */
@@ -220,18 +216,15 @@ class DrawerState(
             expandable: Boolean,
             skipOpenState: Boolean,
             confirmValueChange: (DrawerValue) -> Boolean
-        ) =
-            Saver<DrawerState, DrawerValue>(
-                save = { it.anchoredDraggableState.currentValue },
-                restore = {
-                    DrawerState(
-                        initialValue = it,
-                        expandable = expandable,
-                        skipOpenState = skipOpenState,
-                        confirmValueChange = confirmValueChange
-                    )
-                }
-            )
+        ) = Saver<DrawerState, DrawerValue>(save = { it.anchoredDraggableState.currentValue },
+            restore = {
+                DrawerState(
+                    initialValue = it,
+                    expandable = expandable,
+                    skipOpenState = skipOpenState,
+                    confirmValueChange = confirmValueChange
+                )
+            })
     }
 }
 
@@ -243,9 +236,7 @@ class DrawerState(
 fun rememberDrawerState(confirmValueChange: (DrawerValue) -> Boolean = { true }): DrawerState {
     return rememberSaveable(
         saver = DrawerState.Saver(
-            expandable = true,
-            skipOpenState = false,
-            confirmValueChange = confirmValueChange
+            expandable = true, skipOpenState = false, confirmValueChange = confirmValueChange
         )
     ) {
         DrawerState(
@@ -265,7 +256,10 @@ fun rememberBottomDrawerState(
     confirmValueChange: (DrawerValue) -> Boolean = { true }
 ): DrawerState {
     return rememberSaveable(
-        initialValue, confirmValueChange, expandable, skipOpenState,
+        initialValue,
+        confirmValueChange,
+        expandable,
+        skipOpenState,
         saver = DrawerState.Saver(expandable, skipOpenState, confirmValueChange)
     ) {
         DrawerState(initialValue, confirmValueChange, expandable, skipOpenState)
@@ -333,29 +327,25 @@ fun Drawer(
             onDismissRequest = close,
             popupPositionProvider = popupPositionProvider,
             properties = PopupProperties(focusable = true, clippingEnabled = (offset == null))
-        )
-        {
-            val drawerShape: Shape =
-                when (behaviorType) {
-                    BehaviorType.BOTTOM, BehaviorType.BOTTOM_SLIDE_OVER -> RoundedCornerShape(
-                        topStart = tokens.borderRadius(drawerInfo),
-                        topEnd = tokens.borderRadius(drawerInfo)
-                    )
+        ) {
+            val drawerShape: Shape = when (behaviorType) {
+                BehaviorType.BOTTOM, BehaviorType.BOTTOM_SLIDE_OVER -> RoundedCornerShape(
+                    topStart = tokens.borderRadius(drawerInfo),
+                    topEnd = tokens.borderRadius(drawerInfo)
+                )
 
-                    BehaviorType.TOP -> RoundedCornerShape(
-                        bottomStart = tokens.borderRadius(drawerInfo),
-                        bottomEnd = tokens.borderRadius(drawerInfo)
-                    )
+                BehaviorType.TOP -> RoundedCornerShape(
+                    bottomStart = tokens.borderRadius(drawerInfo),
+                    bottomEnd = tokens.borderRadius(drawerInfo)
+                )
 
-                    else -> RoundedCornerShape(tokens.borderRadius(drawerInfo))
-                }
+                else -> RoundedCornerShape(tokens.borderRadius(drawerInfo))
+            }
             val drawerElevation: Dp = tokens.elevation(drawerInfo)
-            val drawerBackgroundColor: Brush =
-                tokens.backgroundBrush(drawerInfo)
+            val drawerBackgroundColor: Brush = tokens.backgroundBrush(drawerInfo)
             val drawerHandleColor: Color = tokens.handleColor(drawerInfo)
             val scrimOpacity: Float = tokens.scrimOpacity(drawerInfo)
-            val scrimColor: Color =
-                tokens.scrimColor(drawerInfo).copy(alpha = scrimOpacity)
+            val scrimColor: Color = tokens.scrimColor(drawerInfo).copy(alpha = scrimOpacity)
 
             when (behaviorType) {
                 BehaviorType.BOTTOM, BehaviorType.BOTTOM_SLIDE_OVER -> BottomDrawer(
@@ -455,27 +445,20 @@ fun BottomDrawer(
                 scope.launch { drawerState.close() }
             }
         }
-        val behaviorType =
-            if (slideOver) BehaviorType.BOTTOM_SLIDE_OVER else BehaviorType.BOTTOM
+        val behaviorType = if (slideOver) BehaviorType.BOTTOM_SLIDE_OVER else BehaviorType.BOTTOM
         val drawerInfo = DrawerInfo(type = behaviorType)
         ModalPopup(
-            onDismissRequest = close,
-            windowInsetsType = windowInsetsType
-        )
-        {
-            val drawerShape: Shape =
-                RoundedCornerShape(
-                    topStart = tokens.borderRadius(drawerInfo),
-                    topEnd = tokens.borderRadius(drawerInfo)
-                )
+            onDismissRequest = close, windowInsetsType = windowInsetsType
+        ) {
+            val drawerShape: Shape = RoundedCornerShape(
+                topStart = tokens.borderRadius(drawerInfo), topEnd = tokens.borderRadius(drawerInfo)
+            )
 
             val drawerElevation: Dp = tokens.elevation(drawerInfo)
-            val drawerBackgroundColor: Brush =
-                tokens.backgroundBrush(drawerInfo)
+            val drawerBackgroundColor: Brush = tokens.backgroundBrush(drawerInfo)
             val drawerHandleColor: Color = tokens.handleColor(drawerInfo)
             val scrimOpacity: Float = tokens.scrimOpacity(drawerInfo)
-            val scrimColor: Color =
-                tokens.scrimColor(drawerInfo).copy(alpha = scrimOpacity)
+            val scrimColor: Color = tokens.scrimColor(drawerInfo).copy(alpha = scrimOpacity)
             BottomDrawer(
                 modifier = modifier,
                 drawerState = drawerState,

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/HorizontalDrawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/HorizontalDrawer.kt
@@ -90,16 +90,13 @@ fun HorizontalDrawer(
         //Hack to get exact drawerHeight wrt to content.
         val visible = remember { mutableStateOf(true) }
         if (visible.value) {
-            Box(
-                modifier = Modifier
-                    .layout { measurable, constraints ->
-                        val placeable = measurable.measure(constraints)
-                        layout(placeable.width, placeable.height) {
-                            drawerWidth = placeable.width.toFloat()
-                            visible.value = false
-                        }
+            Box(modifier = Modifier.layout { measurable, constraints ->
+                    val placeable = measurable.measure(constraints)
+                    layout(placeable.width, placeable.height) {
+                        drawerWidth = placeable.width.toFloat()
+                        visible.value = false
                     }
-            ) {
+                }) {
                 drawerContent()
             }
         } else {
@@ -117,7 +114,7 @@ fun HorizontalDrawer(
             drawerState.anchoredDraggableState.updateAnchors(anchors)
             val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
             val offset = drawerState.anchoredDraggableState.offset
-            drawerState.positionalThreshold =  { fl: Float -> drawerWidth / 2 }
+            drawerState.positionalThreshold = { fl: Float -> drawerWidth / 2 }
             val drawerVelocityThreshold = convertDpToFloat(DrawerVelocityThreshold)
             drawerState.velocityThreshold = { drawerVelocityThreshold }
             Scrim(
@@ -134,13 +131,12 @@ fun HorizontalDrawer(
 
             Box(
                 modifier = with(LocalDensity.current) {
-                    Modifier
-                        .sizeIn(
-                            minWidth = modalDrawerConstraints.minWidth.toDp(),
-                            minHeight = modalDrawerConstraints.minHeight.toDp(),
-                            maxWidth = modalDrawerConstraints.maxWidth.toDp(),
-                            maxHeight = modalDrawerConstraints.maxHeight.toDp()
-                        )
+                    Modifier.sizeIn(
+                        minWidth = modalDrawerConstraints.minWidth.toDp(),
+                        minHeight = modalDrawerConstraints.minHeight.toDp(),
+                        maxWidth = modalDrawerConstraints.maxWidth.toDp(),
+                        maxHeight = modalDrawerConstraints.maxHeight.toDp()
+                    )
                 }
                     .offset { IntOffset(offset.roundToInt(), 0) }
                     .padding(

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/HorizontalDrawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/HorizontalDrawer.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.token.controlTokens.BehaviorType
+import com.microsoft.fluentui.tokenized.Scrim
 import com.microsoft.fluentui.tokenized.calculateFraction
 import com.microsoft.fluentui.util.dpToPx
 import com.microsoft.fluentui.util.pxToDp
@@ -127,7 +128,8 @@ fun HorizontalDrawer(
                 },
                 color = if (scrimVisible) scrimColor else Color.Transparent,
                 preventDismissalOnScrimClick = preventDismissalOnScrimClick,
-                onScrimClick = onScrimClick
+                onScrimClick = onScrimClick,
+                tag = DRAWER_SCRIM_TAG
             )
 
             Box(

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/TopDrawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/TopDrawer.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.microsoft.fluentui.drawer.R
 import com.microsoft.fluentui.theme.token.Icon
+import com.microsoft.fluentui.tokenized.Scrim
 import com.microsoft.fluentui.tokenized.calculateFraction
 import com.microsoft.fluentui.util.dpToPx
 import com.microsoft.fluentui.util.pxToDp
@@ -111,7 +112,8 @@ fun TopDrawer(
             },
             color = if (scrimVisible) scrimColor else Color.Transparent,
             preventDismissalOnScrimClick = preventDismissalOnScrimClick,
-            onScrimClick = onScrimClick
+            onScrimClick = onScrimClick,
+            tag= DRAWER_SCRIM_TAG
         )
 
         Box(

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/TopDrawer.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/drawer/TopDrawer.kt
@@ -68,17 +68,14 @@ fun TopDrawer(
         val fullHeight = constraints.maxHeight.toFloat()
         var drawerHeight by remember(fullHeight) { mutableStateOf(fullHeight) }
 
-        Box(
-            modifier = Modifier
-                .alpha(0f)
-                .layout { measurable, constraints ->
-                    val placeable = measurable.measure(constraints)
-                    layout(placeable.width, placeable.height) {
-                        drawerHeight =
-                            placeable.height.toFloat() + dpToPx(DrawerHandleHeightOffset)
-                    }
+        Box(modifier = Modifier
+            .alpha(0f)
+            .layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                layout(placeable.width, placeable.height) {
+                    drawerHeight = placeable.height.toFloat() + dpToPx(DrawerHandleHeightOffset)
                 }
-        ) {
+            }) {
             drawerContent()
         }
         val maxOpenHeight = fullHeight * DrawerOpenFraction
@@ -96,10 +93,8 @@ fun TopDrawer(
         drawerState.anchoredDraggableState.updateAnchors(anchors)
 
         val drawerConstraints = with(LocalDensity.current) {
-            Modifier
-                .sizeIn(
-                    maxWidth = constraints.maxWidth.toDp(),
-                    maxHeight = constraints.maxHeight.toDp()
+            Modifier.sizeIn(
+                    maxWidth = constraints.maxWidth.toDp(), maxHeight = constraints.maxHeight.toDp()
                 )
         }
         val drawerStateOffset = drawerState.anchoredDraggableState.offset
@@ -113,7 +108,7 @@ fun TopDrawer(
             color = if (scrimVisible) scrimColor else Color.Transparent,
             preventDismissalOnScrimClick = preventDismissalOnScrimClick,
             onScrimClick = onScrimClick,
-            tag= DRAWER_SCRIM_TAG
+            tag = DRAWER_SCRIM_TAG
         )
 
         Box(
@@ -150,8 +145,7 @@ fun TopDrawer(
                         bottom.linkTo(drawerHandleConstrain.top)
                     }
                     .focusTarget()
-                    .testTag(DRAWER_CONTENT_TAG), content = { drawerContent() }
-                )
+                    .testTag(DRAWER_CONTENT_TAG), content = { drawerContent() })
                 Column(horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
                         .constrainAs(drawerHandleConstrain) {


### PR DESCRIPTION
### Problem 
This PR fixes multiple problems - 
1. Scrim was not getting visible and was not working as expected.
2. no way was present to perform some action after dismiss
3. Preventing dismissal on scrim click was not available.
4. Scrim functionality was not centralized in the drawer module. 
5. expand button was unusable in the demo bottom sheet activity
6. Peek height option in demo app was always disabled

### Root cause 
1. Fraction calculation was not happening correctly, hence scrim was not getting visible.
2. onDismiss callback was not present in bottom sheet arguments
3. preventing dismissal on scrim click option was also not available
4. Bottom sheet and Drawer were having their own implementations for Scrim
5. This was because the expand button was getting activated only when the drawer is visible, and in that case, due to scrim the button was getting unusable.
6. Peek height was always disabled because condition for enabling was when bottom sheet is visible and in that scenario due to scrim, the button becomes unusable

### Fix
1. Fixed the fraction calculation, now scrim is visible.
2. Added onDismiss callback
3. Added preventDismissalOnScrimClick option
4. Centralized Scrim across drawer module.
5. Added the expand button to be always visible and removed the hide button as it was not required.
6. Updated the condition so that the peek height option remains visible when the bottom sheet is hidden

### Validations

After

![bottom sheet ](https://github.com/user-attachments/assets/aa14eaf9-23d7-48ce-a337-6d4834736d38)
