### PR TITLE
[V2 AcrylicPane] Added option to Blur Behind

### DIFF
--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
@@ -63,8 +63,10 @@ class V2AcrylicPaneActivity : V2DemoActivity() {
         setupActivity(this)
     }
 
-    override val paramsUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#params-18" //TODO: Update this URL
-    override val controlTokensUrl = "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-18"
+    override val paramsUrl =
+        "https://github.com/microsoft/fluentui-android/wiki/Controls#params-18" //TODO: Update this URL
+    override val controlTokensUrl =
+        "https://github.com/microsoft/fluentui-android/wiki/Controls#control-tokens-18"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -77,7 +79,7 @@ class V2AcrylicPaneActivity : V2DemoActivity() {
 @Composable
 fun CreateAcrylicPaneActivityUI(
     context: Context
-){
+) {
     var acrylicPaneSizeFraction by rememberSaveable { mutableFloatStateOf(0.5F) }
     var acrylicPaneOrientation by rememberSaveable { mutableStateOf(AcrylicPaneOrientation.BOTTOM) }
     var acrylicPaneBlurRadius by rememberSaveable { mutableStateOf(0.0f) }
@@ -110,7 +112,7 @@ fun CreateAcrylicPaneActivityUI(
                         },
                 )
                 var checkBoxSelectedValues = List(3) { rememberSaveable { mutableStateOf(false) } }
-                when( acrylicPaneOrientation) {
+                when (acrylicPaneOrientation) {
                     AcrylicPaneOrientation.TOP -> checkBoxSelectedValues[0].value = true
                     AcrylicPaneOrientation.CENTER -> checkBoxSelectedValues[1].value = true
                     AcrylicPaneOrientation.BOTTOM -> checkBoxSelectedValues[2].value = true
@@ -229,9 +231,16 @@ fun CreateAcrylicPaneActivityUI(
                             .fillMaxWidth()
                             .padding(horizontal = 12.dp, vertical = 5.dp)
                     ) {
-                        Text(text = "Text $it", fontSize = 14.sp,
+                        Text(
+                            text = "Text $it", fontSize = 14.sp,
                             style = FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Body1]
-                                .merge(TextStyle(color = FluentTheme.aliasTokens.neutralForegroundColor[Foreground2].value(themeMode = FluentTheme.themeMode)))
+                                .merge(
+                                    TextStyle(
+                                        color = FluentTheme.aliasTokens.neutralForegroundColor[Foreground2].value(
+                                            themeMode = FluentTheme.themeMode
+                                        )
+                                    )
+                                )
                         )
                     }
                 }
@@ -242,10 +251,14 @@ fun CreateAcrylicPaneActivityUI(
 }
 
 @Composable
-fun showBottomDrawer(){
+fun showBottomDrawer() {
     val scope = rememberCoroutineScope()
 
-    val drawerState = rememberBottomDrawerState(initialValue = DrawerValue.Closed, expandable = true, skipOpenState = false)
+    val drawerState = rememberBottomDrawerState(
+        initialValue = DrawerValue.Closed,
+        expandable = true,
+        skipOpenState = false
+    )
 
     val open: () -> Unit = {
         scope.launch { drawerState.open() }
@@ -284,7 +297,7 @@ fun showBottomDrawer(){
 }
 
 @Composable
-fun acrylicPaneContent(context: Context){
+fun acrylicPaneContent(context: Context) {
     val scope = rememberCoroutineScope()
 
     val microphonePressedString = getDemoAppString(DemoAppStrings.MicrophonePressed)
@@ -300,9 +313,11 @@ fun acrylicPaneContent(context: Context){
     val showCustomizedAppBar = false
     Column {
         Spacer(modifier = Modifier.height(80.dp))
-        Row(Modifier
-            .height(5.dp)
-            .padding(20.dp)) {
+        Row(
+            Modifier
+                .height(5.dp)
+                .padding(20.dp)
+        ) {
             SearchBar(
                 onValueChange = { query, selectedPerson ->
                     scope.launch {

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
@@ -93,7 +93,7 @@ fun CreateAcrylicPaneActivityUI(
     AcrylicPane(
         paneHeight = (acrylicPaneSizeFraction * 500).toInt().dp,
         orientation = acrylicPaneOrientation,
-        component = { acrylicPaneContent(context = context) },
+        component = { AcrylicPaneContent(context = context) },
         backgroundContent = {
             Column(
                 modifier = Modifier
@@ -111,18 +111,18 @@ fun CreateAcrylicPaneActivityUI(
                             this.contentDescription = "Acrylic Pane Orientation"
                         },
                 )
-                var checkBoxSelectedValues = List(3) { rememberSaveable { mutableStateOf(false) } }
+                val checkBoxSelectedValues = List(3) { rememberSaveable { mutableStateOf(false) } }
                 when (acrylicPaneOrientation) {
                     AcrylicPaneOrientation.TOP -> checkBoxSelectedValues[0].value = true
                     AcrylicPaneOrientation.CENTER -> checkBoxSelectedValues[1].value = true
                     AcrylicPaneOrientation.BOTTOM -> checkBoxSelectedValues[2].value = true
                 }
-                var acrylicPaneOrientations = listOf(
+                val acrylicPaneOrientations = listOf(
                     AcrylicPaneOrientation.TOP,
                     AcrylicPaneOrientation.CENTER,
                     AcrylicPaneOrientation.BOTTOM,
                 )
-                var orientations = listOf("Top", "Center", "Bottom")
+                val orientations = listOf("Top", "Center", "Bottom")
                 for (i in 0..2) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
@@ -214,7 +214,7 @@ fun CreateAcrylicPaneActivityUI(
                             this.contentDescription = "Test Bottom Drawer"
                         },
                 )
-                showBottomDrawer()
+                ShowBottomDrawer()
                 ListItem.Header(
                     title = "Scroll Test",
                     titleMaxLines = 2,
@@ -251,7 +251,7 @@ fun CreateAcrylicPaneActivityUI(
 }
 
 @Composable
-fun showBottomDrawer() {
+fun ShowBottomDrawer() {
     val scope = rememberCoroutineScope()
 
     val drawerState = rememberBottomDrawerState(
@@ -297,7 +297,7 @@ fun showBottomDrawer() {
 }
 
 @Composable
-fun acrylicPaneContent(context: Context) {
+fun AcrylicPaneContent(context: Context) {
     val scope = rememberCoroutineScope()
 
     val microphonePressedString = getDemoAppString(DemoAppStrings.MicrophonePressed)

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
@@ -42,6 +42,9 @@ import com.microsoft.fluentui.theme.token.FluentAliasTokens
 import com.microsoft.fluentui.theme.token.FluentAliasTokens.NeutralForegroundColorTokens.Foreground2
 import com.microsoft.fluentui.theme.token.FluentIcon
 import com.microsoft.fluentui.theme.token.FluentStyle
+import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneInfo
+import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneOrientation
+import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneTokens
 import com.microsoft.fluentui.tokenized.SearchBar
 import com.microsoft.fluentui.tokenized.controls.RadioButton
 import com.microsoft.fluentui.tokenized.drawer.DrawerValue
@@ -76,18 +79,99 @@ fun CreateAcrylicPaneActivityUI(
     context: Context
 ){
     var acrylicPaneSizeFraction by rememberSaveable { mutableFloatStateOf(0.5F) }
-    var acrylicPaneStyle by rememberSaveable { mutableStateOf(FluentStyle.Neutral) }
+    var acrylicPaneOrientation by rememberSaveable { mutableStateOf(AcrylicPaneOrientation.BOTTOM) }
+    var acrylicPaneBlurRadius by rememberSaveable { mutableStateOf(0.0f) }
+    val acrylicPaneTokens: AcrylicPaneTokens = object : AcrylicPaneTokens() {
+        @Composable
+        override fun acrylicPaneBlurRadius(acrylicPaneInfo: AcrylicPaneInfo): Int {
+            return acrylicPaneBlurRadius.toInt()
+        }
+    }
 
     AcrylicPane(
         paneHeight = (acrylicPaneSizeFraction * 500).toInt().dp,
-        acrylicPaneStyle = acrylicPaneStyle,
+        orientation = acrylicPaneOrientation,
         component = { acrylicPaneContent(context = context) },
         backgroundContent = {
             Column(
-                modifier = Modifier.verticalScroll(rememberScrollState()).fillMaxWidth().padding(10.dp),
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .fillMaxWidth()
+                    .padding(10.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Spacer(Modifier.height(300.dp))
+                ListItem.Header(
+                    title = "Acrylic Pane Orientation",
+                    titleMaxLines = 2,
+                    modifier = Modifier
+                        .clearAndSetSemantics {
+                            this.contentDescription = "Acrylic Pane Orientation"
+                        },
+                )
+                var checkBoxSelectedValues = List(3) { rememberSaveable { mutableStateOf(false) } }
+                when( acrylicPaneOrientation) {
+                    AcrylicPaneOrientation.TOP -> checkBoxSelectedValues[0].value = true
+                    AcrylicPaneOrientation.CENTER -> checkBoxSelectedValues[1].value = true
+                    AcrylicPaneOrientation.BOTTOM -> checkBoxSelectedValues[2].value = true
+                }
+                var acrylicPaneOrientations = listOf(
+                    AcrylicPaneOrientation.TOP,
+                    AcrylicPaneOrientation.CENTER,
+                    AcrylicPaneOrientation.BOTTOM,
+                )
+                var orientations = listOf("Top", "Center", "Bottom")
+                for (i in 0..2) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Start,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 10.dp, vertical = 3.dp)
+                    ) {
+                        Text(text = "Orientation ${orientations[i]}")
+                        Spacer(modifier = Modifier.width(320.dp))
+                        RadioButton(
+                            onClick = {
+                                selectRadioGroupButton(i, checkBoxSelectedValues)
+                                acrylicPaneOrientation = acrylicPaneOrientations[i]
+                            },
+                            selected = checkBoxSelectedValues[i].value
+                        )
+                    }
+                }
+                ListItem.Header(
+                    title = "Blur Radius",
+                    titleMaxLines = 2,
+                    modifier = Modifier
+                        .clearAndSetSemantics {
+                            this.contentDescription = "Acrylic Pane Blur Radius"
+                        },
+                )
+                Slider(
+                    value = acrylicPaneBlurRadius,
+                    onValueChange = { acrylicPaneBlurRadius = it },
+                    valueRange = 0F..200F,
+                    colors = SliderDefaults.colors(
+                        thumbColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
+                            FluentTheme.themeMode
+                        ),
+                        activeTrackColor = FluentTheme.aliasTokens.brandColor[FluentAliasTokens.BrandColorTokens.Color80],
+                        inactiveTrackColor = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background3].value(
+                            FluentTheme.themeMode
+                        ),
+                        disabledThumbColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            FluentTheme.themeMode
+                        ),
+                        disabledActiveTrackColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            FluentTheme.themeMode
+                        ),
+                        disabledInactiveTrackColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.ForegroundDisable1].value(
+                            FluentTheme.themeMode
+                        )
+                    ),
+                    steps = 9
+                )
                 ListItem.Header(
                     title = "Acrylic Pane Size",
                     titleMaxLines = 2,
@@ -121,37 +205,6 @@ fun CreateAcrylicPaneActivityUI(
                     steps = 9
                 )
                 ListItem.Header(
-                    title = "Acrylic Pane Theme",
-                    titleMaxLines = 2,
-                    modifier = Modifier
-                        .clearAndSetSemantics {
-                            this.contentDescription = "Acrylic Pane Theme"
-                        },
-                )
-                var checkBoxSelectedValues = List(2) { rememberSaveable { mutableStateOf(false) } }
-                var acrylicPaneStyles = listOf(
-                    FluentStyle.Neutral,
-                    FluentStyle.Brand
-                )
-                for (i in 0..1) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Start,
-                        modifier = Modifier.fillMaxWidth()
-                            .padding(horizontal = 10.dp, vertical = 3.dp)
-                    ) {
-                        Text(text = "Theme $i")
-                        Spacer(modifier = Modifier.width(320.dp))
-                        RadioButton(
-                            onClick = {
-                                selectRadioGroupButton(i, checkBoxSelectedValues)
-                                acrylicPaneStyle = acrylicPaneStyles[i]
-                            },
-                            selected = checkBoxSelectedValues[i].value
-                        )
-                    }
-                }
-                ListItem.Header(
                     title = "Test Bottom Drawer",
                     titleMaxLines = 2,
                     modifier = Modifier
@@ -172,7 +225,9 @@ fun CreateAcrylicPaneActivityUI(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Start,
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 5.dp)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 5.dp)
                     ) {
                         Text(text = "Text $it", fontSize = 14.sp,
                             style = FluentTheme.aliasTokens.typography[FluentAliasTokens.TypographyTokens.Body1]
@@ -181,7 +236,8 @@ fun CreateAcrylicPaneActivityUI(
                     }
                 }
             }
-        }
+        },
+        acrylicPaneTokens = acrylicPaneTokens
     )
 }
 
@@ -244,7 +300,9 @@ fun acrylicPaneContent(context: Context){
     val showCustomizedAppBar = false
     Column {
         Spacer(modifier = Modifier.height(80.dp))
-        Row(Modifier.height(5.dp).padding(20.dp)) {
+        Row(Modifier
+            .height(5.dp)
+            .padding(20.dp)) {
             SearchBar(
                 onValueChange = { query, selectedPerson ->
                     scope.launch {

--- a/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
+++ b/FluentUI.Demo/src/main/java/com/microsoft/fluentuidemo/demos/V2AcrylicActivity.kt
@@ -80,7 +80,7 @@ class V2AcrylicPaneActivity : V2DemoActivity() {
 fun CreateAcrylicPaneActivityUI(
     context: Context
 ) {
-    var acrylicPaneSizeFraction by rememberSaveable { mutableFloatStateOf(0.5F) }
+    var acrylicPaneSize by rememberSaveable { mutableFloatStateOf(250.0f) }
     var acrylicPaneOrientation by rememberSaveable { mutableStateOf(AcrylicPaneOrientation.BOTTOM) }
     var acrylicPaneBlurRadius by rememberSaveable { mutableStateOf(0.0f) }
     val acrylicPaneTokens: AcrylicPaneTokens = object : AcrylicPaneTokens() {
@@ -91,7 +91,7 @@ fun CreateAcrylicPaneActivityUI(
     }
 
     AcrylicPane(
-        paneHeight = (acrylicPaneSizeFraction * 500).toInt().dp,
+        paneHeight = acrylicPaneSize.toInt().dp,
         orientation = acrylicPaneOrientation,
         component = { AcrylicPaneContent(context = context) },
         backgroundContent = {
@@ -183,9 +183,9 @@ fun CreateAcrylicPaneActivityUI(
                         },
                 )
                 Slider(
-                    value = acrylicPaneSizeFraction,
-                    onValueChange = { acrylicPaneSizeFraction = it },
-                    valueRange = 0F..1F,
+                    value = acrylicPaneSize,
+                    onValueChange = { acrylicPaneSize = it },
+                    valueRange = 0F..500F,
                     colors = SliderDefaults.colors(
                         thumbColor = FluentTheme.aliasTokens.neutralForegroundColor[FluentAliasTokens.NeutralForegroundColorTokens.Foreground1].value(
                             FluentTheme.themeMode

--- a/FluentUI/src/main/res/values-night/themes.xml
+++ b/FluentUI/src/main/res/values-night/themes.xml
@@ -14,6 +14,8 @@
 
         <!-- *** Base Semantic Colors *** -->
 
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
         <!--Backgrounds-->
         <item name="fluentuiBackgroundColor">@color/fluentui_black</item>
         <item name="fluentuiBackgroundPressedColor">@color/fluentui_gray_900</item>

--- a/FluentUI/src/main/res/values/themes.xml
+++ b/FluentUI/src/main/res/values/themes.xml
@@ -29,8 +29,6 @@
 
         <!-- *** Base Semantic Colors *** -->
 
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
         <!--Backgrounds-->
         <item name="fluentuiBackgroundColor">@color/fluentui_white</item>
         <item name="fluentuiBackgroundPressedColor">@color/fluentui_gray_100</item>
@@ -123,6 +121,8 @@
         <item name="fluentuiDialogBackgroundColor">?attr/fluentuiBackgroundColor</item>
         <item name="fluentuiDialogCloseIconColor">?attr/colorPrimary</item>
         <item name="fluentuiDialogTabLayoutBackgroundColor">?attr/fluentuiDialogBackgroundColor</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
 
         <!--Drawer-->
         <item name="fluentuiDrawerBackgroundColor">?attr/fluentuiBackgroundColor</item>

--- a/FluentUI/src/main/res/values/themes.xml
+++ b/FluentUI/src/main/res/values/themes.xml
@@ -29,6 +29,8 @@
 
         <!-- *** Base Semantic Colors *** -->
 
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
         <!--Backgrounds-->
         <item name="fluentuiBackgroundColor">@color/fluentui_white</item>
         <item name="fluentuiBackgroundPressedColor">@color/fluentui_gray_100</item>

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
@@ -15,8 +15,15 @@ import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.IControlToken
 import kotlinx.parcelize.Parcelize
 
+enum class AcrylicPaneOrientation {
+    TOP,
+    BOTTOM,
+    CENTER
+}
+
 open class AcrylicPaneInfo(
-    val style: FluentStyle = FluentStyle.Neutral
+    val style: FluentStyle = FluentStyle.Neutral,
+    val orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM
 ) : ControlInfo
 
 @Parcelize
@@ -32,14 +39,35 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
                 ThemeMode.Dark
             )
         ).value(FluentTheme.themeMode)
-        return Brush.verticalGradient(
-            colors = listOf(
-                startColor,
-                startColor,
-                startColor.copy(alpha = 0.5f),
-                startColor.copy(alpha = 0.0f),
-            ),
-            tileMode = TileMode.Decal
-        )
+        when (acrylicPaneInfo.orientation) {
+            AcrylicPaneOrientation.CENTER -> return Brush.verticalGradient(
+                colors = listOf(
+                    startColor,
+                    startColor,
+                    startColor.copy(alpha = 0.5f),
+                    startColor.copy(alpha = 0.0f),
+                ),
+                tileMode = TileMode.Decal
+            )
+            AcrylicPaneOrientation.TOP -> return Brush.verticalGradient(
+                colors = listOf(
+                    startColor.copy(alpha = 0.0f),
+                    startColor.copy(alpha = 0.5f),
+                    startColor,
+                    startColor,
+                    startColor.copy(alpha = 0.5f),
+                    startColor.copy(alpha = 0.0f),
+                ),
+                tileMode = TileMode.Decal
+            )
+            AcrylicPaneOrientation.BOTTOM -> return Brush.verticalGradient(
+                colors = listOf(
+                    startColor.copy(alpha = 0.0f),
+                    startColor.copy(alpha = 0.5f),
+                    startColor
+                ),
+                tileMode = TileMode.Decal
+            )
+        }
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
@@ -6,7 +6,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TileMode
+import com.microsoft.fluentui.theme.FluentTheme
+import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.ControlInfo
+import com.microsoft.fluentui.theme.token.FluentAliasTokens
+import com.microsoft.fluentui.theme.token.FluentColor
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.IControlToken
 import kotlinx.parcelize.Parcelize
@@ -20,31 +24,22 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
 
     @Composable
     open fun acrylicPaneGradient(acrylicPaneInfo: AcrylicPaneInfo): Brush {
-        if(acrylicPaneInfo.style == FluentStyle.Neutral) {
-            val startColor: Color = Color(red = 0xF7, green = 0xF8 , blue = 0xFB, alpha = 0xFF)
-            return Brush.verticalGradient(
-                colors = listOf(
-                    startColor,
-                    startColor,
-                    startColor,
-                    startColor.copy(alpha = 0.5f),
-                    startColor.copy(alpha = 0.0f),
-                ),
-               tileMode = TileMode.Decal
+        val startColor: Color = FluentColor(
+            light = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                ThemeMode.Light
+            ),
+            dark = FluentTheme.aliasTokens.neutralBackgroundColor[FluentAliasTokens.NeutralBackgroundColorTokens.Background5].value(
+                ThemeMode.Dark
             )
-        }
-        else{
-            val startColor: Color = Color(0xFE106cbc)
-            return Brush.verticalGradient(
-                colors = listOf(
-                    startColor,
-                    startColor,
-                    startColor.copy(alpha = 0.8f),
-                    startColor.copy(alpha = 0.5f),
-                    startColor.copy(alpha = 0.0f),
-                ),
-                tileMode = TileMode.Decal
-            )
-        }
+        ).value(FluentTheme.themeMode)
+        return Brush.verticalGradient(
+            colors = listOf(
+                startColor,
+                startColor,
+                startColor.copy(alpha = 0.5f),
+                startColor.copy(alpha = 0.0f),
+            ),
+            tileMode = TileMode.Decal
+        )
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
@@ -48,6 +48,7 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
                 ),
                 tileMode = TileMode.Decal
             )
+
             AcrylicPaneOrientation.CENTER -> return Brush.verticalGradient(
                 colors = listOf(
                     startColor.copy(alpha = 0.0f),
@@ -56,6 +57,7 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
                 ),
                 tileMode = TileMode.Decal
             )
+
             AcrylicPaneOrientation.BOTTOM -> return Brush.verticalGradient(
                 colors = listOf(
                     startColor.copy(alpha = 0.0f),

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
@@ -40,22 +40,18 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
             )
         ).value(FluentTheme.themeMode)
         when (acrylicPaneInfo.orientation) {
-            AcrylicPaneOrientation.CENTER -> return Brush.verticalGradient(
+            AcrylicPaneOrientation.TOP -> return Brush.verticalGradient(
                 colors = listOf(
-                    startColor,
                     startColor,
                     startColor.copy(alpha = 0.5f),
                     startColor.copy(alpha = 0.0f),
                 ),
                 tileMode = TileMode.Decal
             )
-            AcrylicPaneOrientation.TOP -> return Brush.verticalGradient(
+            AcrylicPaneOrientation.CENTER -> return Brush.verticalGradient(
                 colors = listOf(
                     startColor.copy(alpha = 0.0f),
-                    startColor.copy(alpha = 0.5f),
                     startColor,
-                    startColor,
-                    startColor.copy(alpha = 0.5f),
                     startColor.copy(alpha = 0.0f),
                 ),
                 tileMode = TileMode.Decal
@@ -69,5 +65,10 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
                 tileMode = TileMode.Decal
             )
         }
+    }
+
+    @Composable
+    open fun acrylicPaneBlurRadius(acrylicPaneInfo: AcrylicPaneInfo): Int {
+        return 60 // Need blur tokens
     }
 }

--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/AcrylicPaneTokens.kt
@@ -28,6 +28,9 @@ open class AcrylicPaneInfo(
 
 @Parcelize
 open class AcrylicPaneTokens : IControlToken, Parcelable {
+    companion object {
+        const val DEFAULT_BLUR_RADIUS = 60 // Default value, can be overridden by theme
+    }
 
     @Composable
     open fun acrylicPaneGradient(acrylicPaneInfo: AcrylicPaneInfo): Brush {
@@ -71,6 +74,6 @@ open class AcrylicPaneTokens : IControlToken, Parcelable {
 
     @Composable
     open fun acrylicPaneBlurRadius(acrylicPaneInfo: AcrylicPaneInfo): Int {
-        return 60 // Need blur tokens
+        return DEFAULT_BLUR_RADIUS // Need blur tokens
     }
 }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -1,5 +1,7 @@
 package com.microsoft.fluentui.tokenized.acrylicpane
 
+import android.os.Build
+import android.view.WindowManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -8,13 +10,49 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneInfo
 import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneTokens
 
+@Composable
+fun NonModalBlurredDialog(
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    val dialogProperties = DialogProperties(
+        usePlatformDefaultWidth = false,
+        decorFitsSystemWindows = false
+    )
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = dialogProperties
+    ) {
+        val window = (LocalView.current.parent as? DialogWindowProvider)?.window
+
+        SideEffect {
+            if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL)
+                window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+                window.setBackgroundBlurRadius(60)
+                window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
+                window.setDimAmount(0f)
+
+                // CRUCIAL: The window's decor view itself must be transparent.
+                window.decorView.setBackgroundColor(android.graphics.Color.TRANSPARENT)
+            }
+        }
+        content()
+    }
+}
 
 @Composable
 private fun AcrylicPane(
@@ -28,11 +66,20 @@ private fun AcrylicPane(
     ) {
         backgroundContent()
 
-        Box(
-            modifier = modifier
+        NonModalBlurredDialog(
+            onDismissRequest = {}
         ) {
-            component()
+            Box(
+                modifier = modifier
+            ){
+                component()
+            }
         }
+//        Box(
+//            modifier = modifier
+//        ) {
+//            component()
+//        }
     }
 }
 
@@ -60,11 +107,11 @@ public fun AcrylicPane(modifier: Modifier = Modifier, paneHeight: Dp = 300.dp, a
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AcrylicPaneControlType] as AcrylicPaneTokens
     AcrylicPane(
         modifier = modifier
-        .fillMaxWidth()
-        .height(newPaneHeight)
-        .background(
-            token.acrylicPaneGradient(acrylicPaneInfo = paneInfo)
-        ),
+            .fillMaxWidth()
+            .height(newPaneHeight)
+            .background(
+                token.acrylicPaneGradient(acrylicPaneInfo = paneInfo)
+            ),
         component = {
             component()
         },

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -57,9 +57,8 @@ fun NonModalBlurredDialog(
 @Composable
 private fun AcrylicPane(
     modifier: Modifier = Modifier,
-    component: @Composable BoxScope.() -> Unit,
     backgroundContent: @Composable () -> Unit,
-    triggerRecomposition: Boolean = false
+    component: @Composable BoxScope.() -> Unit
 ) {
     Box(
         modifier = Modifier.fillMaxSize()
@@ -75,11 +74,6 @@ private fun AcrylicPane(
                 component()
             }
         }
-//        Box(
-//            modifier = modifier
-//        ) {
-//            component()
-//        }
     }
 }
 
@@ -98,11 +92,10 @@ fun roundToNearestTen(value: Int): Int { // Added for anti-aliasing
  */
 
 @Composable
-public fun AcrylicPane(modifier: Modifier = Modifier, paneHeight: Dp = 300.dp, acrylicPaneStyle:FluentStyle = FluentStyle.Neutral, component: @Composable () -> Unit, backgroundContent: @Composable () -> Unit, acrylicPaneTokens: AcrylicPaneTokens? = null) {
+fun AcrylicPane(modifier: Modifier = Modifier, paneHeight: Dp = 300.dp, acrylicPaneStyle:FluentStyle = FluentStyle.Neutral, component: @Composable () -> Unit, backgroundContent: @Composable () -> Unit, acrylicPaneTokens: AcrylicPaneTokens? = null) {
     val paneInfo: AcrylicPaneInfo = AcrylicPaneInfo(style = acrylicPaneStyle)
     val newPaneHeight = roundToNearestTen(paneHeight.value.toInt()).dp
-    val themeID =
-        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
+    val themeID = FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = acrylicPaneTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AcrylicPaneControlType] as AcrylicPaneTokens
     AcrylicPane(
@@ -112,12 +105,10 @@ public fun AcrylicPane(modifier: Modifier = Modifier, paneHeight: Dp = 300.dp, a
             .background(
                 token.acrylicPaneGradient(acrylicPaneInfo = paneInfo)
             ),
-        component = {
-            component()
-        },
         backgroundContent = {
             backgroundContent()
-        },
-        triggerRecomposition = false
-    )
+        }
+    ){
+        component()
+    }
 }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -51,7 +51,7 @@ private fun BlurBehindDialog(
                 window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL)
                 window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
                 window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     window.setBackgroundBlurRadius(blurRadius)
                 }
                 window.setDimAmount(0f)
@@ -77,8 +77,21 @@ fun roundToNearestTen(value: Int): Int { // Added for anti-aliasing
 
 /**
  * A composable function that creates an AcrylicPane with specified properties and content.
+ * This component leverages a real-time, window-level blur to create its acrylic effect.
+ * This behavior is subject to specific system conditions.
+ *
+ * Platform-Specific Behavior & Requirements:
+ * API Level: The background blur is only supported on Android 12 (API 31) and newer.
+ * Device Setting: For the blur to be visible, the "Allow window-level blurs" option must be enabled in the device's Developer Options.
+ *
+ * Fallback Mechanism:
+ * On devices running older Android versions (below API 31) or when the necessary developer
+ * option is disabled, the AcrylicPane will gracefully fall back to a semi-transparent gradient effect.
+ * This ensures the UI remains functional and aesthetically pleasing even when the blur effect is not available.
  *
  * @param modifier The modifier to be applied to the AcrylicPane.
+ * @param orientation The orientation of the AcrylicPane, default is AcrylicPaneOrientation.BOTTOM.
+ * @param offset The offset of the pane from the top-left corner of the screen, default is IntOffset(0, 0).
  * @param paneHeight The height of the pane, default is 300.dp.
  * @param acrylicPaneStyle The style of the pane, default is FluentStyle.Neutral.
  * @param component The main composable content to be displayed within the pane.

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -73,6 +73,7 @@ private fun BlurBehindDialog(
 fun roundToNearestTen(value: Int): Int { // Added for anti-aliasing
     return ((value + 5) / 10) * 10
 }
+
 /**
  * A composable function that creates an AcrylicPane with specified properties and content.
  *
@@ -85,10 +86,21 @@ fun roundToNearestTen(value: Int): Int { // Added for anti-aliasing
  */
 
 @Composable
-fun AcrylicPane(modifier: Modifier = Modifier, orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM, offset: IntOffset = IntOffset(0,0) ,paneHeight: Dp = 300.dp, acrylicPaneStyle:FluentStyle = FluentStyle.Neutral, component: @Composable () -> Unit, backgroundContent: @Composable () -> Unit, acrylicPaneTokens: AcrylicPaneTokens? = null) {
-    val paneInfo: AcrylicPaneInfo = AcrylicPaneInfo(style = acrylicPaneStyle, orientation = orientation)
+fun AcrylicPane(
+    modifier: Modifier = Modifier,
+    orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM,
+    offset: IntOffset = IntOffset(0, 0),
+    paneHeight: Dp = 300.dp,
+    acrylicPaneStyle: FluentStyle = FluentStyle.Neutral,
+    component: @Composable () -> Unit,
+    backgroundContent: @Composable () -> Unit,
+    acrylicPaneTokens: AcrylicPaneTokens? = null
+) {
+    val paneInfo: AcrylicPaneInfo =
+        AcrylicPaneInfo(style = acrylicPaneStyle, orientation = orientation)
     val newPaneHeight = roundToNearestTen(paneHeight.value.toInt()).dp
-    val themeID = FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
+    val themeID =
+        FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = acrylicPaneTokens
         ?: FluentTheme.controlTokens.tokens[ControlTokens.ControlType.AcrylicPaneControlType] as AcrylicPaneTokens
     val backgroundColor: Brush = token.acrylicPaneGradient(acrylicPaneInfo = paneInfo)
@@ -111,7 +123,7 @@ fun AcrylicPane(modifier: Modifier = Modifier, orientation: AcrylicPaneOrientati
                     .background(
                         backgroundColor
                     )
-            ){
+            ) {
                 component()
             }
         }

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -50,8 +50,8 @@ private fun BlurBehindDialog(
             if (window != null) {
                 window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL)
                 window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
-                window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
                     window.setBackgroundBlurRadius(blurRadius)
                 }
                 window.setDimAmount(0f)

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -28,7 +28,6 @@ import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneTokens
 
 @Composable
 private fun BlurBehindDialog(
-    onDismissRequest: () -> Unit,
     orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM,
     blurRadius: Int = 60,
     offset: IntOffset = IntOffset(0, 0),
@@ -42,17 +41,19 @@ private fun BlurBehindDialog(
     )
 
     Dialog(
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = {},
         properties = dialogProperties
     ) {
         val window = (LocalView.current.parent as? DialogWindowProvider)?.window
 
         SideEffect {
-            if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (window != null) {
                 window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL)
                 window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
-                window.setBackgroundBlurRadius(blurRadius)
                 window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    window.setBackgroundBlurRadius(blurRadius)
+                }
                 window.setDimAmount(0f)
                 window.setGravity(
                     when (orientation) {
@@ -111,10 +112,9 @@ fun AcrylicPane(
         backgroundContent()
 
         BlurBehindDialog(
-            onDismissRequest = {},
             orientation = orientation,
             blurRadius = blurRadius,
-            offset = IntOffset(0, 0)
+            offset = offset
         ) {
             Box(
                 modifier = modifier

--- a/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
+++ b/fluentui_others/src/main/java/com/microsoft/fluentui/tokenized/acrylicpane/AcrylicPane.kt
@@ -1,6 +1,7 @@
 package com.microsoft.fluentui.tokenized.acrylicpane
 
 import android.os.Build
+import android.view.Gravity
 import android.view.WindowManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,11 +21,13 @@ import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.token.ControlTokens
 import com.microsoft.fluentui.theme.token.FluentStyle
 import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneInfo
+import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneOrientation
 import com.microsoft.fluentui.theme.token.controlTokens.AcrylicPaneTokens
 
 @Composable
 fun NonModalBlurredDialog(
     onDismissRequest: () -> Unit,
+    orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM,
     content: @Composable () -> Unit
 ) {
     val dialogProperties = DialogProperties(
@@ -45,7 +48,13 @@ fun NonModalBlurredDialog(
                 window.setBackgroundBlurRadius(60)
                 window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
                 window.setDimAmount(0f)
-
+                window.setGravity(
+                    when (orientation) {
+                        AcrylicPaneOrientation.TOP -> Gravity.TOP
+                        AcrylicPaneOrientation.BOTTOM -> Gravity.BOTTOM
+                        AcrylicPaneOrientation.CENTER -> Gravity.CENTER
+                    }
+                )
                 // CRUCIAL: The window's decor view itself must be transparent.
                 window.decorView.setBackgroundColor(android.graphics.Color.TRANSPARENT)
             }
@@ -57,6 +66,7 @@ fun NonModalBlurredDialog(
 @Composable
 private fun AcrylicPane(
     modifier: Modifier = Modifier,
+    orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM,
     backgroundContent: @Composable () -> Unit,
     component: @Composable BoxScope.() -> Unit
 ) {
@@ -66,7 +76,8 @@ private fun AcrylicPane(
         backgroundContent()
 
         NonModalBlurredDialog(
-            onDismissRequest = {}
+            onDismissRequest = {},
+            orientation = orientation
         ) {
             Box(
                 modifier = modifier
@@ -92,8 +103,8 @@ fun roundToNearestTen(value: Int): Int { // Added for anti-aliasing
  */
 
 @Composable
-fun AcrylicPane(modifier: Modifier = Modifier, paneHeight: Dp = 300.dp, acrylicPaneStyle:FluentStyle = FluentStyle.Neutral, component: @Composable () -> Unit, backgroundContent: @Composable () -> Unit, acrylicPaneTokens: AcrylicPaneTokens? = null) {
-    val paneInfo: AcrylicPaneInfo = AcrylicPaneInfo(style = acrylicPaneStyle)
+fun AcrylicPane(modifier: Modifier = Modifier, orientation: AcrylicPaneOrientation = AcrylicPaneOrientation.BOTTOM, paneHeight: Dp = 300.dp, acrylicPaneStyle:FluentStyle = FluentStyle.Neutral, component: @Composable () -> Unit, backgroundContent: @Composable () -> Unit, acrylicPaneTokens: AcrylicPaneTokens? = null) {
+    val paneInfo: AcrylicPaneInfo = AcrylicPaneInfo(style = acrylicPaneStyle, orientation = orientation)
     val newPaneHeight = roundToNearestTen(paneHeight.value.toInt()).dp
     val themeID = FluentTheme.themeID    //Adding This only for recomposition in case of Token Updates. Unused otherwise.
     val token = acrylicPaneTokens
@@ -105,6 +116,7 @@ fun AcrylicPane(modifier: Modifier = Modifier, paneHeight: Dp = 300.dp, acrylicP
             .background(
                 token.acrylicPaneGradient(acrylicPaneInfo = paneInfo)
             ),
+        orientation = orientation,
         backgroundContent = {
             backgroundContent()
         }


### PR DESCRIPTION
### Problem 
Acrylic Pane was not able to blur the content behind it

### Fix
Implemented Blur Behind with a Dialog

### Validation
Tested down till API 29, will shift to fallback mechanism without blur if it is not supported

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![OldAcrylicPaneDemo](https://github.com/user-attachments/assets/8e73f6a8-0836-448d-bd4f-b23ece2f45dc) [OldAcrylicPaneDemo.webm](https://github.com/user-attachments/assets/473159e8-1e67-417e-b39d-2bb6c986b272) | ![AcrylicPaneDemo (1)](https://github.com/user-attachments/assets/4aebcb92-1bb0-4bd7-a943-54509756945d) [AcrylicPaneDemo.webm](https://github.com/user-attachments/assets/0503fd56-b97f-446f-bc7f-f38cface638e) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
