### PR TITLE
V1 People picker a11y fixes

### DIFF
--- a/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
+++ b/fluentui_peoplepicker/src/main/java/com/microsoft/fluentui/peoplepicker/PeoplePickerTextView.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import androidx.core.view.ViewCompat
@@ -34,6 +35,7 @@ import android.view.accessibility.AccessibilityNodeInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
 import android.widget.MultiAutoCompleteTextView
+import androidx.core.content.ContextCompat
 import com.microsoft.fluentui.persona.IPersona
 import com.microsoft.fluentui.persona.PersonaChipView
 import com.microsoft.fluentui.persona.setPersona
@@ -252,9 +254,14 @@ internal class PeoplePickerTextView : TokenCompleteTextView<IPersona> {
 
         // Soft keyboard does not always show up when the view first loads without this
         if (hasFocus) {
+            // add bottom border
+            this.background = ContextCompat.getDrawable(context, R.drawable.people_picker_textview_focusable_background)
             post {
                 context.inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
             }
+        } else {
+            // remove bottom border
+            this.background = null
         }
 
         /**

--- a/fluentui_peoplepicker/src/main/res/drawable/people_picker_textview_focusable_background.xml
+++ b/fluentui_peoplepicker/src/main/res/drawable/people_picker_textview_focusable_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:left="-8dp"
+        android:right="-8dp"
+        android:top="-8dp">
+        <shape>
+            <stroke
+                android:width="0.5dp"
+                android:color="@color/fluentui_communication_shade_20" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
### Problem 
On navigation using tab, All edit field visually appeared as simple text or blank area.

### Root cause 
Outline boundary is not defined on "Select, SelectDeselect, Delete.. etc" edit field.

### Fix
Added outline boundary on focus in and removed on focus out

### Validations
![People picker a11y](https://github.com/user-attachments/assets/977c4159-370c-40e3-80f0-dae4dd9fdfdd)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
