### PR TITLE
[V2 PillSwitch] Added Configurable Padding

### DIFF
--- a/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillSwitchTokens.kt
+++ b/fluentui_core/src/main/java/com/microsoft/fluentui/theme/token/controlTokens/PillSwitchTokens.kt
@@ -4,6 +4,8 @@ import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.microsoft.fluentui.theme.FluentTheme
 import com.microsoft.fluentui.theme.ThemeMode
 import com.microsoft.fluentui.theme.token.ControlInfo
@@ -37,6 +39,14 @@ open class PillSwitchTokens : PillBarTokens(), Parcelable {
                     )
                 ).value(FluentTheme.themeMode)
             )
+        }
+    }
+
+    @Composable
+    open fun pillSwitchRowPadding(pillSwitchInfo: PillSwitchInfo): Dp {
+        return when (pillSwitchInfo.style) {
+            FluentStyle.Neutral -> 16.dp
+            FluentStyle.Brand -> 16.dp
         }
     }
 }

--- a/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
+++ b/fluentui_tablayout/src/main/java/com/microsoft/fluentui/tokenized/segmentedcontrols/PillSwitch.kt
@@ -61,14 +61,14 @@ fun PillSwitch(
     Row(
         modifier = Modifier
             .wrapContentWidth()
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = token.pillSwitchRowPadding(pillSwitchInfo))
             .background(Color.Transparent)
             .focusable(false)
     ) {
         LazyRow(
             modifier = modifier
                 .wrapContentWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = token.pillSwitchRowPadding(pillSwitchInfo))
                 .focusable(enabled = false)
                 .clip(shape)
                 .background(token.backgroundBrush(pillSwitchInfo), shape),


### PR DESCRIPTION
### Problem 
Pillswitch had a fixed predefined padding 

### Fix
Added token to configure the padding 

### Screenshots

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="247" height="57" alt="PillSwitchBeforePadding" src="https://github.com/user-attachments/assets/a4314b7d-0077-4d42-85ac-fb9bb46a73c4" /> | <img width="235" height="50" alt="PillSwitchAfterPadding" src="https://github.com/user-attachments/assets/194559cf-9a3d-44c5-bf82-467f0df61d7e" /> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] Automated Tests
- [ ] Documentation and demo app examples
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and RTL layouts
- [ ] Size classes and window sizes (notched devices, multitasking, different window sizes, etc)
