### PR TITLE
[V2 Bottomsheet] Fixed Bottomsheet Not Appearing in Office

### DIFF
--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -10,7 +10,6 @@ import android.content.res.Configuration
 import android.view.*
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityManager
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.*
 import androidx.compose.foundation.gestures.Orientation
@@ -368,7 +367,6 @@ fun BottomSheet(
         Box(
             Modifier
                 .align(Alignment.TopCenter)
-                .animateContentSize()
                 .fillMaxWidth(
                     if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) maxLandscapeWidth
                     else 1F

--- a/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
+++ b/fluentui_drawer/src/main/java/com/microsoft/fluentui/tokenized/bottomsheet/BottomSheet.kt
@@ -547,7 +547,7 @@ fun BottomSheet(
                         }
                     } else Modifier.fillMaxSize()), content = {
                         sheetContent()
-                        Box(
+                        Spacer(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .height(


### PR DESCRIPTION
### Problem 
Due to delayed loading of the Bottomsheet, the Box added for smooth resizing was not initialized properly causing the sheet height to be set to 0. Replacing that with Column Spacer fixes the issue.

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  | 
![image](https://github.com/user-attachments/assets/fc7e3b24-d2d7-480e-b91b-5d01c33c4ea5)
 |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
