### PR TITLE
[V2 Bottom drawer] Drawer shifting up with IME open for SDK versions less than 33

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
@@ -157,6 +157,7 @@ private class ModalWindow(
             type = WindowManager.LayoutParams.TYPE_APPLICATION_PANEL
             // Fill up the entire app view
             width = WindowManager.LayoutParams.MATCH_PARENT
+            // for build versions less than or equal to S_V2, set the height to wrap content
             height = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2)
                 WindowManager.LayoutParams.WRAP_CONTENT
             else

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.mandatorySystemGestures
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.tappableElement
@@ -179,7 +178,9 @@ private class ModalWindow(
                             WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
                     ).inv()
 
-            flags = flags or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+            flags = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+                flags
+            } else flags or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
         }
 
     private var content: @Composable () -> Unit by mutableStateOf({})

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/compose/ModalPopup.kt
@@ -2,6 +2,7 @@ package com.microsoft.fluentui.compose
 
 import android.content.Context
 import android.graphics.PixelFormat
+import android.os.Build
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.View
@@ -104,6 +105,7 @@ fun ModalPopup(
         }
     }
 }
+
 @Composable
 fun convertWindowInsetsCompatTypeToWindowInsets(windowInsetsCompatType: Int): WindowInsets {
     return when (windowInsetsCompatType) {
@@ -132,6 +134,7 @@ private class ModalWindow(
     val canCalculatePosition by derivedStateOf {
         popupContentSize != null
     }
+
     init {
         id = android.R.id.content
         // Set up view owners
@@ -155,7 +158,10 @@ private class ModalWindow(
             type = WindowManager.LayoutParams.TYPE_APPLICATION_PANEL
             // Fill up the entire app view
             width = WindowManager.LayoutParams.MATCH_PARENT
-            height = WindowManager.LayoutParams.MATCH_PARENT
+            height = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2)
+                WindowManager.LayoutParams.WRAP_CONTENT
+            else
+                WindowManager.LayoutParams.MATCH_PARENT
 
             // Format of screen pixels
             format = PixelFormat.TRANSLUCENT


### PR DESCRIPTION
### Problem 
For SDK version less than 33, extra padding was seen between bottom drawer when IME opens
<img width="344" alt="image" src="https://github.com/user-attachments/assets/3d9a4520-31f8-4876-8440-7d466a62a61e">

### Root cause 
The extra spacing issue for API versions less than 33 when using WindowManager.LayoutParams.MATCH_PARENT for the height of the modal window is likely due to differences in how the window manager handles layout parameters in different Android versions.  

### Fix
For API versions less than 33, the WindowManager.LayoutParams.WRAP_CONTENT has been used to ensure the modal window only takes up the necessary space without adding extra spacing.

### Validations
![drawer ime](https://github.com/user-attachments/assets/dc960d93-0704-40f2-8510-12b446277a5b)


### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
