### PR TITLE
Added Long Press Functionality To FluentIcon

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AppBarActivity.kt
@@ -323,6 +323,13 @@ class V2AppBarActivity : V2DemoActivity() {
                         FluentIcon(
                             SearchBarIcons.Arrowback,
                             contentDescription = "Navigate Back",
+                            onLongClick = {
+                                Toast.makeText(
+                                    context,
+                                    "Navigation Icon long pressed",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            },
                             onClick = {
                                 Toast.makeText(
                                     context,

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -143,13 +143,12 @@ fun Icon(
 fun Modifier.clickAndLongClick(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
-    rippleColour: Color = Color.Unspecified,
+    rippleColor: Color = Color.Unspecified,
 ): Modifier {
     val interactionSource = remember { MutableInteractionSource() }
-    val ripple = rememberRipple(color = rippleColour)
 
     return this
-        .indication(interactionSource, ripple)
+        .indication(interactionSource, rememberRipple(color = rippleColor))
         .pointerInput(Unit) {
             detectTapGestures(
                 onPress = { offset ->

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -194,7 +194,8 @@ fun Icon(
             Modifier.then (
                 if(onLongClick != null) Modifier.clickAndLongClick(
                     onClick = onClick,
-                    onLongClick = onLongClick
+                    onLongClick = onLongClick,
+                    rippleColor = Color.Unspecified
                 )
                 else Modifier.clickable(
                     interactionSource = remember { MutableInteractionSource() },

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -2,10 +2,14 @@ package com.microsoft.fluentui.theme.token
 
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.remember
@@ -15,11 +19,11 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toolingGraphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
@@ -37,6 +41,7 @@ data class FluentIcon(
     val tint: Color? = null,
     val flipOnRtl: Boolean = false,
     val enabled: Boolean = true,
+    val onLongClick: (() -> Unit)? = null, //TODO: Add tokens for ripple
     val onClick: (() -> Unit)? = null
 ) {
     @Composable
@@ -75,6 +80,7 @@ fun Icon(
         flipOnRtl = icon.flipOnRtl,
         tint = icon.tint ?: tint,
         enabled = icon.enabled,
+        onLongClick = icon.onLongClick,
         onClick = icon.onClick
     )
 }
@@ -103,6 +109,7 @@ fun Icon(
     flipOnRtl: Boolean = false,
     tint: Color = Color.Unspecified,
     enabled: Boolean = true,
+    onLongClick: (() -> Unit)? = null,
     onClick: (() -> Unit)? = null
 ) {
     Icon(
@@ -112,6 +119,7 @@ fun Icon(
         flipOnRtl = flipOnRtl,
         tint = tint,
         enabled = enabled,
+        onLongClick = onLongClick,
         onClick = onClick
     )
 }
@@ -132,6 +140,36 @@ fun Icon(
  * @param onClick onClick Lambda to be invoked when icon is clicked.
  */
 @Composable
+fun Modifier.clickAndLongClick(
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    rippleColour: Color = Color.Unspecified,
+): Modifier {
+    val interactionSource = remember { MutableInteractionSource() }
+    val ripple = rememberRipple(color = rippleColour)
+
+    return this
+        .indication(interactionSource, ripple)
+        .pointerInput(Unit) {
+            detectTapGestures(
+                onPress = { offset ->
+                    val press = PressInteraction.Press(offset)
+                    interactionSource.emit(press)
+                    val released = tryAwaitRelease() // for hold clicks
+                    val endInteraction = if (released) {
+                        PressInteraction.Release(press)
+                    } else {
+                        PressInteraction.Cancel(press)
+                    }
+                    interactionSource.emit(endInteraction)
+                },
+                onTap = { onClick() },
+                onLongPress = { onLongClick() }
+            )
+        }
+}
+
+@Composable
 fun Icon(
     painter: Painter,
     contentDescription: String?,
@@ -139,6 +177,7 @@ fun Icon(
     flipOnRtl: Boolean = false,
     tint: Color = Color.Unspecified,
     enabled: Boolean = true,
+    onLongClick: (() -> Unit)? = null,
     onClick: (() -> Unit)? = null
 ) {
     val colorFilter = if (tint == Color.Unspecified) null else ColorFilter.tint(tint)
@@ -152,11 +191,18 @@ fun Icon(
     }
 
     val clickableModifier = Modifier.then(
-        if (onClick != null) Modifier.clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = LocalIndication.current,
-            enabled = enabled,
-            onClick = onClick
+        if (onClick != null)
+            Modifier.then (
+                if(onLongClick != null) Modifier.clickAndLongClick(
+                    onClick = onClick,
+                    onLongClick = onLongClick
+                )
+                else Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = LocalIndication.current,
+                    enabled = enabled,
+                    onClick = onClick
+                )
         ) else Modifier
     )
 

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -125,7 +125,7 @@ fun Icon(
 }
 
 /**
- * Icon component that draws a [painter] using [tint] .
+ * Icon component that draws a [painter] using [tint].
  *
  * @param painter [Painter] to draw inside this Icon
  * @param contentDescription text used by accessibility services to describe what this icon

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/FluentIcon.kt
@@ -125,7 +125,7 @@ fun Icon(
 }
 
 /**
- * Icon component that draws a [painter] using [tint].
+ * Icon component that draws a [painter] using [tint] .
  *
  * @param painter [Painter] to draw inside this Icon
  * @param contentDescription text used by accessibility services to describe what this icon

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -152,7 +152,7 @@ fun AppBar(
                                     if(navigationIcon.onLongClick != null) Modifier.clickAndLongClick(
                                         onClick = navigationIcon.onClick!!,
                                         onLongClick = navigationIcon.onLongClick!!,
-                                        rippleColour = token.navigationIconRippleColor()
+                                        rippleColor = token.navigationIconRippleColor()
                                     )
                                     else Modifier.clickable(
                                         interactionSource = remember { MutableInteractionSource() },

--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -146,17 +146,24 @@ fun AppBar(
                     Icon(
                         navigationIcon,
                         modifier =
-                        Modifier
-                            .then(
-                                if (navigationIcon.onClick != null)
-                                    Modifier.clickable(
+                        Modifier.then(
+                            if (navigationIcon.onClick != null)
+                                Modifier.then (
+                                    if(navigationIcon.onLongClick != null) Modifier.clickAndLongClick(
+                                        onClick = navigationIcon.onClick!!,
+                                        onLongClick = navigationIcon.onLongClick!!,
+                                        rippleColour = token.navigationIconRippleColor()
+                                    )
+                                    else Modifier.clickable(
                                         interactionSource = remember { MutableInteractionSource() },
                                         indication = rememberRipple(color = token.navigationIconRippleColor()),
-                                        enabled = true,
-                                        onClick = navigationIcon.onClick ?: {}
+                                        enabled = navigationIcon.enabled,
+                                        onClick = navigationIcon.onClick!!
                                     )
-                                else Modifier
-                            )
+                                )
+                            else
+                                Modifier
+                        )
                             .padding(token.navigationIconPadding(appBarInfo))
                             .size(token.leftIconSize(appBarInfo)),
                         tint = token.navigationIconColor(appBarInfo)


### PR DESCRIPTION
Added Long Press Functionality To FluentIcon

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [navIconBeforeLongPress.webm](https://github.com/user-attachments/assets/b860cd9f-ca66-4525-b6be-74503df97322) | [navIconLongPressDemo.webm](https://github.com/user-attachments/assets/eaa2b207-b47a-426d-99c3-228ecbba525a) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
