### PR TITLE
[Fluent V2] Fixes for Fluent Native Controls

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
@@ -37,6 +37,7 @@ import com.microsoft.fluentui.tokenized.menu.Menu
 import com.microsoft.fluentuidemo.R
 import com.microsoft.fluentuidemo.V2DemoActivity
 
+val DefaultMenuInputWidthFraction = 0.35f
 
 class V2MenuActivity : V2DemoActivity() {
     init {

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
@@ -63,36 +63,41 @@ fun CreateMenuActivityUI(context: Context) {
     val repeatContentTextCountState = rememberSaveable { mutableStateOf("4") }
     val contentTextState =
         rememberSaveable { mutableStateOf(context.getString(R.string.menu_content_text_input)) }
+    val textFieldWidthFraction = 0.35f
     Column {
         Column {
             ListItem.Header(title = context.getString(R.string.menu_xOffset),
+                titleMaxLines = 2,
                 trailingAccessoryContent = {
                     BasicTextField(value = xOffsetState.value,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         onValueChange = { xOffsetState.value = it.trim() },
-                        modifier = Modifier.background(Color.White))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
                 }
             )
             ListItem.Header(title = context.getString(R.string.menu_yOffset),
+                titleMaxLines = 2,
                 trailingAccessoryContent = {
                     BasicTextField(value = yOffsetState.value,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         onValueChange = { yOffsetState.value = it.trim() },
-                        modifier = Modifier.background(Color.White))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
                 })
             ListItem.Header(title = context.getString(R.string.menu_content_text),
+                titleMaxLines = 2,
                 trailingAccessoryContent = {
                     BasicTextField(
                         value = contentTextState.value,
                         onValueChange = { contentTextState.value = it },
-                        modifier = Modifier.background(Color.White))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
                 })
             ListItem.Header(title = context.getString(R.string.menu_repeat_content_text),
+                titleMaxLines = 2,
                 trailingAccessoryContent = {
                     BasicTextField(value = repeatContentTextCountState.value,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         onValueChange = { repeatContentTextCountState.value = it.trim() },
-                        modifier = Modifier.background(Color.White))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
                 })
             ListItem.SectionDescription(description = context.getString(R.string.menu_description))
         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
@@ -63,7 +63,7 @@ fun CreateMenuActivityUI(context: Context) {
     val repeatContentTextCountState = rememberSaveable { mutableStateOf("4") }
     val contentTextState =
         rememberSaveable { mutableStateOf(context.getString(R.string.menu_content_text_input)) }
-    val textFieldWidthFraction = 0.35f
+    val textFieldWidthFraction = DefaultMenuInputWidthFraction
     Column {
         Column {
             ListItem.Header(title = context.getString(R.string.menu_xOffset),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2MenuActivity.kt
@@ -64,7 +64,6 @@ fun CreateMenuActivityUI(context: Context) {
     val repeatContentTextCountState = rememberSaveable { mutableStateOf("4") }
     val contentTextState =
         rememberSaveable { mutableStateOf(context.getString(R.string.menu_content_text_input)) }
-    val textFieldWidthFraction = DefaultMenuInputWidthFraction
     Column {
         Column {
             ListItem.Header(title = context.getString(R.string.menu_xOffset),
@@ -73,7 +72,7 @@ fun CreateMenuActivityUI(context: Context) {
                     BasicTextField(value = xOffsetState.value,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         onValueChange = { xOffsetState.value = it.trim() },
-                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = DefaultMenuInputWidthFraction))
                 }
             )
             ListItem.Header(title = context.getString(R.string.menu_yOffset),
@@ -82,7 +81,7 @@ fun CreateMenuActivityUI(context: Context) {
                     BasicTextField(value = yOffsetState.value,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         onValueChange = { yOffsetState.value = it.trim() },
-                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = DefaultMenuInputWidthFraction))
                 })
             ListItem.Header(title = context.getString(R.string.menu_content_text),
                 titleMaxLines = 2,
@@ -90,7 +89,7 @@ fun CreateMenuActivityUI(context: Context) {
                     BasicTextField(
                         value = contentTextState.value,
                         onValueChange = { contentTextState.value = it },
-                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = DefaultMenuInputWidthFraction))
                 })
             ListItem.Header(title = context.getString(R.string.menu_repeat_content_text),
                 titleMaxLines = 2,
@@ -98,7 +97,7 @@ fun CreateMenuActivityUI(context: Context) {
                     BasicTextField(value = repeatContentTextCountState.value,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         onValueChange = { repeatContentTextCountState.value = it.trim() },
-                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = textFieldWidthFraction))
+                        modifier = Modifier.background(Color.White).fillMaxWidth(fraction = DefaultMenuInputWidthFraction))
                 })
             ListItem.SectionDescription(description = context.getString(R.string.menu_description))
         }

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ScaffoldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ScaffoldActivity.kt
@@ -160,6 +160,7 @@ class V2ScaffoldActivity : V2DemoActivity() {
         }
     }
 
+    @OptIn(ExperimentalLayoutApi::class)
     @Composable
     private fun GetContent(context: Context, snackbarState: SnackbarState? = null) {
         val size = remember { mutableStateOf(5) }
@@ -171,7 +172,7 @@ class V2ScaffoldActivity : V2DemoActivity() {
                 drawerState = drawerState,
                 drawerContent = { CreateList(size = 20, context = context) }
             )
-            Row(
+            FlowRow(
                 modifier = Modifier.padding(8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
@@ -179,11 +180,10 @@ class V2ScaffoldActivity : V2DemoActivity() {
                     style = ButtonStyle.OutlinedButton,
                     size = ButtonSize.Medium,
                     text = context.resources.getString(R.string.scaffold_refresh_list),
-                    onClick = { size.value = (40 * Math.random()).toInt() },
-                    modifier = Modifier.weight(1f))
+                    onClick = { size.value = (40 * Math.random()).toInt() })
 
                 Button(
-                    modifier = Modifier.testTag(SCAFFOLD_DRAWER_BUTTON).weight(1f),
+                    modifier = Modifier.testTag(SCAFFOLD_DRAWER_BUTTON),
                     style = ButtonStyle.OutlinedButton,
                     size = ButtonSize.Medium,
                     text = context.resources.getString(R.string.scaffold_open_drawer),
@@ -202,7 +202,7 @@ class V2ScaffoldActivity : V2DemoActivity() {
                         LocalContext.current.resources.getString(R.string.fluentui_timeout)
                     var displayString: String = ""
                     Button(
-                        modifier = Modifier.testTag(SCAFFOLD_SNACKBAR_BUTTON).weight(1f),
+                        modifier = Modifier.testTag(SCAFFOLD_SNACKBAR_BUTTON),
                         style = ButtonStyle.OutlinedButton,
                         size = ButtonSize.Medium,
                         text = context.resources.getString(R.string.fluentui_show_snackbar),

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ScaffoldActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2ScaffoldActivity.kt
@@ -179,10 +179,11 @@ class V2ScaffoldActivity : V2DemoActivity() {
                     style = ButtonStyle.OutlinedButton,
                     size = ButtonSize.Medium,
                     text = context.resources.getString(R.string.scaffold_refresh_list),
-                    onClick = { size.value = (40 * Math.random()).toInt() })
+                    onClick = { size.value = (40 * Math.random()).toInt() },
+                    modifier = Modifier.weight(1f))
 
                 Button(
-                    modifier = Modifier.testTag(SCAFFOLD_DRAWER_BUTTON),
+                    modifier = Modifier.testTag(SCAFFOLD_DRAWER_BUTTON).weight(1f),
                     style = ButtonStyle.OutlinedButton,
                     size = ButtonSize.Medium,
                     text = context.resources.getString(R.string.scaffold_open_drawer),
@@ -201,7 +202,7 @@ class V2ScaffoldActivity : V2DemoActivity() {
                         LocalContext.current.resources.getString(R.string.fluentui_timeout)
                     var displayString: String = ""
                     Button(
-                        modifier = Modifier.testTag(SCAFFOLD_SNACKBAR_BUTTON),
+                        modifier = Modifier.testTag(SCAFFOLD_SNACKBAR_BUTTON).weight(1f),
                         style = ButtonStyle.OutlinedButton,
                         size = ButtonSize.Medium,
                         text = context.resources.getString(R.string.fluentui_show_snackbar),

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -198,9 +198,9 @@ class ListContentBuilder {
                                 onClick = itemDataList[row * itemsInRow + col].onClick,
                                 accessory = itemDataList[row * itemsInRow + col].accessory,
                                 icon = itemDataList[row * itemsInRow + col].icon,
-                                modifier = Modifier.semantics {
+                                modifier = Modifier.fillMaxWidth(widthRatio).semantics {
                                     contentDescription = titleString
-                                }.fillMaxWidth(widthRatio),
+                                },
                                 tabItemTokens = tabItemTokens
                             )
                             col++

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/contentBuilder/ListContentBuilder.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -100,7 +102,7 @@ class ListContentBuilder {
         header: String? = null,
         maxItemInRow: Int = 4,
         equidistant: Boolean = false,
-        tabItemTokens: TabItemTokens? = null
+        tabItemTokens: TabItemTokens? = TabItemTokens()
     ): ListContentBuilder {
         add(VerticalGridContentData(itemDataList, header, maxItemInRow, equidistant, tabItemTokens))
         return this
@@ -157,7 +159,7 @@ class ListContentBuilder {
         header: String?,
         maxItemsInRow: Int,
         equidistant: Boolean,
-        tabItemTokens: TabItemTokens? = null
+        tabItemTokens: TabItemTokens? = TabItemTokens()
     ): LazyListScope.() -> Unit {
         return {
             if (header != null) {
@@ -189,13 +191,16 @@ class ListContentBuilder {
                         else
                             1.0f / min(itemsInRow, (size - (row * itemsInRow)))
                         while (col < itemsInRow && (row * itemsInRow + col) < size) {
+                            val titleString = itemDataList[row * itemsInRow + col].title
                             TabItem(
-                                title = itemDataList[row * itemsInRow + col].title,
+                                title = titleString,
                                 enabled = itemDataList[row * itemsInRow + col].enabled,
                                 onClick = itemDataList[row * itemsInRow + col].onClick,
                                 accessory = itemDataList[row * itemsInRow + col].accessory,
                                 icon = itemDataList[row * itemsInRow + col].icon,
-                                modifier = Modifier.fillMaxWidth(widthRatio),
+                                modifier = Modifier.semantics {
+                                    contentDescription = titleString
+                                }.fillMaxWidth(widthRatio),
                                 tabItemTokens = tabItemTokens
                             )
                             col++
@@ -233,7 +238,7 @@ class ListContentBuilder {
         itemDataList: List<ItemData>,
         header: String?,
         fixedWidth: Boolean = false,
-        tabItemTokens: TabItemTokens? = null
+        tabItemTokens: TabItemTokens? = TabItemTokens()
     ): LazyListScope.() -> Unit {
         return {
             if (header != null) {
@@ -277,6 +282,9 @@ class ListContentBuilder {
                                             )
                                         }
                                     }
+                                }
+                                .semantics {
+                                    contentDescription = item.title
                                 },
                             tabItemTokens = tabItemTokens
                         )
@@ -289,7 +297,7 @@ class ListContentBuilder {
     private fun createVerticalList(
         itemDataList: List<ItemData>,
         header: String?,
-        listItemTokens: ListItemTokens? = null
+        listItemTokens: ListItemTokens? = ListItemTokens()
     ): LazyListScope.() -> Unit {
         return {
             if (header != null) {


### PR DESCRIPTION
### Problem 
Fixed the Following Problems with Fluent Native Controls:
```
[Fluent Native controls] [Android] [V2 BottomSheet]: Name is not defined for the controls.
[Fluent Native controls] [Android] [V2 Menu] : After applying Resize, Text is not visible clearly.
[Fluent Native controls] [Android] [V2 Scaffold]: After applying Resize, Show Snackbar Button is not visible.
```

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/6c77bd12-6514-4453-82e6-de11cbbe6a10) <br> ![image](https://github.com/user-attachments/assets/22331551-2e59-4649-99ee-911aecf2aaae) | ![image](https://github.com/user-attachments/assets/454c5afc-66b0-4357-91c6-d737ea04d72d) <br> ![image](https://github.com/user-attachments/assets/98b923d2-42ef-4526-82cc-a3f5766ae19f) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
