### PR TITLE
[V2 Search Bar] Increased customization support

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/CustomizedTokens.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/CustomizedTokens.kt
@@ -1,12 +1,20 @@
 package com.microsoft.fluentuidemo
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentColor
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
+import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.StateBrush
 import com.microsoft.fluentui.theme.token.controlTokens.ListItemInfo
 import com.microsoft.fluentui.theme.token.controlTokens.ListItemTokens
+import com.microsoft.fluentui.theme.token.controlTokens.SearchBarInfo
+import com.microsoft.fluentui.theme.token.controlTokens.SearchBarTokens
 
 object CustomizedTokens {
     val listItemTokens = object : ListItemTokens() {
@@ -17,5 +25,46 @@ object CustomizedTokens {
                 pressed = SolidColor(FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background2Pressed].value())
             )
         }
+    }
+}
+
+object CustomizedSearchBarTokens: SearchBarTokens() {
+    @Composable
+    override fun height(searchBarInfo: SearchBarInfo): Dp {
+        return FluentGlobalTokens.SizeTokens.Size480.value
+    }
+
+    @Composable
+    override fun elevation(searchBarInfo: SearchBarInfo): Dp =
+        FluentGlobalTokens.ShadowTokens.Shadow16.value
+
+    @Composable
+    override fun cornerRadius(searchBarInfo: SearchBarInfo): Dp =
+        FluentGlobalTokens.CornerRadiusTokens.CornerRadius160.value
+
+    @Composable
+    override fun borderWidth(searchBarInfo: SearchBarInfo): Dp =
+        FluentGlobalTokens.StrokeWidthTokens.StrokeWidth10.value
+
+    @Composable
+    override fun inputBackgroundBrush(searchBarInfo: SearchBarInfo): Brush {
+        return SolidColor(
+            when (searchBarInfo.style) {
+                FluentStyle.Neutral ->
+                    FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                        themeMode = FluentTheme.themeMode
+                    )
+
+                FluentStyle.Brand ->
+                    FluentColor(
+                        light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
+                            ThemeMode.Light
+                        ),
+                        dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                            ThemeMode.Dark
+                        )
+                    ).value(themeMode = FluentTheme.themeMode)
+            }
+        )
     }
 }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SearchBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SearchBarActivity.kt
@@ -1,10 +1,10 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.content.Context
-import android.graphics.drawable.Icon
 import android.os.Bundle
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.getValue
@@ -13,13 +13,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import com.microsoft.fluentui.icons.AllIcons
+import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.icons.SearchBarIcons
-import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
 import com.microsoft.fluentui.icons.searchbaricons.Office
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.FluentStyle
@@ -186,23 +186,23 @@ class V2SearchBarActivity : V2DemoActivity() {
                                 )
                             }
                         )
-                    }
 
-                    ListItem.Item(
-                        text = "Customized Search Bar",
-                        subText = if (customizedSearchBar)
-                            LocalContext.current.resources.getString(R.string.fluentui_enabled)
-                        else
-                            LocalContext.current.resources.getString(R.string.fluentui_disabled),
-                        trailingAccessoryContent = {
-                            ToggleSwitch(
-                                onValueChange = {
-                                    customizedSearchBar = it
-                                },
-                                checkedState = customizedSearchBar
-                            )
-                        }
-                    )
+                        ListItem.Item(
+                            text = "Customized Search Bar",
+                            subText = if (customizedSearchBar)
+                                LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                            else
+                                LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                            trailingAccessoryContent = {
+                                ToggleSwitch(
+                                    onValueChange = {
+                                        customizedSearchBar = it
+                                    },
+                                    checkedState = customizedSearchBar
+                                )
+                            }
+                        )
+                    }
                 }
 
                 val microphonePressedString = getDemoAppString(DemoAppStrings.MicrophonePressed)
@@ -213,6 +213,7 @@ class V2SearchBarActivity : V2DemoActivity() {
                 val scope = rememberCoroutineScope()
                 var loading by rememberSaveable { mutableStateOf(false) }
                 val keyboardController = LocalSoftwareKeyboardController.current
+                val showCustomizedAppBar = searchBarStyle == FluentStyle.Neutral && customizedSearchBar
 
                 SearchBar(
                     onValueChange = { query, selectedPerson ->
@@ -270,9 +271,10 @@ class V2SearchBarActivity : V2DemoActivity() {
                             }
                         )
                     } else null,
-                    searchBarTokens = if (searchBarStyle == FluentStyle.Neutral && customizedSearchBar) {
+                    searchBarTokens = if (showCustomizedAppBar) {
                         CustomizedSearchBarTokens
-                    } else null
+                    } else null,
+                    modifier = if (showCustomizedAppBar) Modifier.requiredHeight(60.dp) else Modifier
                 )
 
                 val filteredPersona = mutableListOf<Persona>()

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SearchBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SearchBarActivity.kt
@@ -1,38 +1,30 @@
 package com.microsoft.fluentuidemo.demos
 
 import android.content.Context
+import android.graphics.drawable.Icon
 import android.os.Bundle
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.Dp
+import com.microsoft.fluentui.icons.AllIcons
 import com.microsoft.fluentui.icons.SearchBarIcons
+import com.microsoft.fluentui.icons.searchbaricons.Dismisscircle
 import com.microsoft.fluentui.icons.searchbaricons.Office
-import com.microsoft.fluentui.theme.FluentTheme
-import com.microsoft.fluentui.theme.ThemeMode
-import com.microsoft.fluentui.theme.token.FluentAliasTokens
-import com.microsoft.fluentui.theme.token.FluentColor
-import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.BorderType
-import com.microsoft.fluentui.theme.token.controlTokens.SearchBarInfo
-import com.microsoft.fluentui.theme.token.controlTokens.SearchBarTokens
 import com.microsoft.fluentui.tokenized.SearchBar
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.listitem.ChevronOrientation
@@ -40,6 +32,7 @@ import com.microsoft.fluentui.tokenized.listitem.ListItem
 import com.microsoft.fluentui.tokenized.persona.Person
 import com.microsoft.fluentui.tokenized.persona.Persona
 import com.microsoft.fluentui.tokenized.persona.PersonaList
+import com.microsoft.fluentuidemo.CustomizedSearchBarTokens
 import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.V2DemoActivity
 import com.microsoft.fluentuidemo.util.DemoAppStrings
@@ -277,41 +270,8 @@ class V2SearchBarActivity : V2DemoActivity() {
                             }
                         )
                     } else null,
-                    searchBarTokens = if (customizedSearchBar) object : SearchBarTokens() {
-                        @Composable
-                        override fun height(searchBarInfo: SearchBarInfo): Dp {
-                            return FluentGlobalTokens.SizeTokens.Size480.value
-                        }
-
-                        @Composable
-                       override fun elevation(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.ShadowTokens.Shadow08.value
-
-                        @Composable
-                        override fun cornerRadius(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.CornerRadiusTokens.CornerRadius160.value
-
-                        @Composable
-                        override fun borderWidth(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.StrokeWidthTokens.StrokeWidth20.value
-
-                        @Composable
-                        override fun backgroundBrush(searchBarInfo: SearchBarInfo): Brush {
-                            return SolidColor(
-                                when (searchBarInfo.style) {
-                                    FluentStyle.Neutral ->
-                                        FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                                            themeMode = FluentTheme.themeMode
-                                        )
-                                    FluentStyle.Brand ->
-                                        FluentColor(
-                                            light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
-                                                ThemeMode.Light
-                                            ),
-                                            dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
-                                                ThemeMode.Dark
-                                            )
-                                        ).value(themeMode = FluentTheme.themeMode)
-                                }
-                            )
-                        }
+                    searchBarTokens = if (searchBarStyle == FluentStyle.Neutral && customizedSearchBar) {
+                        CustomizedSearchBarTokens
                     } else null
                 )
 

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SearchBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2SearchBarActivity.kt
@@ -6,23 +6,33 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.Dp
 import com.microsoft.fluentui.icons.SearchBarIcons
 import com.microsoft.fluentui.icons.searchbaricons.Office
+import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.ThemeMode
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentColor
+import com.microsoft.fluentui.theme.token.FluentGlobalTokens
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.BorderType
+import com.microsoft.fluentui.theme.token.controlTokens.SearchBarInfo
+import com.microsoft.fluentui.theme.token.controlTokens.SearchBarTokens
 import com.microsoft.fluentui.tokenized.SearchBar
 import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.listitem.ChevronOrientation
@@ -45,7 +55,6 @@ class V2SearchBarActivity : V2DemoActivity() {
     override val paramsUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#params-29"
     override val controlTokensUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-27"
 
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -56,8 +65,8 @@ class V2SearchBarActivity : V2DemoActivity() {
             var searchBarStyle: FluentStyle by rememberSaveable { mutableStateOf(FluentStyle.Neutral) }
             var displayRightAccessory: Boolean by rememberSaveable { mutableStateOf(true) }
             var induceDelay: Boolean by rememberSaveable { mutableStateOf(false) }
-
             var selectedPeople: Person? by rememberSaveable { mutableStateOf(null) }
+            var customizedSearchBar: Boolean by rememberSaveable { mutableStateOf(false) }
 
             val listofPeople = listOf(
                 Person(
@@ -185,6 +194,22 @@ class V2SearchBarActivity : V2DemoActivity() {
                             }
                         )
                     }
+
+                    ListItem.Item(
+                        text = "Customized Search Bar",
+                        subText = if (customizedSearchBar)
+                            LocalContext.current.resources.getString(R.string.fluentui_enabled)
+                        else
+                            LocalContext.current.resources.getString(R.string.fluentui_disabled),
+                        trailingAccessoryContent = {
+                            ToggleSwitch(
+                                onValueChange = {
+                                    customizedSearchBar = it
+                                },
+                                checkedState = customizedSearchBar
+                            )
+                        }
+                    )
                 }
 
                 val microphonePressedString = getDemoAppString(DemoAppStrings.MicrophonePressed)
@@ -251,6 +276,42 @@ class V2SearchBarActivity : V2DemoActivity() {
                                     .show()
                             }
                         )
+                    } else null,
+                    searchBarTokens = if (customizedSearchBar) object : SearchBarTokens() {
+                        @Composable
+                        override fun height(searchBarInfo: SearchBarInfo): Dp {
+                            return FluentGlobalTokens.SizeTokens.Size480.value
+                        }
+
+                        @Composable
+                       override fun elevation(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.ShadowTokens.Shadow08.value
+
+                        @Composable
+                        override fun cornerRadius(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.CornerRadiusTokens.CornerRadius160.value
+
+                        @Composable
+                        override fun borderWidth(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.StrokeWidthTokens.StrokeWidth20.value
+
+                        @Composable
+                        override fun backgroundBrush(searchBarInfo: SearchBarInfo): Brush {
+                            return SolidColor(
+                                when (searchBarInfo.style) {
+                                    FluentStyle.Neutral ->
+                                        FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                                            themeMode = FluentTheme.themeMode
+                                        )
+                                    FluentStyle.Brand ->
+                                        FluentColor(
+                                            light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
+                                                ThemeMode.Light
+                                            ),
+                                            dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                                                ThemeMode.Dark
+                                            )
+                                        ).value(themeMode = FluentTheme.themeMode)
+                                }
+                            )
+                        }
                     } else null
                 )
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentGlobalTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentGlobalTokens.kt
@@ -224,6 +224,7 @@ object FluentGlobalTokens {
         CornerRadius40(4.dp),
         CornerRadius80(8.dp),
         CornerRadius120(12.dp),
+        CornerRadius160(16.dp),
         CornerRadiusCircle(9999.dp)
     }
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
@@ -30,6 +30,7 @@ open class SearchBarTokens : IControlToken, Parcelable {
                     FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
                         themeMode = FluentTheme.themeMode
                     )
+
                 FluentStyle.Brand ->
                     FluentColor(
                         light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground2].value(
@@ -51,6 +52,7 @@ open class SearchBarTokens : IControlToken, Parcelable {
                     FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
                         themeMode = FluentTheme.themeMode
                     )
+
                 FluentStyle.Brand ->
                     FluentColor(
                         light = FluentTheme.aliasTokens.brandBackgroundColor[FluentAliasTokens.BrandBackgroundColorTokens.BrandBackground1].value(
@@ -90,6 +92,7 @@ open class SearchBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -108,6 +111,7 @@ open class SearchBarTokens : IControlToken, Parcelable {
             when (searchBarInfo.style) {
                 FluentStyle.Neutral ->
                     FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value()
+
                 FluentStyle.Brand ->
                     FluentColor(
                         light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -128,6 +132,7 @@ open class SearchBarTokens : IControlToken, Parcelable {
                 FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground2].value(
                     themeMode = FluentTheme.themeMode
                 )
+
             FluentStyle.Brand ->
                 FluentColor(
                     light = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundOnColor].value(
@@ -171,7 +176,8 @@ open class SearchBarTokens : IControlToken, Parcelable {
     }
 
     @Composable
-    open fun cornerRadius(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.CornerRadiusTokens.CornerRadius80.value
+    open fun cornerRadius(searchBarInfo: SearchBarInfo): Dp =
+        FluentGlobalTokens.CornerRadiusTokens.CornerRadius80.value
 
     @Composable
     open fun elevation(searchBarInfo: SearchBarInfo): Dp = 0.dp
@@ -180,7 +186,8 @@ open class SearchBarTokens : IControlToken, Parcelable {
     open fun borderWidth(searchBarInfo: SearchBarInfo): Dp = 0.dp
 
     @Composable
-    open fun borderColor(searchBarInfo: SearchBarInfo): Color = FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value()
+    open fun borderColor(searchBarInfo: SearchBarInfo): Color =
+        FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value()
 
     @Composable
     open fun shadowColor(searchBarInfo: SearchBarInfo): Color = DefaultShadowColor

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SearchBarTokens.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.DefaultShadowColor
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
@@ -168,4 +169,19 @@ open class SearchBarTokens : IControlToken, Parcelable {
     open fun height(searchBarInfo: SearchBarInfo): Dp {
         return 40.dp
     }
+
+    @Composable
+    open fun cornerRadius(searchBarInfo: SearchBarInfo): Dp = FluentGlobalTokens.CornerRadiusTokens.CornerRadius80.value
+
+    @Composable
+    open fun elevation(searchBarInfo: SearchBarInfo): Dp = 0.dp
+
+    @Composable
+    open fun borderWidth(searchBarInfo: SearchBarInfo): Dp = 0.dp
+
+    @Composable
+    open fun borderColor(searchBarInfo: SearchBarInfo): Color = FluentTheme.aliasTokens.neutralStrokeColor[FluentAliasTokens.NeutralStrokeColorTokens.Stroke2].value()
+
+    @Composable
+    open fun shadowColor(searchBarInfo: SearchBarInfo): Color = DefaultShadowColor
 }

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -1,8 +1,8 @@
 package com.microsoft.fluentui.tokenized
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
@@ -15,10 +15,10 @@ import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -73,8 +73,6 @@ import com.microsoft.fluentui.topappbars.R
  * @param rightAccessoryIcon [FluentIcon] Object which is displayed on the right side of microphone. Default: [null]
  * @param searchBarTokens Tokens which help in customizing appearance of search bar. Default: [null]
  */
-//         AnimatedContent                        Backspace Key
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalAnimationApi::class)
 @Composable
 fun SearchBar(
     onValueChange: (String, Person?) -> Unit,
@@ -109,6 +107,7 @@ fun SearchBar(
 
     val scope = rememberCoroutineScope()
 
+
     Row(
         modifier = modifier
             .background(token.backgroundBrush(searchBarInfo))
@@ -117,11 +116,21 @@ fun SearchBar(
         Row(
             Modifier
                 .requiredHeightIn(min = token.height(searchBarInfo))
+                .border(
+                    width = token.borderWidth(searchBarInfo),
+                    color = token.borderColor(searchBarInfo),
+                    shape = RoundedCornerShape(token.cornerRadius(searchBarInfo))
+                )
+                .shadow(
+                    elevation = token.elevation(searchBarInfo),
+                    shape = RoundedCornerShape(token.cornerRadius(searchBarInfo)),
+                    spotColor = token.shadowColor(searchBarInfo)
+                )
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(token.cornerRadius(searchBarInfo)))
                 .background(
                     token.inputBackgroundBrush(searchBarInfo),
-                    RoundedCornerShape(8.dp)
+                    RoundedCornerShape(token.cornerRadius(searchBarInfo))
                 ),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -107,6 +107,7 @@ fun SearchBar(
     var selectedPerson: Person? = selectedPerson
     val borderWidth = token.borderWidth(searchBarInfo)
     val elevation = token.elevation(searchBarInfo)
+    val height = token.height(searchBarInfo)
 
     val scope = rememberCoroutineScope()
     val borderModifier = if (borderWidth > 0.dp) {
@@ -129,7 +130,7 @@ fun SearchBar(
     ) {
         Row(
             Modifier
-                .requiredHeightIn(min = token.height(searchBarInfo))
+                .requiredHeightIn(min = height)
                 .then(borderModifier)
                 .then(shadowModifier)
                 .fillMaxWidth()

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -88,6 +88,7 @@ fun SearchBar(
     personaChipOnClick: (() -> Unit)? = null,
     microphoneCallback: (() -> Unit)? = null,
     navigationIconCallback: (() -> Unit)? = null,
+    leftAccessoryIcon: ImageVector? = SearchBarIcons.Search,
     rightAccessoryIcon: FluentIcon? = null,
     searchBarTokens: SearchBarTokens? = null
 ) {
@@ -165,7 +166,7 @@ fun SearchBar(
                         onClick = {
                             focusRequester.requestFocus()
                         }
-                        icon = SearchBarIcons.Search
+                        icon = leftAccessoryIcon ?: SearchBarIcons.Search
                         contentDescription =
                             LocalContext.current.resources.getString(R.string.fluentui_search)
                         mirrorImage = false

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/SearchBar.kt
@@ -105,9 +105,22 @@ fun SearchBar(
 
     var personaChipSelected by rememberSaveable { mutableStateOf(false) }
     var selectedPerson: Person? = selectedPerson
+    val borderWidth = token.borderWidth(searchBarInfo)
+    val elevation = token.elevation(searchBarInfo)
 
     val scope = rememberCoroutineScope()
-
+    val borderModifier = if (borderWidth > 0.dp) {
+        Modifier.border(
+            width = borderWidth,
+            color = token.borderColor(searchBarInfo),
+            shape = RoundedCornerShape(token.cornerRadius(searchBarInfo))
+        )
+    } else Modifier
+    val shadowModifier = if (elevation > 0.dp) Modifier.shadow(
+        elevation = token.elevation(searchBarInfo),
+        shape = RoundedCornerShape(token.cornerRadius(searchBarInfo)),
+        spotColor = token.shadowColor(searchBarInfo)
+    ) else Modifier
 
     Row(
         modifier = modifier
@@ -117,16 +130,8 @@ fun SearchBar(
         Row(
             Modifier
                 .requiredHeightIn(min = token.height(searchBarInfo))
-                .border(
-                    width = token.borderWidth(searchBarInfo),
-                    color = token.borderColor(searchBarInfo),
-                    shape = RoundedCornerShape(token.cornerRadius(searchBarInfo))
-                )
-                .shadow(
-                    elevation = token.elevation(searchBarInfo),
-                    shape = RoundedCornerShape(token.cornerRadius(searchBarInfo)),
-                    spotColor = token.shadowColor(searchBarInfo)
-                )
+                .then(borderModifier)
+                .then(shadowModifier)
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(token.cornerRadius(searchBarInfo)))
                 .background(
@@ -162,6 +167,7 @@ fun SearchBar(
                         if (LocalLayoutDirection.current == LayoutDirection.Rtl)
                             mirrorImage = true
                     }
+
                     false -> {
                         onClick = {
                             focusRequester.requestFocus()
@@ -316,6 +322,7 @@ fun SearchBar(
                                 onClick = microphoneCallback
                             )
                         }
+
                     false ->
                         Box(
                             modifier = Modifier


### PR DESCRIPTION
### Problem 
Allow increased customization support for search bar including
- elevation
- shadow
- border width/color
- corner radius
- customizable left accessory icon

### Fix
Search bar experience
![customized search bar](https://github.com/user-attachments/assets/08add968-8d5d-4ec4-b039-ae6a1471e4f8)

Search in app bar experience
![image](https://github.com/user-attachments/assets/ada1d41c-1e74-4fb3-9ae0-58559ad18137)


### Validations

(how the change was tested, including both manual and automated tests)

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
