### PR TITLE
Disallowed Random Composable in Bottom Drawer Types

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2DrawerActivity.kt
@@ -89,7 +89,7 @@ private fun CreateActivityUI() {
     var offsetX by rememberSaveable { mutableIntStateOf(0) }
     var offsetY by rememberSaveable { mutableIntStateOf(0) }
     Column {
-        if (relativeToParentAnchor) {
+        if (relativeToParentAnchor && selectedBehaviorType != BehaviorType.BOTTOM_SLIDE_OVER && selectedBehaviorType != BehaviorType.BOTTOM) {
             Row(
                 Modifier
                     .width(500.dp)
@@ -184,6 +184,32 @@ private fun CreateActivityUI() {
                                     selectedBehaviorType = BehaviorType.BOTTOM_SLIDE_OVER
                                 },
                                 selected = selectedBehaviorType == BehaviorType.BOTTOM_SLIDE_OVER
+                            )
+                        }
+                    )
+                }
+                item {
+                    val showRandomAnchor =
+                        stringResource(id = R.string.show_random_anchor)  + if(selectedBehaviorType == BehaviorType.BOTTOM || selectedBehaviorType == BehaviorType.BOTTOM_SLIDE_OVER) " (" + stringResource(R.string.switch_drawer_type) + ")" else ""
+                    ListItem.Header(title = showRandomAnchor,
+                        modifier = Modifier
+                            .toggleable(
+                                value = relativeToParentAnchor,
+                                role = Role.Switch,
+                                onValueChange = {
+                                    relativeToParentAnchor = !relativeToParentAnchor
+                                }
+                            )
+                            .clearAndSetSemantics {
+                                this.contentDescription = showRandomAnchor
+                            },
+                        trailingAccessoryContent = {
+                            ToggleSwitch(
+                                onValueChange = {
+                                    relativeToParentAnchor = !relativeToParentAnchor
+                                },
+                                checkedState = relativeToParentAnchor,
+                                enabledSwitch = selectedBehaviorType != BehaviorType.BOTTOM_SLIDE_OVER && selectedBehaviorType != BehaviorType.BOTTOM
                             )
                         }
                     )

--- a/FluentUI.Demo/src/main/res/values/strings.xml
+++ b/FluentUI.Demo/src/main/res/values/strings.xml
@@ -893,6 +893,10 @@
     <string name="drawer_expandable">Expandable</string>
     <!-- UI Label for direct swipe down dismiss-->
     <string name="skip_open_state">Skip Open State</string>
+    <!-- UI Label for enabling random anchor-->
+    <string name="show_random_anchor">Random Anchor</string>
+    <!-- UI Label for requesting drawer type switch-->
+    <string name="switch_drawer_type">Unsupported Drawer Type</string>
     <!-- UI Label for direct swipe down dismiss-->
     <string name="prevent_scrim_click_dismissal">Prevent Dismissal on Scrim Click</string>
     <!-- UI Label for Show Handle -->


### PR DESCRIPTION
### Problem 
With Bottom Drawer Types, when screen content was less than half, the drawer would not be visible

### Root cause 
Random Composable Reduced Drawer Height leading to less visibility

### Fix
Removed Random Composable for Bottom Drawer Types

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/8e0565f0-c785-4a01-be2d-8ff7797577a8) | ![image](https://github.com/user-attachments/assets/58b7f642-dfda-43f5-9c34-27dfe84a2031)<br> ![image](https://github.com/user-attachments/assets/6d08190f-f775-4095-b7bd-885724fc6305) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
