### PR TITLE
Restored Shimmer Tokens

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ShimmerActivity.kt
@@ -85,7 +85,17 @@ class V2ShimmerActivity : V2DemoActivity() {
     private fun CreateShimmerActivityUI() {
         var shimmerOrientation by rememberSaveable { mutableStateOf(0) }
         var isShimmering by rememberSaveable { mutableStateOf(true) }
-        val shimmerTokens = ShimmerTokens()
+        val shimmerTokens = object: ShimmerTokens(){
+            @Composable
+            override fun delay(shimmerInfo: ShimmerInfo): Int {
+                return 1000
+            }
+
+            @Composable
+            override fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
+                return getShimmerOrientation(shimmerOrientation)
+            }
+        }
         Column(
             Modifier
                 .padding(all = 12.dp)

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ShimmerTokens.kt
@@ -15,7 +15,8 @@ enum class ShimmerOrientation {
     LEFT_TO_RIGHT,
     RIGHT_TO_LEFT,
     TOPLEFT_TO_BOTTOMRIGHT,
-    BOTTOMRIGHT_TO_TOPLEFT
+    BOTTOMRIGHT_TO_TOPLEFT,
+    _NONE //DO NOT USE
 }
 
 @Parcelize
@@ -32,5 +33,15 @@ open class ShimmerTokens : IControlToken, Parcelable {
         return FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Stencil1].value(
             themeMode = FluentTheme.themeMode
         )
+    }
+
+    @Composable
+    open fun delay(shimmerInfo: ShimmerInfo): Int {
+        return -1
+    }
+
+    @Composable
+    open fun orientation(shimmerInfo: ShimmerInfo): ShimmerOrientation {
+        return ShimmerOrientation._NONE //Do not return ShimmerOrientation._NONE if you are overriding this method, it will default to ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT in that case
     }
 }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -101,8 +101,9 @@ internal fun InternalShimmer(
     val diagonal =
         sqrt((screenHeight * screenHeight + screenWidth * screenWidth).toDouble()).toFloat()
     val shimmerInfo = ShimmerInfo()
-    val shimmerDelayValue = if(tokens.delay(shimmerInfo) != -1){
-        tokens.delay(shimmerInfo)
+    val cachedDelay = tokens.delay(shimmerInfo)
+    val shimmerDelayValue = if (cachedDelay != -1) {
+        cachedDelay
     } else {
         shimmerDelay
     }

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -101,6 +101,16 @@ internal fun InternalShimmer(
     val diagonal =
         sqrt((screenHeight * screenHeight + screenWidth * screenWidth).toDouble()).toFloat()
     val shimmerInfo = ShimmerInfo()
+    val shimmerDelayValue = if(tokens.delay(shimmerInfo) != -1){
+        tokens.delay(shimmerInfo)
+    } else {
+        shimmerDelay
+    }
+    val orientation: ShimmerOrientation = if(tokens.orientation(shimmerInfo) != ShimmerOrientation._NONE){
+        tokens.orientation(shimmerInfo)
+    } else {
+        shimmerOrientation
+    }
     val shimmerBackgroundColor = if (content != null) {
         Color.Transparent
     } else {
@@ -110,7 +120,7 @@ internal fun InternalShimmer(
     val cornerRadius =
         dpToPx(cornerRadius)
     val infiniteTransition = rememberInfiniteTransition()
-    val isLtr = if (shimmerOrientation in listOf(
+    val isLtr = if (orientation in listOf(
             ShimmerOrientation.LEFT_TO_RIGHT,
             ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT
         )
@@ -124,7 +134,7 @@ internal fun InternalShimmer(
                 targetValue,
                 infiniteRepeatable(
                     animation = tween(
-                        durationMillis = shimmerDelay,
+                        durationMillis = shimmerDelayValue,
                         easing = LinearEasing
                     ),
                     repeatMode = RepeatMode.Restart
@@ -135,7 +145,7 @@ internal fun InternalShimmer(
         remember { mutableFloatStateOf(0f) }
     }
 
-    val startOffset: Offset = when (shimmerOrientation) {
+    val startOffset: Offset = when (orientation) {
         ShimmerOrientation.LEFT_TO_RIGHT -> Offset.Zero
         ShimmerOrientation.RIGHT_TO_LEFT -> Offset.Zero
         ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT -> Offset.Zero
@@ -143,7 +153,7 @@ internal fun InternalShimmer(
         else -> Offset.Zero
     }
     val endOffset: Offset = if (isShimmering) {
-        when (shimmerOrientation) {
+        when (orientation) {
             ShimmerOrientation.LEFT_TO_RIGHT -> Offset(shimmerEffect.absoluteValue, 0F)
             ShimmerOrientation.RIGHT_TO_LEFT -> Offset(shimmerEffect.absoluteValue, 0F)
             ShimmerOrientation.TOPLEFT_TO_BOTTOMRIGHT -> Offset(shimmerEffect.absoluteValue, shimmerEffect.absoluteValue)

--- a/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
+++ b/fluentui_progress/src/main/java/com/microsoft/fluentui/tokenized/shimmer/Shimmer.kt
@@ -106,8 +106,9 @@ internal fun InternalShimmer(
     } else {
         shimmerDelay
     }
-    val orientation: ShimmerOrientation = if(tokens.orientation(shimmerInfo) != ShimmerOrientation._NONE){
-        tokens.orientation(shimmerInfo)
+    val tokenOrientation = tokens.orientation(shimmerInfo)
+    val orientation: ShimmerOrientation = if(tokenOrientation != ShimmerOrientation._NONE){
+        tokenOrientation
     } else {
         shimmerOrientation
     }


### PR DESCRIPTION
### Problem 
Shimmer Tokens for delay and orientation were removed in release v0.3.7. This caused problems with applications that rely on using tokens for these values. 

### Root cause 
Removal of tokens

### Fix
Restored these tokens to have backward compatibility despite the API changes

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
