### PR TITLE
[Fluent v2] Add support for customizing cutout icon color

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
@@ -693,6 +694,12 @@ open class AvatarTokens(private val activityRingToken: ActivityRingsToken = Acti
             AvatarSize.Size72 -> activityRingToken.inactiveBorderStroke(ActivityRingSize.Size72)
         }
     }
+
+    @Composable
+    open fun cutoutColorFilter(avatarInfo: AvatarInfo): ColorFilter? {
+        return null
+    }
+
 
     @Composable
     open fun cutoutCornerRadius(avatarInfo: AvatarInfo): Dp {

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AvatarTokens.kt
@@ -699,8 +699,7 @@ open class AvatarTokens(private val activityRingToken: ActivityRingsToken = Acti
     open fun cutoutColorFilter(avatarInfo: AvatarInfo): ColorFilter? {
         return null
     }
-
-
+    
     @Composable
     open fun cutoutCornerRadius(avatarInfo: AvatarInfo): Dp {
         return when (avatarInfo.cutoutStyle) {

--- a/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
+++ b/fluentui_persona/src/main/java/com/microsoft/fluentui/tokenized/persona/Avatar.kt
@@ -172,7 +172,8 @@ fun Avatar(
                                 )
                                 .padding(4.dp)
                                 .size(cutoutIconSize),
-                            contentDescription = cutoutContentDescription
+                            contentDescription = cutoutContentDescription,
+                            colorFilter = token.cutoutColorFilter(avatarInfo = avatarInfo)
                         )
                     } else if (cutoutIconImageVector != null) {
                         Image(
@@ -185,7 +186,8 @@ fun Avatar(
                                 )
                                 .padding(4.dp)
                                 .size(cutoutIconSize),
-                            contentDescription = cutoutContentDescription
+                            contentDescription = cutoutContentDescription,
+                            colorFilter = token.cutoutColorFilter(avatarInfo = avatarInfo)
                         )
                     }
                 }


### PR DESCRIPTION
### Problem 
No option for customizing cutout icon color

### Fix
Added cutoutColorFilter in avatarTokens

### Validations
With colorFilter as ColorFilter.tint(Color.Blue)
<img width="75" alt="image" src="https://github.com/user-attachments/assets/d331cfcc-3531-4f0a-896c-a084603ecc6b">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
