### PR TITLE
[V2 Badge] Responsiveness

### DIFF
--- a/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
+++ b/fluentui_notification/src/main/java/com/microsoft/fluentui/tokenized/notification/Badge.kt
@@ -7,6 +7,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -69,7 +73,15 @@ fun Badge(
         }
     } else {
         val textColor = token.textColor(badgeInfo = badgeInfo)
-        val typography = token.typography(badgeInfo = badgeInfo)
+        var typography = token.typography(badgeInfo = badgeInfo)
+        val fontSize = remember { mutableStateOf(typography.fontSize) }
+        var textStyle by remember(textColor) {
+            mutableStateOf(
+                typography.merge(TextStyle(color = textColor, fontSize = fontSize.value,  platformStyle = PlatformTextStyle(
+                    includeFontPadding = false
+                )))
+            )
+        }
         val paddingValues = token.padding(badgeInfo = badgeInfo)
         val shape = RoundedCornerShape(token.cornerRadius(badgeInfo = badgeInfo))
 
@@ -86,14 +98,14 @@ fun Badge(
             BasicText(
                 text,
                 modifier = Modifier.padding(paddingValues),
-                style = typography.merge(
-                    TextStyle(
-                        color = textColor,
-                        platformStyle = PlatformTextStyle(
-                            includeFontPadding = false
-                        )
-                    )
-                )
+                style = textStyle,
+                onTextLayout = { textLayoutResult ->
+                    if (textLayoutResult.didOverflowHeight) {
+                        textStyle.fontSize
+                        fontSize.value *= 0.9
+                        textStyle = textStyle.copy(fontSize = fontSize.value)
+                    }
+                }
             )
         }
     }


### PR DESCRIPTION
### Problem 
With font size increase, content was getting cut off
<img width="461" alt="image" src="https://github.com/user-attachments/assets/1dd93a15-9a54-4b1d-8330-b677fd7f2fcd">

### Fix
Added logic to adjust fontsize when content overflows available height

### Validations
<img width="393" alt="image" src="https://github.com/user-attachments/assets/5295a651-da99-4593-9343-945f9dd007a1">
<img width="391" alt="image" src="https://github.com/user-attachments/assets/37dfacc7-f127-4e32-9cfd-aa4e47fbf183">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
