### PR TITLE
Center-aligned NavigationBar title with leading left Avatar icon button

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Email
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -34,7 +36,9 @@ import com.microsoft.fluentui.theme.token.FluentColor
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.Icon
+import com.microsoft.fluentui.theme.token.controlTokens.AppBarInfo
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
+import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.TitleAlignment
@@ -57,6 +61,15 @@ const val APP_BAR_SUBTITLE_PARAM = "App Bar Subtitle Param"
 const val APP_BAR_STYLE_PARAM = "App Bar AppBar Style Param"
 const val APP_BAR_BUTTONBAR_PARAM = "App Bar ButtonBar Param"
 const val APP_BAR_SEARCHBAR_PARAM = "App Bar SearchBar Param"
+const val APP_BAR_LOGO_PARAM = "App Bar Logo Param"
+const val APP_BAR_NAVIGATION_ICON_PARAM = "App Bar Navigation Icon Param"
+
+class AlignedAppBarTokens(private var titleAlignment: Alignment.Horizontal) : AppBarTokens() {
+    @Composable
+    override fun titleAlignment(info: AppBarInfo): Alignment.Horizontal {
+        return titleAlignment
+    }
+}
 
 class V2AppBarActivity : V2DemoActivity() {
     init {
@@ -82,6 +95,7 @@ class V2AppBarActivity : V2DemoActivity() {
             var enableBottomBorder: Boolean by rememberSaveable { mutableStateOf(true) }
             var titleAlignment: TitleAlignment by rememberSaveable { mutableStateOf(TitleAlignment.Start) }
             var yAxisDelta: Float by rememberSaveable { mutableStateOf(1.0F) }
+            var enableLogo: Boolean by rememberSaveable { mutableStateOf(true) }
 
             Column(modifier = Modifier.pointerInput(Unit) {
                 detectDragGestures { _, distance ->
@@ -239,6 +253,23 @@ class V2AppBarActivity : V2DemoActivity() {
                                 )
                             }
                         )
+
+                        ListItem.Item(
+                            text = LocalContext.current.resources.getString(R.string.left_logo),
+                            subText = if (enableLogo)
+                                LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                            else
+                                LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                            trailingAccessoryContent = {
+                                ToggleSwitch(
+                                    onValueChange = {
+                                        enableLogo = !enableLogo
+                                    },
+                                    modifier = Modifier.testTag(APP_BAR_LOGO_PARAM),
+                                    checkedState = enableLogo
+                                )
+                            }
+                        )
                     }
                 }
 
@@ -295,18 +326,23 @@ class V2AppBarActivity : V2DemoActivity() {
                         flipOnRtl = true
                     ),
                     subTitle = subtitle,
-                    logo = {
-                        Avatar(
-                            Person(
-                                "Allan",
-                                "Munger",
-                                status = AvatarStatus.DND,
-                                isActive = true
-                            ),
-                            enablePresence = true,
-                            size = AvatarSize.Size32
-                        )
-                    },
+                    appBarTokens = if (titleAlignment == TitleAlignment.Center) AlignedAppBarTokens(
+                        Alignment.CenterHorizontally
+                    ) else null,
+                    logo = if (enableLogo) {
+                        {
+                            Avatar(
+                                Person(
+                                    "Allan",
+                                    "Munger",
+                                    status = AvatarStatus.DND,
+                                    isActive = true
+                                ),
+                                enablePresence = true,
+                                size = AvatarSize.Size32
+                            )
+                        }
+                    } else null,
                     postTitleIcon = FluentIcon(
                         ListItemIcons.Chevron,
                         contentDescription = LocalContext.current.resources.getString(R.string.fluentui_chevron),
@@ -348,7 +384,6 @@ class V2AppBarActivity : V2DemoActivity() {
                     } else null,
                     appTitleDelta = appTitleDelta,
                     accessoryDelta = accessoryDelta,
-                    titleAlignment = titleAlignment,
                     rightAccessoryView = {
                         Icon(
                             Icons.Filled.Add,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -38,7 +38,6 @@ import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
-import com.microsoft.fluentui.theme.token.controlTokens.TitleAlignment
 import com.microsoft.fluentui.tokenized.AppBar
 import com.microsoft.fluentui.tokenized.SearchBar
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
@@ -59,6 +58,11 @@ const val APP_BAR_STYLE_PARAM = "App Bar AppBar Style Param"
 const val APP_BAR_BUTTONBAR_PARAM = "App Bar ButtonBar Param"
 const val APP_BAR_SEARCHBAR_PARAM = "App Bar SearchBar Param"
 const val APP_BAR_LOGO_PARAM = "App Bar Logo Param"
+
+enum class TitleAlignment {
+    Start,
+    Center
+}
 
 class V2AppBarActivity : V2DemoActivity() {
     init {

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Email
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -36,9 +35,7 @@ import com.microsoft.fluentui.theme.token.FluentColor
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.Icon
-import com.microsoft.fluentui.theme.token.controlTokens.AppBarInfo
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
-import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.TitleAlignment
@@ -62,14 +59,6 @@ const val APP_BAR_STYLE_PARAM = "App Bar AppBar Style Param"
 const val APP_BAR_BUTTONBAR_PARAM = "App Bar ButtonBar Param"
 const val APP_BAR_SEARCHBAR_PARAM = "App Bar SearchBar Param"
 const val APP_BAR_LOGO_PARAM = "App Bar Logo Param"
-const val APP_BAR_NAVIGATION_ICON_PARAM = "App Bar Navigation Icon Param"
-
-class AlignedAppBarTokens(private var titleAlignment: Alignment.Horizontal) : AppBarTokens() {
-    @Composable
-    override fun titleAlignment(info: AppBarInfo): Alignment.Horizontal {
-        return titleAlignment
-    }
-}
 
 class V2AppBarActivity : V2DemoActivity() {
     init {
@@ -326,9 +315,7 @@ class V2AppBarActivity : V2DemoActivity() {
                         flipOnRtl = true
                     ),
                     subTitle = subtitle,
-                    appBarTokens = if (titleAlignment == TitleAlignment.Center) AlignedAppBarTokens(
-                        Alignment.CenterHorizontally
-                    ) else null,
+                    titleAlignment = if (titleAlignment == TitleAlignment.Center) Alignment.CenterHorizontally else Alignment.Start,
                     logo = if (enableLogo) {
                         {
                             Avatar(

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -345,7 +345,10 @@ class V2AppBarActivity : V2DemoActivity() {
                                     isActive = true
                                 ),
                                 enablePresence = true,
-                                size = AvatarSize.Size32
+                                size = AvatarSize.Size32,
+                                modifier = if (!showNavigationIcon) {
+                                    Modifier.padding(start = 16.dp)
+                                } else Modifier
                             )
                         }
                     } else null,

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -58,11 +58,8 @@ const val APP_BAR_STYLE_PARAM = "App Bar AppBar Style Param"
 const val APP_BAR_BUTTONBAR_PARAM = "App Bar ButtonBar Param"
 const val APP_BAR_SEARCHBAR_PARAM = "App Bar SearchBar Param"
 const val APP_BAR_LOGO_PARAM = "App Bar Logo Param"
-
-enum class TitleAlignment {
-    Start,
-    Center
-}
+const val APP_BAR_CENTER_ALIGN_PARAM = "App Bar Center Align Param"
+const val APP_BAR_NAVIGATION_ICON_PARAM = "App Bar Navigation Icon Param"
 
 class V2AppBarActivity : V2DemoActivity() {
     init {
@@ -86,7 +83,8 @@ class V2AppBarActivity : V2DemoActivity() {
             var enableSearchBar: Boolean by rememberSaveable { mutableStateOf(false) }
             var enableButtonBar: Boolean by rememberSaveable { mutableStateOf(false) }
             var enableBottomBorder: Boolean by rememberSaveable { mutableStateOf(true) }
-            var titleAlignment: TitleAlignment by rememberSaveable { mutableStateOf(TitleAlignment.Start) }
+            var centerAlignAppBar: Boolean by rememberSaveable { mutableStateOf(false) }
+            var showNavigationIcon: Boolean by rememberSaveable { mutableStateOf(true) }
             var yAxisDelta: Float by rememberSaveable { mutableStateOf(1.0F) }
             var enableLogo: Boolean by rememberSaveable { mutableStateOf(true) }
 
@@ -128,24 +126,6 @@ class V2AppBarActivity : V2DemoActivity() {
                                     text = LocalContext.current.resources.getString(R.string.fluentui_search),
                                     onClick = { searchMode = !searchMode },
                                     selected = searchMode
-                                )
-                            ), style = style,
-                            showBackground = true
-                        )
-
-                        ListItem.Header(LocalContext.current.resources.getString(R.string.title_alignment))
-
-                        PillBar(
-                            mutableListOf(
-                                PillMetaData(
-                                    text = LocalContext.current.resources.getString(R.string.title_alignment_start),
-                                    onClick = { titleAlignment = TitleAlignment.Start },
-                                    selected = titleAlignment == TitleAlignment.Start
-                                ),
-                                PillMetaData(
-                                    text = LocalContext.current.resources.getString(R.string.title_alignment_center),
-                                    onClick = { titleAlignment = TitleAlignment.Center },
-                                    selected = titleAlignment == TitleAlignment.Center
                                 )
                             ), style = style,
                             showBackground = true
@@ -263,6 +243,39 @@ class V2AppBarActivity : V2DemoActivity() {
                                 )
                             }
                         )
+
+                        ListItem.Item(
+                            text = LocalContext.current.resources.getString(R.string.navigation_icon),
+                            subText = if (showNavigationIcon)
+                                LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                            else
+                                LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                            trailingAccessoryContent = {
+                                ToggleSwitch(
+                                    onValueChange = {
+                                        showNavigationIcon = !showNavigationIcon
+                                    },
+                                    modifier = Modifier.testTag(APP_BAR_NAVIGATION_ICON_PARAM),
+                                    checkedState = showNavigationIcon
+                                )
+                            }
+                        )
+                        ListItem.Item(
+                            text = LocalContext.current.resources.getString(R.string.center_title_alignment),
+                            subText = if (centerAlignAppBar)
+                                LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                            else
+                                LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                            trailingAccessoryContent = {
+                                ToggleSwitch(
+                                    onValueChange = {
+                                        centerAlignAppBar = !centerAlignAppBar
+                                    },
+                                    modifier = Modifier.testTag(APP_BAR_CENTER_ALIGN_PARAM),
+                                    checkedState = centerAlignAppBar
+                                )
+                            }
+                        )
                     }
                 }
 
@@ -306,20 +319,22 @@ class V2AppBarActivity : V2DemoActivity() {
 
                 AppBar(
                     title = "Fluent UI Demo",
-                    navigationIcon = FluentIcon(
-                        SearchBarIcons.Arrowback,
-                        contentDescription = "Navigate Back",
-                        onClick = {
-                            Toast.makeText(
-                                context,
-                                "Navigation Icon pressed",
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        },
-                        flipOnRtl = true
-                    ),
+                    navigationIcon = if (showNavigationIcon) {
+                        FluentIcon(
+                            SearchBarIcons.Arrowback,
+                            contentDescription = "Navigate Back",
+                            onClick = {
+                                Toast.makeText(
+                                    context,
+                                    "Navigation Icon pressed",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            },
+                            flipOnRtl = true
+                        )
+                    } else null,
                     subTitle = subtitle,
-                    titleAlignment = if (titleAlignment == TitleAlignment.Center) Alignment.CenterHorizontally else Alignment.Start,
+                    centerAlignAppBar = centerAlignAppBar,
                     logo = if (enableLogo) {
                         {
                             Avatar(

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -37,6 +37,7 @@ import com.microsoft.fluentui.theme.token.Icon
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
+import com.microsoft.fluentui.theme.token.controlTokens.TitleAlignment
 import com.microsoft.fluentui.tokenized.AppBar
 import com.microsoft.fluentui.tokenized.SearchBar
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
@@ -79,6 +80,7 @@ class V2AppBarActivity : V2DemoActivity() {
             var enableSearchBar: Boolean by rememberSaveable { mutableStateOf(false) }
             var enableButtonBar: Boolean by rememberSaveable { mutableStateOf(false) }
             var enableBottomBorder: Boolean by rememberSaveable { mutableStateOf(true) }
+            var titleAlignment: TitleAlignment by rememberSaveable { mutableStateOf(TitleAlignment.Start) }
             var yAxisDelta: Float by rememberSaveable { mutableStateOf(1.0F) }
 
             Column(modifier = Modifier.pointerInput(Unit) {
@@ -97,6 +99,7 @@ class V2AppBarActivity : V2DemoActivity() {
                     chevronOrientation = ChevronOrientation(90f, 0f),
                 ) {
                     Column {
+                        ListItem.Header(LocalContext.current.resources.getString(R.string.app_bar_size))
                         PillBar(
                             mutableListOf(
                                 PillMetaData(
@@ -118,6 +121,24 @@ class V2AppBarActivity : V2DemoActivity() {
                                     text = LocalContext.current.resources.getString(R.string.fluentui_search),
                                     onClick = { searchMode = !searchMode },
                                     selected = searchMode
+                                )
+                            ), style = style,
+                            showBackground = true
+                        )
+
+                        ListItem.Header(LocalContext.current.resources.getString(R.string.title_alignment))
+
+                        PillBar(
+                            mutableListOf(
+                                PillMetaData(
+                                    text = LocalContext.current.resources.getString(R.string.title_alignment_start),
+                                    onClick = { titleAlignment = TitleAlignment.Start },
+                                    selected = titleAlignment == TitleAlignment.Start
+                                ),
+                                PillMetaData(
+                                    text = LocalContext.current.resources.getString(R.string.title_alignment_center),
+                                    onClick = { titleAlignment = TitleAlignment.Center },
+                                    selected = titleAlignment == TitleAlignment.Center
                                 )
                             ), style = style,
                             showBackground = true
@@ -327,6 +348,7 @@ class V2AppBarActivity : V2DemoActivity() {
                     } else null,
                     appTitleDelta = appTitleDelta,
                     accessoryDelta = accessoryDelta,
+                    titleAlignment = titleAlignment,
                     rightAccessoryView = {
                         Icon(
                             Icons.Filled.Add,

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -43,15 +43,16 @@
     <string name="app_bar_layout_navigation_icon_clicked">Navigation icon clicked.</string>
 
     <!-- Text for title alignment -->
-    <string name="title_alignment">Title alignment</string>
-    <string name="title_alignment_start">Start</string>
-    <string name="title_alignment_center">Center</string>
+    <string name="center_title_alignment">Center align app bar</string>
 
     <!-- Text for app bar size -->
     <string name="app_bar_size">App Bar size</string>
 
     <!-- Text for app bar left accessories -->
     <string name="left_logo">Left Logo</string>
+
+    <!-- Text for app bar navigation icon -->
+    <string name="navigation_icon">Navigation Icon</string>
 
     <!-- Icon labels -->
     <string name="app_bar_layout_menu_flag">Flag</string>

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
     <!-- Text for app bar size -->
     <string name="app_bar_size">App Bar size</string>
 
+    <!-- Text for app bar left accessories -->
+    <string name="left_logo">Left Logo</string>
+
     <!-- Icon labels -->
     <string name="app_bar_layout_menu_flag">Flag</string>
     <string name="app_bar_layout_menu_settings">Settings</string>

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -42,6 +42,14 @@
     <!-- Text that shows the action performed to the user -->
     <string name="app_bar_layout_navigation_icon_clicked">Navigation icon clicked.</string>
 
+    <!-- Text for title alignment -->
+    <string name="title_alignment">Title alignment</string>
+    <string name="title_alignment_start">Start</string>
+    <string name="title_alignment_center">Center</string>
+
+    <!-- Text for app bar size -->
+    <string name="app_bar_size">App Bar size</string>
+
     <!-- Icon labels -->
     <string name="app_bar_layout_menu_flag">Flag</string>
     <string name="app_bar_layout_menu_settings">Settings</string>

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -169,7 +169,6 @@ open class AppBarTokens : IControlToken, Parcelable {
             AppBarSize.Large -> FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Title1]
             AppBarSize.Medium -> FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Title2]
             AppBarSize.Small -> FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Body1Strong]
-            else -> TextStyle(fontSize = 0.sp)
         }
     }
 
@@ -203,7 +202,7 @@ open class AppBarTokens : IControlToken, Parcelable {
     @Composable
     open fun navigationIconPadding(info: AppBarInfo): PaddingValues {
         return when (info.appBarSize) {
-            AppBarSize.Large -> PaddingValues()
+            AppBarSize.Large -> PaddingValues(16.dp)
             AppBarSize.Medium -> PaddingValues(16.dp)
             AppBarSize.Small -> PaddingValues(16.dp)
         }
@@ -213,7 +212,7 @@ open class AppBarTokens : IControlToken, Parcelable {
     open fun textPadding(info: AppBarInfo): PaddingValues {
         return when (info.appBarSize) {
             AppBarSize.Large -> PaddingValues(start = 12.dp)
-            AppBarSize.Medium -> PaddingValues()
+            AppBarSize.Medium -> PaddingValues(start = 8.dp)
             AppBarSize.Small -> PaddingValues(start = 8.dp)
         }
     }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -65,11 +65,6 @@ open class AppBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun titleAlignment(info: AppBarInfo): Alignment.Horizontal {
-        return Alignment.Start
-    }
-
-    @Composable
     open fun navigationIconColor(info: AppBarInfo): Color {
         return when (info.style) {
             FluentStyle.Neutral ->

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -28,6 +28,11 @@ enum class AppBarSize {
     Small
 }
 
+enum class TitleAlignment {
+    Start,
+    Center
+}
+
 open class AppBarInfo(
     val style: FluentStyle = FluentStyle.Neutral,
     val appBarSize: AppBarSize = AppBarSize.Medium

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -29,11 +29,6 @@ enum class AppBarSize {
     Small
 }
 
-enum class TitleAlignment {
-    Start,
-    Center
-}
-
 open class AppBarInfo(
     val style: FluentStyle = FluentStyle.Neutral,
     val appBarSize: AppBarSize = AppBarSize.Medium

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AppBarTokens.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -61,6 +62,11 @@ open class AppBarTokens : IControlToken, Parcelable {
                     ).value(themeMode = FluentTheme.themeMode)
             }
         )
+    }
+
+    @Composable
+    open fun titleAlignment(info: AppBarInfo): Alignment.Horizontal {
+        return Alignment.Start
     }
 
     @Composable

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -35,6 +35,7 @@ import com.microsoft.fluentui.theme.token.*
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarInfo
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
+import com.microsoft.fluentui.theme.token.controlTokens.TitleAlignment
 
 /**
  * An app bar appears at the top of an app screen, below the status bar,
@@ -72,6 +73,7 @@ const val APP_BAR = "Fluent App bar"
 const val APP_BAR_SUBTITLE = "Fluent App bar Subtitle"
 const val APP_BAR_BOTTOM_BAR = "Fluent App bar Bottom bar"
 const val APP_BAR_SEARCH_BAR = "Fluent App bar Search bar"
+
 @OptIn(ExperimentalTextApi::class)
 @Composable
 fun AppBar(
@@ -95,7 +97,8 @@ fun AppBar(
     bottomBorder: Boolean = true,
     appTitleDelta: Float = 1.0F,
     accessoryDelta: Float = 1.0F,
-    appBarTokens: AppBarTokens? = null
+    appBarTokens: AppBarTokens? = null,
+    titleAlignment: TitleAlignment = TitleAlignment.Start
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -140,23 +143,23 @@ fun AppBar(
                     .fillMaxWidth()
                     .scale(scaleX = 1.0F, scaleY = appTitleDelta)
                     .alpha(if (appTitleDelta != 1.0F) appTitleDelta / 3 else 1.0F),
-                horizontalArrangement = Arrangement.Start,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (appBarSize != AppBarSize.Large && navigationIcon.isIconAvailable()) {
                     Icon(
                         navigationIcon,
                         modifier =
-                        Modifier.then(
-                            if(navigationIcon.onClick != null)
-                                Modifier.clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = rememberRipple(color = token.navigationIconRippleColor()),
-                                enabled = true,
-                                onClick = navigationIcon.onClick ?: {}
+                        Modifier
+                            .then(
+                                if (navigationIcon.onClick != null)
+                                    Modifier.clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = rememberRipple(color = token.navigationIconRippleColor()),
+                                        enabled = true,
+                                        onClick = navigationIcon.onClick ?: {}
+                                    )
+                                else Modifier
                             )
-                            else Modifier
-                        )
                             .padding(token.navigationIconPadding(appBarInfo))
                             .size(token.leftIconSize(appBarInfo)),
                         tint = token.navigationIconColor(appBarInfo)
@@ -185,7 +188,8 @@ fun AppBar(
                         modifier = Modifier
                             .weight(1F)
                             .padding(token.textPadding(appBarInfo))
-                            .testTag(APP_BAR_SUBTITLE)
+                            .testTag(APP_BAR_SUBTITLE),
+                        horizontalAlignment = if (titleAlignment == TitleAlignment.Center) Alignment.CenterHorizontally else Alignment.Start
                     ) {
                         Row(
                             modifier = Modifier
@@ -262,20 +266,26 @@ fun AppBar(
                         }
                     }
                 } else {
-                    BasicText(
-                        text = title,
+                    Column(
                         modifier = Modifier
                             .padding(token.textPadding(appBarInfo))
                             .weight(1F)
                             .semantics { heading() },
-                        style = titleTextStyle.merge(
-                            TextStyle(
-                                color = token.titleTextColor(appBarInfo)
-                            )
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                        horizontalAlignment = if (titleAlignment == TitleAlignment.Center) Alignment.CenterHorizontally else Alignment.Start
+                    ) {
+
+                        BasicText(
+                            text = title,
+                            style = titleTextStyle.merge(
+                                TextStyle(
+                                    color = token.titleTextColor(appBarInfo)
+                                )
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+
+                    }
                 }
 
                 if (rightAccessoryView != null) {

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -94,7 +94,8 @@ fun AppBar(
     bottomBorder: Boolean = true,
     appTitleDelta: Float = 1.0F,
     accessoryDelta: Float = 1.0F,
-    appBarTokens: AppBarTokens? = null
+    titleAlignment: Alignment.Horizontal = Alignment.Start,
+    appBarTokens: AppBarTokens? = null,
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -185,7 +186,7 @@ fun AppBar(
                             .weight(1F)
                             .padding(token.textPadding(appBarInfo))
                             .testTag(APP_BAR_SUBTITLE),
-                        horizontalAlignment = token.titleAlignment(appBarInfo)
+                        horizontalAlignment = titleAlignment
                     ) {
                         Row(
                             modifier = Modifier
@@ -267,7 +268,7 @@ fun AppBar(
                             .padding(token.textPadding(appBarInfo))
                             .weight(1F)
                             .semantics { heading() },
-                        horizontalAlignment = token.titleAlignment(appBarInfo)
+                        horizontalAlignment = titleAlignment
                     ) {
 
                         BasicText(

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.core.R
 import com.microsoft.fluentui.icons.ListItemIcons
-import com.microsoft.fluentui.icons.SearchBarIcons
-import com.microsoft.fluentui.icons.appbaricons.appbaricons.Arrowback
 import com.microsoft.fluentui.icons.listitemicons.Chevron
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.*
@@ -142,7 +140,7 @@ fun AppBar(
                     .alpha(if (appTitleDelta != 1.0F) appTitleDelta / 3 else 1.0F),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (navigationIcon !== null && appBarSize != AppBarSize.Large && navigationIcon.isIconAvailable()) {
+                if (navigationIcon !== null && navigationIcon.isIconAvailable()) {
                     Icon(
                         navigationIcon,
                         modifier =
@@ -163,17 +161,7 @@ fun AppBar(
                     )
                 }
 
-                Box(
-                    modifier = Modifier
-                        .then(
-                            if (appBarSize == AppBarSize.Large)
-                                Modifier.padding(start = 16.dp)
-                            else
-                                Modifier
-                        )
-                ) {
-                    logo?.invoke()
-                }
+                logo?.invoke()
 
                 val titleTextStyle = token.titleTypography(appBarInfo)
                 val subtitleTextStyle = token.subtitleTypography(appBarInfo)

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.core.R
 import com.microsoft.fluentui.icons.ListItemIcons
 import com.microsoft.fluentui.icons.SearchBarIcons
-import com.microsoft.fluentui.icons.appbaricons.AppBarIcons
 import com.microsoft.fluentui.icons.appbaricons.appbaricons.Arrowback
 import com.microsoft.fluentui.icons.listitemicons.Chevron
 import com.microsoft.fluentui.theme.FluentTheme
@@ -53,7 +52,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
  * @param subTitle Subtitle to be displayed. Default: [null]
  * @param logo Composable to be placed at left of Title. Guideline is to not increase a size of 32x32. Default: [null]
  * @param searchMode Boolean to enable/disable searchMode. Default: [false]
- * @param navigationIcon Navigate Back Icon to be placed at extreme left. Default: [SearchBarIcons.Arrowback]
  * @param postTitleIcon Icon to be placed after title making the title clickable. Default: Empty [FluentIcon]
  * @param preSubtitleIcon Icon to be placed before subtitle. Default: Empty [FluentIcon]
  * @param postSubtitleIcon Icon to be placed after subtitle. Default: [ListItemIcons.Chevron]
@@ -63,6 +61,8 @@ import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
  * @param bottomBorder Boolean to place a bottom border on AppBar. Applies only when searchBar and bottomBar are empty. Default: [true]
  * @param appTitleDelta Ratio of opening of appTitle. Used for Shychrome and other animations. Default: [1.0F]
  * @param accessoryDelta Ratio of opening of accessory View. Used for Shychrome and other animations. Default: [1.0F]
+ * @param centerAlignAppBar boolean indicating if the app bar should be center aligned. Default: [false]
+ * @param navigationIcon Navigate Back Icon to be placed at extreme left. Default: [null]
  * @param appBarTokens Optional Tokens for App Bar to customize it. Default: [null]
  */
 
@@ -81,7 +81,6 @@ fun AppBar(
     subTitle: String? = null,
     logo: @Composable (() -> Unit)? = null,
     searchMode: Boolean = false,
-    navigationIcon: FluentIcon = FluentIcon(AppBarIcons.Arrowback, flipOnRtl = true),
     postTitleIcon: FluentIcon = FluentIcon(),
     preSubtitleIcon: FluentIcon = FluentIcon(),
     postSubtitleIcon: FluentIcon = FluentIcon(
@@ -94,7 +93,8 @@ fun AppBar(
     bottomBorder: Boolean = true,
     appTitleDelta: Float = 1.0F,
     accessoryDelta: Float = 1.0F,
-    titleAlignment: Alignment.Horizontal = Alignment.Start,
+    centerAlignAppBar: Boolean = false,
+    navigationIcon: FluentIcon? = null,
     appBarTokens: AppBarTokens? = null,
 ) {
     val themeID =
@@ -142,7 +142,7 @@ fun AppBar(
                     .alpha(if (appTitleDelta != 1.0F) appTitleDelta / 3 else 1.0F),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (appBarSize != AppBarSize.Large && navigationIcon.isIconAvailable()) {
+                if (navigationIcon !== null && appBarSize != AppBarSize.Large && navigationIcon.isIconAvailable()) {
                     Icon(
                         navigationIcon,
                         modifier =
@@ -179,6 +179,7 @@ fun AppBar(
 
                 val titleTextStyle = token.titleTypography(appBarInfo)
                 val subtitleTextStyle = token.subtitleTypography(appBarInfo)
+                val titleAlignment: Alignment.Horizontal = if(centerAlignAppBar)  Alignment.CenterHorizontally else Alignment.Start
 
                 if (appBarSize != AppBarSize.Large && !subTitle.isNullOrBlank()) {
                     Column(

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -35,7 +34,6 @@ import com.microsoft.fluentui.theme.token.*
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarInfo
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AppBarTokens
-import com.microsoft.fluentui.theme.token.controlTokens.TitleAlignment
 
 /**
  * An app bar appears at the top of an app screen, below the status bar,
@@ -74,7 +72,6 @@ const val APP_BAR_SUBTITLE = "Fluent App bar Subtitle"
 const val APP_BAR_BOTTOM_BAR = "Fluent App bar Bottom bar"
 const val APP_BAR_SEARCH_BAR = "Fluent App bar Search bar"
 
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun AppBar(
     title: String,
@@ -97,8 +94,7 @@ fun AppBar(
     bottomBorder: Boolean = true,
     appTitleDelta: Float = 1.0F,
     accessoryDelta: Float = 1.0F,
-    appBarTokens: AppBarTokens? = null,
-    titleAlignment: TitleAlignment = TitleAlignment.Start
+    appBarTokens: AppBarTokens? = null
 ) {
     val themeID =
         FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
@@ -189,7 +185,7 @@ fun AppBar(
                             .weight(1F)
                             .padding(token.textPadding(appBarInfo))
                             .testTag(APP_BAR_SUBTITLE),
-                        horizontalAlignment = if (titleAlignment == TitleAlignment.Center) Alignment.CenterHorizontally else Alignment.Start
+                        horizontalAlignment = token.titleAlignment(appBarInfo)
                     ) {
                         Row(
                             modifier = Modifier
@@ -271,7 +267,7 @@ fun AppBar(
                             .padding(token.textPadding(appBarInfo))
                             .weight(1F)
                             .semantics { heading() },
-                        horizontalAlignment = if (titleAlignment == TitleAlignment.Center) Alignment.CenterHorizontally else Alignment.Start
+                        horizontalAlignment = token.titleAlignment(appBarInfo)
                     ) {
 
                         BasicText(

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -163,23 +163,22 @@ fun AppBar(
                     )
                 }
 
-                if (appBarSize != AppBarSize.Medium) {
-                    Box(
-                        modifier = Modifier
-                            .then(
-                                if (appBarSize == AppBarSize.Large)
-                                    Modifier.padding(start = 16.dp)
-                                else
-                                    Modifier
-                            )
-                    ) {
-                        logo?.invoke()
-                    }
+                Box(
+                    modifier = Modifier
+                        .then(
+                            if (appBarSize == AppBarSize.Large)
+                                Modifier.padding(start = 16.dp)
+                            else
+                                Modifier
+                        )
+                ) {
+                    logo?.invoke()
                 }
 
                 val titleTextStyle = token.titleTypography(appBarInfo)
                 val subtitleTextStyle = token.subtitleTypography(appBarInfo)
-                val titleAlignment: Alignment.Horizontal = if(centerAlignAppBar)  Alignment.CenterHorizontally else Alignment.Start
+                val titleAlignment: Alignment.Horizontal =
+                    if (centerAlignAppBar) Alignment.CenterHorizontally else Alignment.Start
 
                 if (appBarSize != AppBarSize.Large && !subTitle.isNullOrBlank()) {
                     Column(


### PR DESCRIPTION
### Problem 
Center aligned top app bar was not present.
Navigation icon was a fixed parameter
logo was not visible for medium size app bar

### Root cause
Center aligned top app bar was not present.
Navigation icon was a fixed parameter
check was added to not show logo for medium sized app bar

### Fix
Added support for center alignment in top app bar
Made navigation icon optional
removed the check, now logo will show up for all app bar sizes
Made some other refactor and UI fixes

### Validations
<img width="435" alt="image" src="https://github.com/user-attachments/assets/6d046b98-1a89-4fc3-9da3-8b05c7ebdba4">

<img width="390" alt="image" src="https://github.com/user-attachments/assets/de9b3622-83d3-4f91-8c11-c209963dd30f">


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
