### PR TITLE
[V2 Snackbar] Setting Default Elevation and Shadow Value to 0 

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SnackbarTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/SnackbarTokens.kt
@@ -94,13 +94,7 @@ open class SnackBarTokens : IControlToken, Parcelable {
 
     @Composable
     open fun shadowElevationValue(snackBarInfo: SnackBarInfo): Dp {
-        return when (snackBarInfo.style) {
-            SnackbarStyle.Neutral -> FluentGlobalTokens.ShadowTokens.Shadow02.value
-            SnackbarStyle.Contrast -> FluentGlobalTokens.ShadowTokens.Shadow16.value
-            SnackbarStyle.Accent -> FluentGlobalTokens.ShadowTokens.Shadow04.value
-            SnackbarStyle.Warning -> FluentGlobalTokens.ShadowTokens.Shadow08.value
-            SnackbarStyle.Danger -> FluentGlobalTokens.ShadowTokens.Shadow00.value
-        }
+        return 0.dp
     }
 
     @Composable


### PR DESCRIPTION
### Problem 
Previously added default values to Snackbar Tokens which might render shadows by default for all existing users. Pointed out by @joyeeta26 
Now setting the default value to 0

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
