### PR TITLE
Fix alignment issue in list content builder & peek height option

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2BottomSheetActivity.kt
@@ -429,14 +429,14 @@ private fun CreateActivityUI() {
                     style = ButtonStyle.Button,
                     size = ButtonSize.Medium,
                     text = "+ 8 dp",
-                    enabled = !hidden,
+                    enabled = hidden,
                     onClick = { peekHeightState += 8.dp })
 
                 Button(
                     style = ButtonStyle.Button,
                     size = ButtonSize.Medium,
                     text = "- 8 dp",
-                    enabled = !hidden && (peekHeightState > 0.dp),
+                    enabled = hidden && (peekHeightState > 0.dp),
                     onClick = { peekHeightState -= 8.dp })
             }
 

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -185,7 +185,7 @@ class ListContentBuilder {
                     content = {
                         var col = 0
                         val widthRatio = if ((row + 1) * itemsInRow <= size || !equidistant)
-                            1.0f / itemsInRow
+                            1.0f / maxItemsInRow
                         else
                             1.0f / min(itemsInRow, (size - (row * itemsInRow)))
                         while (col < itemsInRow && (row * itemsInRow + col) < size) {


### PR DESCRIPTION
### Problem 
1. Alignment issue in List content builder
2. Peek height option not usable in demo app bottom sheet

### Root cause 
1. The issue was happening specifically when maxItemsInRow > itemsInRow and equidistant= false, because width ratio was being calculated as 1/itemsInRow.
2. Because peek height option was getting activated when bottom sheet gets activated, hence rendering it unusable 

### Fix
1. For euidistant false, the width ratio should be calculated as 1/maxItemsInRow.
2. Updated the condition so that peek height option is visible when bottom sheet is hidden

### Validations
for maxItemsInRow > size
![image](https://github.com/user-attachments/assets/3a073561-310c-4034-935f-5d0dae375726)

For maxItemsInRow = size
![image](https://github.com/user-attachments/assets/685429a8-e8da-4b8a-9b1c-7854b9590c9b)

For maxItemsInRow < size
![image](https://github.com/user-attachments/assets/2697cb2f-2080-47d6-959a-996f167029d4)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
