### PR TITLE
[V2 ListItem] Add Token for Modifying Text Overflow in ListItem Item and Header

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
@@ -352,5 +353,10 @@ open class ListItemTokens : IControlToken, Parcelable {
     @Composable
     open fun textAccessoryContentTextSpacing(listItemInfo: ListItemInfo): Dp {
         return FluentGlobalTokens.SizeTokens.Size40.value
+    }
+
+    @Composable
+    open fun textOverflow(listItemInfo: ListItemInfo): TextOverflow {
+        return TextOverflow.Clip
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/ListItemTokens.kt
@@ -357,6 +357,6 @@ open class ListItemTokens : IControlToken, Parcelable {
 
     @Composable
     open fun textOverflow(listItemInfo: ListItemInfo): TextOverflow {
-        return TextOverflow.Clip
+        return TextOverflow.Ellipsis
     }
 }

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -294,6 +294,7 @@ object ListItem {
             Alignment.Bottom -> Alignment.BottomEnd
             else -> Alignment.CenterEnd
         }
+        val textOverflow = token.textOverflow(listItemInfo)
         Row(
             modifier
                 .background(backgroundColor)
@@ -364,7 +365,7 @@ object ListItem {
                             text = text,
                             style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                             maxLines = textMaxLines,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = textOverflow
                         )
                         if (primaryTextTrailingContent != null) {
                             primaryTextTrailingContent()
@@ -376,7 +377,7 @@ object ListItem {
                                 text = subText,
                                 style = subTextTypography.merge(TextStyle(color = subTextColor)),
                                 maxLines = subTextMaxLines,
-                                overflow = TextOverflow.Ellipsis
+                                overflow = textOverflow
                             )
                         }
                     }
@@ -399,7 +400,7 @@ object ListItem {
                                         text = secondarySubText,
                                         style = secondarySubTextTypography.merge(TextStyle(color = secondarySubTextColor)),
                                         maxLines = secondarySubTextMaxLines,
-                                        overflow = TextOverflow.Ellipsis
+                                        overflow = textOverflow
                                     )
                                 } else if (secondarySubTextAnnotated != null) {
                                     BasicText(
@@ -407,7 +408,7 @@ object ListItem {
                                         text = secondarySubTextAnnotated,
                                         inlineContent = secondarySubTextInlineContent,
                                         maxLines = secondarySubTextMaxLines,
-                                        overflow = TextOverflow.Ellipsis
+                                        overflow = textOverflow
                                     )
                                 }
                                 if (secondarySubTextTrailingContent != null) {
@@ -708,6 +709,7 @@ object ListItem {
         )
         val expandedString = LocalContext.current.resources.getString(R.string.fluentui_expanded)
         val collapsedString = LocalContext.current.resources.getString(R.string.fluentui_collapsed)
+        val textOverflow = token.textOverflow(listItemInfo)
         Box(
             modifier = modifier
                 .fillMaxWidth()
@@ -785,7 +787,7 @@ object ListItem {
                                     text = title,
                                     style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                                     maxLines = titleMaxLines,
-                                    overflow = TextOverflow.Ellipsis
+                                    overflow = textOverflow
                                 )
                                 if(titleTrailingContent != null){
                                     titleTrailingContent()
@@ -801,7 +803,7 @@ object ListItem {
                                 Modifier.clickable(
                                     onClick = accessoryTextOnClick ?: {})
                                     .clearAndSetSemantics { contentDescription = accessoryTextTitle
-                                    role = Role.Button },
+                                        role = Role.Button },
                                 style = actionTextTypography.merge(TextStyle(color = actionTextColor))
                             )
                         }
@@ -1037,7 +1039,7 @@ object ListItem {
         val borderColor = token.borderColor(listItemInfo).getColorByState(
             enabled = enabled, selected = false, interactionSource = interactionSource
         )
-
+        val textOverflow = token.textOverflow(listItemInfo) ?: TextOverflow.Ellipsis
         Box(
             modifier = modifier
                 .fillMaxWidth()
@@ -1064,7 +1066,7 @@ object ListItem {
                         .weight(1f),
                     style = primaryTextTypography.merge(TextStyle(color = primaryTextColor)),
                     maxLines = titleMaxLines,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = textOverflow
                 )
 
                 if (accessoryTextTitle != null) {
@@ -1079,7 +1081,8 @@ object ListItem {
                                 onClick = accessoryTextOnClick ?: {})
                             .clearAndSetSemantics { contentDescription = accessoryTextTitle
                                 role = Role.Button },
-                        style = actionTextTypography.merge(TextStyle(color = actionTextColor))
+                        style = actionTextTypography.merge(TextStyle(color = actionTextColor)),
+                        overflow = textOverflow,
                     )
                 }
                 if (trailingAccessoryContent != null) {

--- a/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
+++ b/fluentui_listitem/src/main/java/com/microsoft/fluentui/tokenized/listitem/ListItem.kt
@@ -1039,7 +1039,7 @@ object ListItem {
         val borderColor = token.borderColor(listItemInfo).getColorByState(
             enabled = enabled, selected = false, interactionSource = interactionSource
         )
-        val textOverflow = token.textOverflow(listItemInfo) ?: TextOverflow.Ellipsis
+        val textOverflow = token.textOverflow(listItemInfo)
         Box(
             modifier = modifier
                 .fillMaxWidth()


### PR DESCRIPTION
### Changes
Added ability to change the Text Overflow for ListItem.Item and Header, through tokens. 
Requested in #785

### Screenshots

| Before (Default using TextOverflow.Ellipsis                                      | After (UsingTextOverflow.Clip)                                     |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/805038b5-eee5-455e-b61e-833a7e296fed) | ![image](https://github.com/user-attachments/assets/0dd383de-d6f6-42a1-b768-5d0bed5ae4f9) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
