### PR TITLE
[V2 Tabbar] Tab item text responsiveness

### DIFF
--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/tabItem/TabItem.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
@@ -47,7 +46,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
-import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.Icon


### PR DESCRIPTION
### Problem 
Tab item text was not adapting correctly with different display sizes

### Root cause 
In the current implementation, when text was overflowing height, font size was being changed by 0.9, which was leading to inconsistent behaviour
![tab bar screen size old](https://github.com/user-attachments/assets/b47b4f2e-9058-4bec-afac-c2f287a75c4d)


### Fix
Removed the font size calculation logic so that text adapts size correctly

### Validations
![tab bar screen size](https://github.com/user-attachments/assets/641d41a1-38e0-4e96-8f5a-c2cacb21cb71)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
