### PR TITLE
Update fluentui-android-release.yml for Azure Pipelines

### DIFF
--- a/fluentui-android-release.yml
+++ b/fluentui-android-release.yml
@@ -60,6 +60,8 @@ extends:
         condition: succeeded()
         timeoutInMinutes: 0
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             buildType: 'specific'


### PR DESCRIPTION
##  Problem
1ES PT Error: Job 'Job_1' uses the release tasks ["AppCenterDistribute@3"] but is not marked as a release job. Release tasks will soon be disallowed outside of release jobs.

## Fix 
Added release type