### PR TITLE
Migrating release and publish pipelines to governed office template

### DIFF
--- a/fluentui-android-release.yml
+++ b/fluentui-android-release.yml
@@ -3,7 +3,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 resources:
   pipelines:
   - pipeline: 'fluentui-android-maven-publish'
-    project: 'fluentui-native'
+    project: 'ISS'
     source: 'fluentui-maven-central-publish [1es-pt]'
   repositories:
   - repository: OfficePipelineTemplates

--- a/fluentui-android-release.yml
+++ b/fluentui-android-release.yml
@@ -40,17 +40,19 @@ extends:
             artifactName: 'Build'
             targetPath: '$(Pipeline.Workspace)/fluentui-android-maven-publish/Build'
         steps:
-        - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@7
+        - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
           displayName: 'ESRP Release'
           inputs:
-            connectedservicename: '$(connectedServiceName)'
-            keyvaultname: $(keyVaultName)
-            authcertname: $(authCertName)
-            signcertname: '$(signCertName) '
-            clientid: '$(clientId)'
+            connectedservicename: 'ESRP-JSHost3'
+            usemanagedidentity: false
+            keyvaultname: 'OGX-JSHost-KV'
+            authcertname: 'OGX-JSHost-Auth4'
+            signcertname: 'OGX-JSHost-Sign3'
+            clientid: '0a35e01f-eadf-420a-a2bf-def002ba898d'
+            domaintenantid: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
             folderlocation: '$(Pipeline.Workspace)/fluentui-android-maven-publish/Build'
-            owners: '$(owners)'
-            approvers: '$(approvers)'
+            owners: 'ronakdhoot@microsoft.com'
+            approvers: 'dhruvmishra@microsoft.com'
             mainpublisher: fluentuiandroidrelease
     - stage: Stage_2
       displayName: AppCenter Release

--- a/fluentui-android-release.yml
+++ b/fluentui-android-release.yml
@@ -6,12 +6,12 @@ resources:
     project: 'fluentui-native'
     source: 'fluentui-maven-central-publish [1es-pt]'
   repositories:
-  - repository: 1ESPipelineTemplates
+  - repository: OfficePipelineTemplates
     type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
     ref: refs/tags/release
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared

--- a/fluentui-android-release.yml
+++ b/fluentui-android-release.yml
@@ -53,7 +53,6 @@ extends:
             folderlocation: '$(Pipeline.Workspace)/fluentui-android-maven-publish/Build'
             owners: 'ronakdhoot@microsoft.com'
             approvers: 'dhruvmishra@microsoft.com'
-            mainpublisher: fluentuiandroidrelease
     - stage: Stage_2
       displayName: AppCenter Release
       jobs:

--- a/fluentui-maven-central-publish-1espt.yml
+++ b/fluentui-maven-central-publish-1espt.yml
@@ -5,12 +5,12 @@ variables:
   value: production,externalfacing
 resources:
   repositories:
-  - repository: 1ESPipelineTemplates
+  - repository: OfficePipelineTemplates
     type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
     ref: refs/tags/release
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     sdl:
       spotBugs:


### PR DESCRIPTION
Migrating the Fluent Android Release and Fluent Maven Central Pipeline to the Office Pipeline Templates.