### PR TITLE
[Fluent v2] Added Shimmer Token for disabling shimmer animation in the background

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -2,6 +2,7 @@ package com.microsoft.fluentuidemo.demos
 
 import android.os.Bundle
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.ListItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +26,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -44,6 +47,7 @@ import com.microsoft.fluentui.theme.token.controlTokens.ShimmerTokens
 import com.microsoft.fluentui.tokenized.controls.Button
 import com.microsoft.fluentui.tokenized.controls.Label
 import com.microsoft.fluentui.tokenized.controls.RadioButton
+import com.microsoft.fluentui.tokenized.controls.ToggleSwitch
 import com.microsoft.fluentui.tokenized.notification.Badge
 import com.microsoft.fluentui.tokenized.persona.Avatar
 import com.microsoft.fluentui.tokenized.persona.Person
@@ -293,14 +297,32 @@ class V2ShimmerActivity : V2DemoActivity() {
                 onClick = { shimmerOrientation = 3 }
             )
             Spacer(modifier = Modifier.height(10.dp))
-            Button(
-                text = "Stop Shimmer",
-                onClick = {
-                    isShimmering = !isShimmering
-                },
-                style = ButtonStyle.Button,
-                modifier = Modifier.testTag("ResetButton")
+            Label(
+                text = "Toggle Animation",
+                textStyle = FluentAliasTokens.TypographyTokens.Title2,
+                colorStyle = ColorStyle.Brand
             )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().clickable {
+                    isShimmering = !isShimmering
+                }
+            ) {
+                BasicText(
+                    text = "Toggle Shimmer Animation",
+                    modifier = Modifier.weight(1F),
+                    style = TextStyle(
+                        color = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground3].value(
+                            themeMode = ThemeMode.Auto
+                        )
+                    )
+                )
+                ToggleSwitch(
+                    onValueChange = { isShimmering = !isShimmering },
+                    checkedState = isShimmering
+                )
+            }
         }
 
     }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarSize
 import com.microsoft.fluentui.theme.token.controlTokens.AvatarStatus
 import com.microsoft.fluentui.theme.token.controlTokens.BadgeInfo
 import com.microsoft.fluentui.theme.token.controlTokens.BadgeTokens
+import com.microsoft.fluentui.theme.token.controlTokens.ButtonStyle
 import com.microsoft.fluentui.theme.token.controlTokens.ColorStyle
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipSize
 import com.microsoft.fluentui.theme.token.controlTokens.PersonaChipStyle
@@ -69,6 +71,7 @@ class V2ShimmerActivity : V2DemoActivity() {
     @Composable
     private fun CreateShimmerActivityUI() {
         var shimmerOrientation by rememberSaveable { mutableStateOf(0) }
+        var isShimmering by rememberSaveable { mutableStateOf(true) }
         val shimmerTokens = object : ShimmerTokens() {
             @Composable
             override fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
@@ -79,6 +82,11 @@ class V2ShimmerActivity : V2DemoActivity() {
                     3 -> ShimmerOrientation.BOTTOMRIGHT_TO_TOPLEFT
                     else -> ShimmerOrientation.LEFT_TO_RIGHT
                 }
+            }
+
+            @Composable
+            override fun isShimmering(shimmerInfo: ShimmerInfo): Boolean {
+                return isShimmering
             }
         }
         Column(
@@ -184,6 +192,11 @@ class V2ShimmerActivity : V2DemoActivity() {
                         else -> ShimmerOrientation.LEFT_TO_RIGHT
                     }
                 }
+
+                @Composable
+                override fun isShimmering(shimmerInfo: ShimmerInfo): Boolean {
+                    return isShimmering
+                }
             }
 
             class BadgeColorToken : BadgeTokens() {
@@ -230,7 +243,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                         size = PersonaChipSize.Small,
                         style = PersonaChipStyle.Brand
                     )
-                }, shimmerTokens = shimmerTokens )
+                }, shimmerTokens = shimmerTokens)
             }
             Row(
                 modifier = Modifier
@@ -278,6 +291,15 @@ class V2ShimmerActivity : V2DemoActivity() {
                 testTag = "Bottom Right to Top Left",
                 selected = shimmerOrientation == 3,
                 onClick = { shimmerOrientation = 3 }
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            Button(
+                text = "Stop Shimmer",
+                onClick = {
+                    isShimmering = !isShimmering
+                },
+                style = ButtonStyle.Button,
+                modifier = Modifier.testTag("ResetButton")
             )
         }
 

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -71,28 +71,21 @@ class V2ShimmerActivity : V2DemoActivity() {
             CreateShimmerActivityUI()
         }
     }
+    private fun getShimmerOrientation(shimmerOrientation: Int): ShimmerOrientation {
+        return when (shimmerOrientation) {
+            0 -> ShimmerOrientation.LEFT_TO_RIGHT
+            1 -> ShimmerOrientation.RIGHT_TO_LEFT
+            2 -> ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
+            3 -> ShimmerOrientation.BOTTOMRIGHT_TO_TOPLEFT
+            else -> ShimmerOrientation.LEFT_TO_RIGHT
+        }
+    }
 
     @Composable
     private fun CreateShimmerActivityUI() {
         var shimmerOrientation by rememberSaveable { mutableStateOf(0) }
         var isShimmering by rememberSaveable { mutableStateOf(true) }
-        val shimmerTokens = object : ShimmerTokens() {
-            @Composable
-            override fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
-                return when (shimmerOrientation) {
-                    0 -> ShimmerOrientation.LEFT_TO_RIGHT
-                    1 -> ShimmerOrientation.RIGHT_TO_LEFT
-                    2 -> ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
-                    3 -> ShimmerOrientation.BOTTOMRIGHT_TO_TOPLEFT
-                    else -> ShimmerOrientation.LEFT_TO_RIGHT
-                }
-            }
-
-            @Composable
-            override fun isShimmering(shimmerInfo: ShimmerInfo): Boolean {
-                return isShimmering
-            }
-        }
+        val shimmerTokens = ShimmerTokens()
         Column(
             Modifier
                 .padding(all = 12.dp)
@@ -109,16 +102,16 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(120.dp, 80.dp), shimmerTokens = shimmerTokens)
+                Shimmer(modifier = Modifier.size(120.dp, 80.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 Column(
                     Modifier
                         .height(80.dp)
                         .padding(top = 10.dp, bottom = 10.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Shimmer(modifier = Modifier.size(140.dp, 12.dp), shimmerTokens = shimmerTokens)
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens)
-                    Shimmer(modifier = Modifier.size(200.dp, 12.dp), shimmerTokens = shimmerTokens)
+                    Shimmer(modifier = Modifier.size(140.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
+                    Shimmer(modifier = Modifier.size(200.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 }
             }
             Label(
@@ -133,15 +126,15 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)), shimmerTokens = shimmerTokens)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 Column(
                     Modifier
                         .height(80.dp)
                         .padding(top = 10.dp, bottom = 10.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens)
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens)
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 }
             }
             Row(
@@ -151,15 +144,15 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)), shimmerTokens = shimmerTokens)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 Column(
                     Modifier
                         .height(80.dp)
                         .padding(top = 10.dp, bottom = 10.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Shimmer(modifier = Modifier.size(140.dp, 12.dp), shimmerTokens = shimmerTokens)
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens)
+                    Shimmer(modifier = Modifier.size(140.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 }
             }
             Row(
@@ -169,37 +162,21 @@ class V2ShimmerActivity : V2DemoActivity() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)), shimmerTokens = shimmerTokens)
+                Shimmer(modifier = Modifier.size(60.dp, 60.dp).clip(RoundedCornerShape(50.dp)), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 Column(
                     Modifier
                         .height(80.dp)
                         .padding(top = 10.dp, bottom = 10.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Shimmer(modifier = Modifier.size(140.dp, 12.dp), shimmerTokens = shimmerTokens)
-                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens)
+                    Shimmer(modifier = Modifier.size(140.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
+                    Shimmer(modifier = Modifier.size(180.dp, 12.dp), shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
                 }
             }
             class ShimmerGoldEffectToken : ShimmerTokens() {
                 @Composable
                 override fun knockoutEffectColor(shimmerInfo: ShimmerInfo): Color {
                     return Color(0XFFE1BA27)
-                }
-
-                @Composable
-                override fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
-                    return when (shimmerOrientation) {
-                        0 -> ShimmerOrientation.LEFT_TO_RIGHT
-                        1 -> ShimmerOrientation.RIGHT_TO_LEFT
-                        2 -> ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
-                        3 -> ShimmerOrientation.BOTTOMRIGHT_TO_TOPLEFT
-                        else -> ShimmerOrientation.LEFT_TO_RIGHT
-                    }
-                }
-
-                @Composable
-                override fun isShimmering(shimmerInfo: ShimmerInfo): Boolean {
-                    return isShimmering
                 }
             }
 
@@ -231,7 +208,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                 Label(text = "Badge", textStyle = FluentAliasTokens.TypographyTokens.Body1)
                 Shimmer(content = {
                     Badge(text = "Badge", badgeTokens = BadgeColorToken())
-                }, shimmerTokens = ShimmerGoldEffectToken() , cornerRadius = 100.dp)
+                }, shimmerTokens = ShimmerGoldEffectToken() , cornerRadius = 100.dp, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
             }
             Row(
                 modifier = Modifier
@@ -247,7 +224,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                         size = PersonaChipSize.Small,
                         style = PersonaChipStyle.Brand
                     )
-                }, shimmerTokens = shimmerTokens)
+                }, shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
             }
             Row(
                 modifier = Modifier
@@ -264,7 +241,7 @@ class V2ShimmerActivity : V2DemoActivity() {
                             status = AvatarStatus.Available,
                         ), size = AvatarSize.Size72, enableActivityRings = false
                     )
-                }, shimmerTokens = shimmerTokens)
+                }, shimmerTokens = shimmerTokens, isShimmering = isShimmering, shimmerOrientation = getShimmerOrientation(shimmerOrientation))
             }
             Label(
                 text = "Change Orientation",

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
@@ -43,4 +43,9 @@ open class ShimmerTokens : IControlToken, Parcelable {
     open fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
         return ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
     }
+
+    @Composable
+    open fun isShimmering(shimmerInfo: ShimmerInfo): Boolean {
+        return true
+    }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
@@ -33,19 +33,4 @@ open class ShimmerTokens : IControlToken, Parcelable {
             themeMode = FluentTheme.themeMode
         )
     }
-
-    @Composable
-    open fun delay(shimmerInfo: ShimmerInfo): Int {
-        return 1000
-    }
-
-    @Composable
-    open fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
-        return ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
-    }
-
-    @Composable
-    open fun isShimmering(shimmerInfo: ShimmerInfo): Boolean {
-        return true
-    }
 }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -40,12 +40,12 @@ import kotlin.math.sqrt
 private const val DEFAULT_CORNER_RADIUS = 4
 
 /**
- * Create Shimmer effect on some content, creates an empty shimmer if content not provided.
+ * Create Shimmer effect on some content, creates an empty shimmer if content not provided or left null
  *
  * @param cornerRadius Corner radius of the shimmer
  * @param modifier Modifier for shimmer
  * @param shimmerTokens Token values for shimmer
- * @param content Content to be shimmered, creates ab
+ * @param content Content to be shimmered, creates an empty shimmer if content not provided or left null
  *
  */
 @Composable

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -124,8 +124,7 @@ internal fun InternalShimmer(
     val cornerRadius =
         dpToPx(cornerRadius)
     val infiniteTransition = rememberInfiniteTransition()
-    val orientation: ShimmerOrientation = shimmerOrientation
-    val isLtr = if (orientation in listOf(
+    val isLtr = if (shimmerOrientation in listOf(
             ShimmerOrientation.LEFT_TO_RIGHT,
             ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
         )
@@ -145,26 +144,26 @@ internal fun InternalShimmer(
                 )
             )
     }
-     else{
+     else {
         remember { mutableFloatStateOf(0f) }
     }
 
-    val startOffset: Offset = when (orientation) {
+    val startOffset: Offset = when (shimmerOrientation) {
         ShimmerOrientation.LEFT_TO_RIGHT -> Offset.Zero
         ShimmerOrientation.RIGHT_TO_LEFT -> Offset.Zero
         ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT -> Offset.Zero
         ShimmerOrientation.BOTTOMRIGHT_TO_TOPLEFT -> Offset.Zero
         else -> Offset.Zero
     }
-    val endOffset: Offset = if(isShimmering){
-        when (orientation) {
+    val endOffset: Offset = if (isShimmering) {
+        when (shimmerOrientation) {
             ShimmerOrientation.LEFT_TO_RIGHT -> Offset(shimmerEffect.absoluteValue, 0F)
             ShimmerOrientation.RIGHT_TO_LEFT -> Offset(shimmerEffect.absoluteValue, 0F)
             ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT -> Offset(shimmerEffect.absoluteValue, shimmerEffect.absoluteValue)
             ShimmerOrientation.BOTTOMRIGHT_TO_TOPLEFT -> Offset(shimmerEffect.absoluteValue, shimmerEffect.absoluteValue)
             else -> Offset(shimmerEffect.absoluteValue, shimmerEffect.absoluteValue)
         }
-    } else{
+    } else {
         Offset.Zero
     }
     val gradientColor = Brush.linearGradient(
@@ -191,7 +190,7 @@ internal fun InternalShimmer(
             }
         }
     } else {
-        if(true) {
+        if (true) {
             Spacer(
                 modifier = modifier
                     .clip(RoundedCornerShape(cornerRadius))

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -40,56 +40,33 @@ import kotlin.math.sqrt
 private const val DEFAULT_CORNER_RADIUS = 4
 
 /**
- * Create an empty Shimmer effect
- *
- * @param modifier Modifier for shimmer
- * @param shimmerTokens Token values for shimmer
- *
- */
-@Composable
-fun Shimmer(
-    modifier: Modifier = Modifier,
-    shimmerTokens: ShimmerTokens? = null,
-    shimmerDelay: Int = 1000,
-    isShimmering: Boolean = true,
-    shimmerOrientation: ShimmerOrientation = ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT,
-) {
-    InternalShimmer(
-        cornerRadius = DEFAULT_CORNER_RADIUS.dp,
-        modifier = modifier,
-        shimmerTokens = shimmerTokens,
-        shimmerDelay = shimmerDelay,
-        isShimmering = isShimmering,
-        shimmerOrientation = shimmerOrientation
-    )
-}
-
-/**
- * Create Shimmer effect on some content
+ * Create Shimmer effect on some content, creates an empty shimmer if content not provided.
  *
  * @param cornerRadius Corner radius of the shimmer
  * @param modifier Modifier for shimmer
  * @param shimmerTokens Token values for shimmer
- * @param content Content to be shimmered
+ * @param content Content to be shimmered, creates ab
  *
  */
 @Composable
 fun Shimmer(
-    cornerRadius: Dp,
+    cornerRadius: Dp = DEFAULT_CORNER_RADIUS.dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null,
-    shimmerDelay: Int = 1000,
-    isShimmering: Boolean = true,
-    shimmerOrientation: ShimmerOrientation = ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT,
-    content: @Composable () -> Unit,
+    content: (@Composable () -> Unit)? = null,
 ) {
+    if(content == null) {
+        InternalShimmer(
+            cornerRadius = cornerRadius,
+            modifier = modifier,
+            shimmerTokens = shimmerTokens
+        )
+        return
+    }
     InternalShimmer(
         cornerRadius = cornerRadius,
         modifier = modifier,
-        shimmerTokens = shimmerTokens,
-        shimmerDelay = shimmerDelay,
-        isShimmering = isShimmering,
-        shimmerOrientation = shimmerOrientation,
+        shimmerTokens = shimmerTokens
     ) {
         content()
     }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -49,12 +49,18 @@ private const val DEFAULT_CORNER_RADIUS = 4
 @Composable
 fun Shimmer(
     modifier: Modifier = Modifier,
-    shimmerTokens: ShimmerTokens? = null
+    shimmerTokens: ShimmerTokens? = null,
+    shimmerDelay: Int = 1000,
+    isShimmering: Boolean = true,
+    shimmerOrientation: ShimmerOrientation = ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT,
 ) {
     InternalShimmer(
         cornerRadius = DEFAULT_CORNER_RADIUS.dp,
         modifier = modifier,
-        shimmerTokens = shimmerTokens
+        shimmerTokens = shimmerTokens,
+        shimmerDelay = shimmerDelay,
+        isShimmering = isShimmering,
+        shimmerOrientation = shimmerOrientation
     )
 }
 
@@ -72,12 +78,18 @@ fun Shimmer(
     cornerRadius: Dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null,
+    shimmerDelay: Int = 1000,
+    isShimmering: Boolean = true,
+    shimmerOrientation: ShimmerOrientation = ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT,
     content: @Composable () -> Unit,
 ) {
     InternalShimmer(
         cornerRadius = cornerRadius,
         modifier = modifier,
-        shimmerTokens = shimmerTokens
+        shimmerTokens = shimmerTokens,
+        shimmerDelay = shimmerDelay,
+        isShimmering = isShimmering,
+        shimmerOrientation = shimmerOrientation,
     ) {
         content()
     }
@@ -88,6 +100,9 @@ internal fun InternalShimmer(
     cornerRadius: Dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null,
+    shimmerDelay: Int = 1000,
+    isShimmering: Boolean = true,
+    shimmerOrientation: ShimmerOrientation = ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT,
     content: (@Composable () -> Unit)? = null,
 ) {
     val themeID =
@@ -108,9 +123,8 @@ internal fun InternalShimmer(
     val shimmerKnockoutEffectColor = tokens.knockoutEffectColor(shimmerInfo)
     val cornerRadius =
         dpToPx(cornerRadius)
-    val shimmerDelay = tokens.delay(shimmerInfo)
     val infiniteTransition = rememberInfiniteTransition()
-    val orientation: ShimmerOrientation = tokens.orientation(shimmerInfo)
+    val orientation: ShimmerOrientation = shimmerOrientation
     val isLtr = if (orientation in listOf(
             ShimmerOrientation.LEFT_TO_RIGHT,
             ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
@@ -118,7 +132,6 @@ internal fun InternalShimmer(
     ) (LocalLayoutDirection.current == LayoutDirection.Ltr) else (LocalLayoutDirection.current == LayoutDirection.Rtl)
     val initialValue = if (isLtr) 0f else diagonal
     val targetValue = if (isLtr) diagonal else 0f
-    val isShimmering = tokens.isShimmering(shimmerInfo)
     val shimmerEffect by if (isShimmering) {
             infiniteTransition.animateFloat(
                 initialValue,

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -53,20 +53,29 @@ fun Shimmer(
     cornerRadius: Dp = DEFAULT_CORNER_RADIUS.dp,
     modifier: Modifier = Modifier,
     shimmerTokens: ShimmerTokens? = null,
+    shimmerDelay: Int = 1000,
+    isShimmering: Boolean = true,
+    shimmerOrientation: ShimmerOrientation = ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT,
     content: (@Composable () -> Unit)? = null,
 ) {
     if(content == null) {
         InternalShimmer(
             cornerRadius = cornerRadius,
             modifier = modifier,
-            shimmerTokens = shimmerTokens
+            shimmerTokens = shimmerTokens,
+            shimmerDelay = shimmerDelay,
+            isShimmering = isShimmering,
+            shimmerOrientation = shimmerOrientation
         )
         return
     }
     InternalShimmer(
         cornerRadius = cornerRadius,
         modifier = modifier,
-        shimmerTokens = shimmerTokens
+        shimmerTokens = shimmerTokens,
+        shimmerDelay = shimmerDelay,
+        isShimmering = isShimmering,
+        shimmerOrientation = shimmerOrientation,
     ) {
         content()
     }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -176,12 +176,10 @@ internal fun InternalShimmer(
             }
         }
     } else {
-        if (true) {
-            Spacer(
-                modifier = modifier
-                    .clip(RoundedCornerShape(cornerRadius))
-                    .background(gradientColor)
-            )
-        }
+        Spacer(
+            modifier = modifier
+                .clip(RoundedCornerShape(cornerRadius))
+                .background(gradientColor)
+        )
     }
 }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -115,6 +115,7 @@ internal fun InternalShimmer(
             ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
         )
     ) (LocalLayoutDirection.current == LayoutDirection.Ltr) else (LocalLayoutDirection.current == LayoutDirection.Rtl)
+
     val initialValue = if (isLtr) 0f else diagonal
     val targetValue = if (isLtr) diagonal else 0f
     val shimmerEffect by if (isShimmering) {


### PR DESCRIPTION
### Problem 
Shimmer animation was being run in the background even if the compose view containing shimmer was hidden/not in view

### Fix
Added a shimmer token to allow the developers to disable the shimmer animation in the background. This should improve performance and shorten the call stack.

### Screenshots

| Activity Before | Activity After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/077b2678-0f49-4b05-a9ae-b4e19945fb66) | ![image](https://github.com/user-attachments/assets/268909fc-a546-41bb-89b1-f55f8f4cedd7) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
