### PR TITLE
Fixes for bottomsheet jarring collapse on content size changes

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -495,7 +495,20 @@ fun BottomSheet(
                         if (focusState.hasFocus && sheetState.currentValue != BottomSheetValue.Expanded) {        // this expands the sheet when the content is focused
                             scope.launch { sheetState.expand() }
                         }
-                    } else Modifier.fillMaxSize()), content = { sheetContent() })
+                    } else Modifier.fillMaxSize()), content = {
+                        sheetContent()
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(
+                                    fullHeight.dp
+                                )
+                                .background(sheetBackgroundColor)
+                                .onGloballyPositioned {
+                                    sheetHeightState.value = sheetHeightState.value?.minus(it.size.height.toFloat())
+                                }
+                        )
+                    })
             }
         }
     }


### PR DESCRIPTION
### Problem 
When the size of the content inside the sheet would change with sildeOver set to Off, the sheet would resize to fit the content. In this resizing, the sheet would collapse and then expand again, causing a jarring effect

### Root cause 
The content size inside the sheet would update, causing the container to resize which led to a brief moment of the shorter content size being visible

### Fix
Added a filler composable to take up the empty space when resizing and modified the resizing logic to adjust the filler box height 

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [beforeCollapseFix.webm](https://github.com/user-attachments/assets/bdb318df-4cc2-4486-a37b-b714255a3a30) | [afterCollapseFix.webm](https://github.com/user-attachments/assets/d22dd29a-5ae8-468c-8128-8c3326cee350) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
