### PR TITLE
Always publish artifacts to local repository

### DIFF
--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -94,7 +94,7 @@ extends:
             targetPath: $(build.sourcesdirectory)/build/_manifest
           - output: pipelineArtifact
             displayName: 'Publish artifacts to pipeline'
-            targetPath: "$(build.sourcesdirectory)/build"
+            targetPath: "$(build.sourcesdirectory)/build/artifacts/com/microsoft/fluentui"
             artifactName: "Build"
             publishLocation: "pipeline"
           - output: pipelineArtifact

--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -40,6 +40,7 @@ extends:
               # Write your commands here
               bash -c "echo '$GPG_KEY_CONTENT' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
               ls
+              tree -a
         - task: Gradle@3
           inputs:
             gradleWrapperFile: "gradlew"

--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -40,7 +40,6 @@ extends:
               # Write your commands here
               bash -c "echo '$GPG_KEY_CONTENT' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
               ls
-              tree -a
         - task: Gradle@3
           inputs:
             gradleWrapperFile: "gradlew"
@@ -95,7 +94,7 @@ extends:
             targetPath: $(build.sourcesdirectory)/build/_manifest
           - output: pipelineArtifact
             displayName: 'Publish artifacts to pipeline'
-            targetPath: "$(build.sourcesdirectory)/build/artifacts/com/microsoft/fluentui"
+            targetPath: "$(build.sourcesdirectory)/build"
             artifactName: "Build"
             publishLocation: "pipeline"
           - output: pipelineArtifact

--- a/publish.gradle
+++ b/publish.gradle
@@ -36,9 +36,9 @@ project.ext.publishingFunc = { artifactIdName ->
                 url rootProject.buildDir.path + '/artifacts'
             }
         }
-        tasks.withType(PublishToMavenRepository) {
+        tasks.withType(PublishToMavenRepository).configureEach {
             onlyIf {
-                (repository == publishing.repositories.local && !(artifactExists("central", artifactIdName, android.defaultConfig.versionName))) || (repository == publishing.repositories.feed && !(artifactExists("feed", artifactIdName, android.defaultConfig.versionName)))
+                (repository == publishing.repositories.local) || (repository == publishing.repositories.feed && !(artifactExists("feed", artifactIdName, android.defaultConfig.versionName)))
             }
         }
         publications {


### PR DESCRIPTION
### Problem
In the current scenario, artifacts were not published locally as well, if they existed on maven central.
This caused issues in scenarios where the build timed out without running all the steps. 
In such cases, we were not able to run the build again because the artifacts already existed in maven, so they were not pushed in local, resulting in source not found error

### Fix
In this PR, we have updated gradle publish such that artifacts are always published to local repo. But for feed we keep checking if it already exists or not.