### PR TITLE
[V2 AppBarLayout] Avoid truncating post title icons when title is large

### DIFF
--- a/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
+++ b/fluentui_topappbars/src/main/java/com/microsoft/fluentui/tokenized/AppBar.kt
@@ -203,7 +203,8 @@ fun AppBar(
                                     )
                                 ),
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false)
                             )
                             if (postTitleIcon.isIconAvailable() && appBarSize == AppBarSize.Small)
                                 Icon(


### PR DESCRIPTION
### Problem 
Long text in title bar truncated post title icons

### Fix
Added weight to text to avoid truncating icons 

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![appBarLayoutBefore](https://github.com/user-attachments/assets/827f62e9-7785-4547-8b60-5db50c35e184) | ![appBarLayoutAfter](https://github.com/user-attachments/assets/d194e931-f597-4dc6-8e28-a68564db79c1) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
