### PR TITLE
[Fluent v2] Added Long Press Functionality for ListItem

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ListItemActivity.kt
@@ -114,6 +114,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Item(
                 text = primaryText,
                 onClick = {},
+                onLongClick = { invokeToast("ListItem Long", context) },
                 border = BorderType.Bottom,
                 borderInset = XXLarge,
                 primaryTextTrailingContent = { Icon20() }
@@ -121,6 +122,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Item(
                 text = primaryText,
                 onClick = {},
+                onLongClick = { invokeToast("ListItem Long", context) },
                 subText = secondaryText,
                 border = BorderType.Bottom,
                 borderInset = XXLarge,
@@ -129,6 +131,7 @@ private fun CreateListActivityUI(context: Context) {
             ListItem.Item(
                 text = primaryText,
                 onClick = {},
+                onLongClick = { invokeToast("ListItem Long", context) },
                 subText = secondaryText,
                 secondarySubText = tertiaryText,
                 border = BorderType.Bottom,
@@ -419,11 +422,13 @@ private fun OneLineListAccessoryContentContent(context: Context) {
             },
             border = BorderType.Bottom,
             borderInset = XXLarge,
-            onClick = { checked = !checked }
+            onClick = { checked = !checked },
+            onLongClick = { invokeToast("ListItem Long", context) }
         )
         ListItem.Item(
             text = primaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = {
                 RightContentButton(
                     size = ButtonSize.Small,
@@ -443,6 +448,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentAvatar(size = Size24) },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -456,6 +462,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = "",
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentThreeIcon() },
             border = BorderType.Bottom,
             borderInset = XXLarge
@@ -463,6 +470,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentRadioButton() },
             trailingAccessoryContent = { RightContentAvatarStack(Size24) },
             border = BorderType.Bottom,
@@ -471,6 +479,7 @@ private fun OneLineListAccessoryContentContent(context: Context) {
         ListItem.Item(
             text = primaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentThreeButton() },
             trailingAccessoryContent = { RightContentToggle() },
             border = BorderType.Bottom,
@@ -488,6 +497,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             text = primaryText,
             secondarySubText = tertiaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentAvatar(size = Size40) },
             trailingAccessoryContent = { LeftContentAvatar(size = Size40) },
             border = BorderType.Bottom,
@@ -503,6 +513,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             borderInset = XXLarge,
             unreadDot = unreadDot1,
             onClick = { unreadDot1 = !unreadDot1 },
+            onLongClick = { invokeToast("ListItem Long", context) },
             primaryTextTrailingContent = { Icon20() },
             secondarySubTextTrailingContent = { Icon16() }
         )
@@ -514,6 +525,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             borderInset = XXLarge,
             unreadDot = unreadDot2,
             onClick = { unreadDot2 = !unreadDot2 },
+            onLongClick = { invokeToast("ListItem Long", context) },
             primaryTextTrailingContent = { Icon20() },
             secondarySubTextTrailingContent = { Icon16() }
         )
@@ -521,6 +533,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             text = primaryText,
             secondarySubText = tertiaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             primaryTextLeadingContent = {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -542,6 +555,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             text = primaryText,
             subText = secondaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             trailingAccessoryContent = { RightContentAvatarStack(Size40) },
             border = BorderType.Bottom,
@@ -552,6 +566,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             secondarySubText = tertiaryText,
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             secondarySubTextLeadingContent = {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Icon16()
@@ -577,6 +592,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             text = primaryText,
             secondarySubText = tertiaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             secondarySubTextTrailingContent = { Icon16() },
             trailingAccessoryContent = { RightContentToggle() },
@@ -587,6 +603,7 @@ private fun TwoLineListAccessoryContentContent(context: Context) {
             text = primaryText,
             subText = secondaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentThreeButton() },
             trailingAccessoryContent = { RightContentText("Value") },
             border = BorderType.Bottom,
@@ -613,6 +630,7 @@ private fun ThreeLineListAccessoryContentContent(
             subText = "Wanda can you please update the file with comments",
             secondarySubTextAnnotated = footer,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentAvatar(size = Size56) },
             trailingAccessoryContent = { rightContentIconButton() },
             primaryTextTrailingContent = { Badge(text = "2") },
@@ -628,6 +646,7 @@ private fun ThreeLineListAccessoryContentContent(
             subText = secondaryText,
             secondarySubText = tertiaryText,
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             leadingAccessoryContent = { LeftContentFolderIcon40() },
             primaryTextTrailingContent = { Badge(text = "Suggested") },
             trailingAccessoryContent = {
@@ -644,6 +663,7 @@ private fun ThreeLineListAccessoryContentContent(
             subText = secondaryText,
             bottomContent = { LinearProgressIndicator() },
             onClick = {},
+            onLongClick = { invokeToast("ListItem Long", context) },
             primaryTextLeadingContent = { Icon20() },
             secondarySubTextTrailingContent = {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -3,8 +3,10 @@ package com.microsoft.fluentui.tokenized.listitem
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
@@ -59,18 +61,22 @@ object ListItem {
         }
     }
 
-    private fun Modifier.clickAndSemanticsModifier(
+    @OptIn(ExperimentalFoundationApi::class)
+    private fun Modifier.longPressSemanticsModifier(
         interactionSource: MutableInteractionSource,
         onClick: () -> Unit,
+        onLongClick: () -> Unit,
         enabled: Boolean,
         rippleColor: Color
     ): Modifier = composed {
-        Modifier.clickable(
+        Modifier.combinedClickable(
             interactionSource = interactionSource,
             indication = rememberRipple(color = rippleColor),
             onClickLabel = null,
+            onLongClickLabel = null,
             enabled = enabled,
-            onClick = onClick
+            onClick = onClick,
+            onLongClick = onLongClick
         )
     }
 
@@ -210,6 +216,7 @@ object ListItem {
         subTextMaxLines: Int = 1,
         secondarySubTextMaxLines: Int = 1,
         onClick: (() -> Unit)? = null,
+        onLongClick: (() -> Unit)? = null,
         primaryTextLeadingContent: (@Composable () -> Unit)? = null,
         primaryTextTrailingContent: (@Composable () -> Unit)? = null,
         secondarySubTextLeadingContent: (@Composable () -> Unit)? = null,
@@ -295,9 +302,10 @@ object ListItem {
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
                 .then(
                     if (onClick != null) {
-                        Modifier.clickAndSemanticsModifier(
+                        Modifier.longPressSemanticsModifier(
                             interactionSource,
                             onClick = onClick,
+                            onLongClick = onLongClick ?: {},
                             enabled,
                             rippleColor
                         )
@@ -441,6 +449,7 @@ object ListItem {
      * @param subTextMaxLines Optional max visible lines for secondary text.
      * @param secondarySubTextMaxLines Optional max visible lines for tertiary text.
      * @param onClick Optional onClick action for list item.
+     * @param onLongClick Optional onLongClick action for list item.
      * @param primaryTextLeadingContent Optional primary text leading Content.
      * @param primaryTextTrailingContent Optional primary text trailing Content.
      * @param secondarySubTextLeadingContent Optional secondary text leading Content.
@@ -469,6 +478,7 @@ object ListItem {
         subTextMaxLines: Int = 1,
         secondarySubTextMaxLines: Int = 1,
         onClick: (() -> Unit)? = null,
+        onLongClick: (() -> Unit)? = null,
         primaryTextLeadingContent: (@Composable () -> Unit)? = null,
         primaryTextTrailingContent: (@Composable () -> Unit)? = null,
         secondarySubTextLeadingContent: (@Composable () -> Unit)? = null,
@@ -496,6 +506,7 @@ object ListItem {
             subTextMaxLines = subTextMaxLines,
             secondarySubTextMaxLines = secondarySubTextMaxLines,
             onClick = onClick,
+            onLongClick = onLongClick,
             primaryTextLeadingContent = primaryTextLeadingContent,
             primaryTextTrailingContent = primaryTextTrailingContent,
             secondarySubTextLeadingContent = secondarySubTextLeadingContent,
@@ -528,6 +539,7 @@ object ListItem {
      * @param subTextMaxLines Optional max visible lines for secondary text.
      * @param secondarySubTextMaxLines Optional max visible lines for tertiary text.
      * @param onClick Optional onClick action for list item.
+     * @param onLongClick Optional onLongClick action for list item.
      * @param primaryTextLeadingContent Optional primary text leading Content.
      * @param primaryTextTrailingContent Optional primary text trailing Content.
      * @param secondarySubTextLeadingContent Optional secondary text leading Content.
@@ -557,6 +569,7 @@ object ListItem {
         subTextMaxLines: Int = 1,
         secondarySubTextMaxLines: Int = 1,
         onClick: (() -> Unit)? = null,
+        onLongClick: (() -> Unit)? = null,
         primaryTextLeadingContent: (@Composable () -> Unit)? = null,
         primaryTextTrailingContent: (@Composable () -> Unit)? = null,
         secondarySubTextLeadingContent: (@Composable () -> Unit)? = null,
@@ -585,6 +598,7 @@ object ListItem {
             subTextMaxLines = subTextMaxLines,
             secondarySubTextMaxLines = secondarySubTextMaxLines,
             onClick = onClick,
+            onLongClick = onLongClick,
             primaryTextLeadingContent = primaryTextLeadingContent,
             primaryTextTrailingContent = primaryTextTrailingContent,
             secondarySubTextLeadingContent = secondarySubTextLeadingContent,
@@ -701,9 +715,12 @@ object ListItem {
                 .background(backgroundColor)
                 .then(
                     if (enableContentOpenCloseTransition && content != null) {
-                        Modifier.clickAndSemanticsModifier(
+                        Modifier.longPressSemanticsModifier(
                             interactionSource,
                             onClick = {
+                                expandedState = !expandedState
+                            },
+                            onLongClick = {
                                 expandedState = !expandedState
                             },
                             enabled,
@@ -827,6 +844,7 @@ object ListItem {
      * @param actionText Option boolean to append "Action" text button to the description text.
      * @param descriptionPlacement [TextPlacement] Enum value for placing the description text in the list item.
      * @param onClick Optional onClick action for list item.
+     * @param onLongClick Optional onLongClick action for list item.
      * @param onActionClick Optional onClick action for actionText.
      * @param border [BorderType] Optional border for the list item.
      * @param borderInset [BorderInset] Optional borderInset for list item.
@@ -844,6 +862,7 @@ object ListItem {
         border: BorderType = NoBorder,
         borderInset: BorderInset = None,
         onClick: (() -> Unit)? = null,
+        onLongClick: (() -> Unit)? = null,
         onActionClick: (() -> Unit)? = null,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         leadingAccessoryContent: (@Composable () -> Unit)? = null,
@@ -895,8 +914,8 @@ object ListItem {
                 .heightIn(min = cellHeight)
                 .background(backgroundColor)
                 .borderModifier(border, borderColor, borderSize, borderInsetToPx)
-                .clickAndSemanticsModifier(
-                    interactionSource, onClick = onClick ?: {}, enabled, rippleColor
+                .longPressSemanticsModifier(
+                    interactionSource, onClick = onClick ?: {}, onLongClick = onLongClick ?: {} ,enabled, rippleColor
                 ), verticalAlignment = descriptionAlignment
         ) {
             if (leadingAccessoryContent != null && descriptionPlacement == Top) {


### PR DESCRIPTION
### Problem 
No way to implement long press functions in Fluent ListItem

### Fix
Added the onLongClick Optional parameter to the ListItem.Item API 

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![beforeLongPress](https://github.com/user-attachments/assets/ec76dd8d-a077-4500-8a19-b4f4bead0b42) | ![afterLongPress](https://github.com/user-attachments/assets/430f1a7b-d3b1-43be-8ace-b2ca2ebeb6a7) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
